### PR TITLE
feat: add order reservation workflow

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 import { Telegraf, Markup, Context } from 'telegraf';
+=======
+import { Telegraf, Context, Markup } from 'telegraf';
+>>>>>>> 0cb5d4a (feat: add order reservation workflow)
 import { upsertUser, getUser } from '../services/users.js';
 
 export default function startCommand(bot: Telegraf) {
@@ -6,11 +10,14 @@ export default function startCommand(bot: Telegraf) {
   const pendingAgreement = new Map<number, 'client' | 'courier'>();
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   const pendingCity = new Map<number, true>();
 =======
 >>>>>>> bdae1ea (feat: add geo utilities)
 =======
 >>>>>>> 3c7234d (feat: improve 2gis integration)
+=======
+>>>>>>> 0cb5d4a (feat: add order reservation workflow)
 
   bot.start(async (ctx) => {
     await ctx.reply(
@@ -51,6 +58,7 @@ export default function startCommand(bot: Telegraf) {
     pendingRoles.delete(uid);
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     if (role === 'client') {
       pendingCity.set(uid, true);
       await ctx.reply('Введите ваш город (по умолчанию Алматы).');
@@ -87,15 +95,20 @@ export default function startCommand(bot: Telegraf) {
 =======
 =======
 >>>>>>> 3c7234d (feat: improve 2gis integration)
+=======
+>>>>>>> 0cb5d4a (feat: add order reservation workflow)
     pendingAgreement.set(uid, role);
     await ctx.reply(
       'Город: Алматы. Согласны с правилами сервиса?',
       Markup.keyboard([['Согласен']]).oneTime().resize()
     );
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> bdae1ea (feat: add geo utilities)
 =======
 >>>>>>> 3c7234d (feat: improve 2gis integration)
+=======
+>>>>>>> 0cb5d4a (feat: add order reservation workflow)
   });
 
   bot.hears('Согласен', async (ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
-import { Telegraf } from 'telegraf';
+import { Telegraf, Markup } from 'telegraf';
 import dotenv from 'dotenv';
 import startCommand from './commands/start.js';
 import { handleBindingCommands, pingBindingsCommand } from './commands/bindings.js';
 import orderCommands from './commands/order.js';
+import { releaseExpiredReservations } from './services/orders.js';
+import { getSettings } from './services/settings.js';
 
 dotenv.config();
 
@@ -21,6 +23,29 @@ orderCommands(bot);
 bot.launch().then(() => {
   console.log('Bot started');
 });
+
+setInterval(async () => {
+  const settings = getSettings();
+  if (!settings.drivers_channel_id) return;
+  const expired = releaseExpiredReservations();
+  for (const order of expired) {
+    if (!order.message_id) continue;
+    const text = `Новый заказ #${order.id}\nОткуда: ${order.from.addr}\nКуда: ${order.to.addr}`;
+    try {
+      await bot.telegram.editMessageText(
+        settings.drivers_channel_id,
+        order.message_id,
+        undefined,
+        text,
+        Markup.inlineKeyboard([
+          [Markup.button.callback('Принять', `accept_${order.id}`)]
+        ])
+      );
+    } catch (e) {
+      console.error('edit fail', e);
+    }
+  }
+}, 5000);
 
 process.once('SIGINT', () => bot.stop('SIGINT'));
 process.once('SIGTERM', () => bot.stop('SIGTERM'));

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -21,6 +21,10 @@ export interface Order {
   pay_type: 'cash' | 'p2p' | 'receiver';
   comment?: string;
   created_at: string;
+  status: 'open' | 'reserved' | 'assigned';
+  reserved_by?: number;
+  reserved_until?: string;
+  message_id?: number;
 }
 
 function load(): Order[] {
@@ -38,12 +42,86 @@ function save(orders: Order[]) {
   writeFileSync(FILE_PATH, JSON.stringify(orders, null, 2));
 }
 
-export function createOrder(order: Omit<Order, 'id' | 'created_at'>): Order {
+export function createOrder(
+  order: Omit<
+    Order,
+    'id' | 'created_at' | 'status' | 'reserved_by' | 'reserved_until' | 'message_id'
+  >
+): Order {
   const orders = load();
   const last = orders[orders.length - 1];
   const id = last ? last.id + 1 : 1;
-  const newOrder: Order = { ...order, id, created_at: new Date().toISOString() };
+  const newOrder: Order = {
+    ...order,
+    id,
+    created_at: new Date().toISOString(),
+    status: 'open'
+  };
   orders.push(newOrder);
   save(orders);
   return newOrder;
+}
+
+export function updateOrder(id: number, patch: Partial<Omit<Order, 'id'>>): Order | undefined {
+  const orders = load();
+  const idx = orders.findIndex((o) => o.id === id);
+  if (idx === -1) return undefined;
+  orders[idx] = { ...orders[idx], ...patch } as Order;
+  save(orders);
+  return orders[idx];
+}
+
+export function reserveOrder(id: number, userId: number, ttlSec = 90): Order | undefined {
+  const orders = load();
+  const idx = orders.findIndex((o) => o.id === id);
+  if (idx === -1) return undefined;
+  const order = orders[idx]!;
+  const now = Date.now();
+  const expired = order.reserved_until ? new Date(order.reserved_until).getTime() < now : true;
+  if (order.status === 'open' || (order.status === 'reserved' && expired)) {
+    order.status = 'reserved';
+    order.reserved_by = userId;
+    order.reserved_until = new Date(now + ttlSec * 1000).toISOString();
+    orders[idx] = order;
+    save(orders);
+    return order;
+  }
+  return undefined;
+}
+
+export function assignOrder(id: number, userId: number): Order | undefined {
+  const orders = load();
+  const idx = orders.findIndex((o) => o.id === id);
+  if (idx === -1) return undefined;
+  const order = orders[idx]!;
+  if (order.status === 'reserved' && order.reserved_by === userId) {
+    order.status = 'assigned';
+    orders[idx] = order;
+    save(orders);
+    return order;
+  }
+  return undefined;
+}
+
+export function releaseExpiredReservations(): Order[] {
+  const orders = load();
+  const now = Date.now();
+  const updated: Order[] = [];
+  for (const order of orders) {
+    if (order.status === 'reserved' && order.reserved_until && new Date(order.reserved_until).getTime() < now) {
+      order.status = 'open';
+      delete order.reserved_by;
+      delete order.reserved_until;
+      updated.push(order);
+    }
+  }
+  if (updated.length) {
+    save(orders);
+  }
+  return updated;
+}
+
+export function getOrder(id: number): Order | undefined {
+  const orders = load();
+  return orders.find((o) => o.id === id);
 }


### PR DESCRIPTION
## Summary
- add order status and reservation fields with helpers
- publish new orders with interactive card and reservation flow
- background job refreshes expired reservations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6cdf7554c832d9c4bccbd95854139