### PR TITLE
Add receiver payment flow and encrypt courier data

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -163,6 +163,9 @@ async function finalize(ctx: Context, uid: number, data: Required<CourierProfile
     );
     await ctx.telegram.sendPhoto(settings.verify_channel_id, profile.selfie);
     upsertCourier({ ...profile, verifyMsgId: verifyMessage.message_id });
+    setTimeout(() => {
+      ctx.telegram.deleteMessage(settings.verify_channel_id!, verifyMessage.message_id).catch(() => {});
+    }, 2 * 60 * 60 * 1000);
   }
   await ctx.reply('Анкета отправлена на проверку.', Markup.removeKeyboard());
 }


### PR DESCRIPTION
## Summary
- Encrypt courier payment details and decrypt on read
- Auto-delete courier verification messages with payment data after 2 hours
- Support "recipient pays" flow and require courier payment confirmation

## Testing
- ❌ `npm test` (fails: Merge conflict marker encountered)


------
https://chatgpt.com/codex/tasks/task_e_68c6ee82a1ac832d80566d59469737e7