### PR TITLE
feat: add role-based onboarding menus

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,6 +1,9 @@
 import { Telegraf, Markup, Context } from 'telegraf';
+import { upsertUser } from '../services/users.js';
 
 export default function startCommand(bot: Telegraf) {
+  const pendingRoles = new Map<number, 'client' | 'courier'>();
+
   bot.start(async (ctx) => {
     await ctx.reply(
       'Добро пожаловать 👋\nСервис доставок в Алматы. Выберите роль.',
@@ -11,7 +14,8 @@ export default function startCommand(bot: Telegraf) {
     );
   });
 
-  const requestContact = async (ctx: Context) => {
+  const requestContact = async (ctx: Context, role: 'client' | 'courier') => {
+    pendingRoles.set(ctx.from!.id, role);
     await ctx.reply(
       'Нужно подтвердить номер телефона.',
       Markup.keyboard([
@@ -20,10 +24,43 @@ export default function startCommand(bot: Telegraf) {
     );
   };
 
-  bot.hears('Заказать доставку', requestContact);
-  bot.hears('Стать исполнителем', requestContact);
+  bot.hears('Заказать доставку', (ctx) => requestContact(ctx, 'client'));
+  bot.hears('Стать исполнителем', (ctx) => requestContact(ctx, 'courier'));
 
   bot.on('contact', async (ctx) => {
-    await ctx.reply('Спасибо! Контакт получен.');
+    const uid = ctx.from!.id;
+    const role = pendingRoles.get(uid);
+    if (!role) {
+      await ctx.reply('Сначала выберите роль.');
+      return;
+    }
+    const phone = ctx.message.contact?.phone_number;
+    if (!phone) {
+      await ctx.reply('Не удалось получить номер. Нажмите кнопку «Поделиться номером».');
+      return;
+    }
+    upsertUser({ id: uid, phone, role });
+    pendingRoles.delete(uid);
+    if (role === 'client') {
+      await ctx.reply(
+        'Спасибо! Контакт получен.',
+        Markup.keyboard([
+          ['Создать заказ'],
+          ['Мои заказы', 'Поддержка']
+        ]).resize()
+      );
+    } else {
+      await ctx.reply(
+        'Спасибо! Контакт получен.',
+        Markup.keyboard([
+          ['Профиль'],
+          ['Поддержка']
+        ]).resize()
+      );
+    }
   });
+
+  bot.hears('Мои заказы', (ctx) => ctx.reply('Здесь будут ваши заказы.'));
+  bot.hears('Профиль', (ctx) => ctx.reply('Профиль в разработке.'));
+  bot.hears('Поддержка', (ctx) => ctx.reply('Поддержка в разработке.'));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Telegraf } from 'telegraf';
 import dotenv from 'dotenv';
 import startCommand from './commands/start.js';
 import { handleBindingCommands, pingBindingsCommand } from './commands/bindings.js';
+import orderCommands from './commands/order.js';
 
 dotenv.config();
 
@@ -15,6 +16,7 @@ const bot = new Telegraf(token);
 startCommand(bot);
 handleBindingCommands(bot);
 pingBindingsCommand(bot);
+orderCommands(bot);
 
 bot.launch().then(() => {
   console.log('Bot started');


### PR DESCRIPTION
## Summary
- save selected role and phone during onboarding
- show role-specific menus after contact sharing
- enable order creation commands in bot startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6bbcdceb4832d882e543abe34c17c