### PR TITLE
feat: expand order status and reservation handling

### DIFF
--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -8,14 +8,48 @@ export function setOrdersBot(bot: Telegraf<Context>) { botRef = bot; }
 
 const file = path.join(process.cwd(), 'data', 'orders.json');
 
+export type OrderStatus =
+  | 'open'
+  | 'reserved'
+  | 'assigned'
+  | 'picked_up'
+  | 'delivered'
+  | 'closed'
+  | 'canceled';
+
+export interface StatusTransition {
+  status: OrderStatus;
+  at: string;
+}
+
+export interface DisputeMessage {
+  author: 'courier' | 'client' | 'moderator';
+  text: string;
+  created_at: string;
+}
+
+export interface Dispute {
+  status: 'open' | 'resolved';
+  messages: DisputeMessage[];
+  opened_at: string;
+  resolved_at?: string;
+}
+
 export interface Order {
   id: number;
   customer_id: number;
+  courier_id?: number | null;
   from: Point;
   to: Point;
   comment: string | null;
   price_estimate: number;
-  status: 'new' | 'assigned' | 'done' | 'canceled';
+  status: OrderStatus;
+  reserved_by: number | null;
+  reserved_until: string | null;
+  pickup_proof?: string | null;
+  delivery_proof?: string | null;
+  dispute?: Dispute;
+  transitions: StatusTransition[];
   created_at: string;
 }
 
@@ -38,6 +72,7 @@ function writeAll(list: Order[]) {
 export function createOrder(input: CreateOrderInput): Order {
   const list = readAll();
   const id = (list.at(-1)?.id ?? 0) + 1;
+  const now = new Date().toISOString();
   const order: Order = {
     id,
     customer_id: input.customer_id,
@@ -45,10 +80,152 @@ export function createOrder(input: CreateOrderInput): Order {
     to: input.to,
     comment: input.comment,
     price_estimate: input.price_estimate,
-    status: 'new',
-    created_at: new Date().toISOString(),
+    status: 'open',
+    reserved_by: null,
+    reserved_until: null,
+    pickup_proof: null,
+    delivery_proof: null,
+    dispute: undefined,
+    transitions: [{ status: 'open', at: now }],
+    created_at: now,
   };
   list.push(order);
+  writeAll(list);
+  return order;
+}
+
+export function getOrder(id: number): Order | undefined {
+  return readAll().find(o => o.id === id);
+}
+
+export function updateOrder(id: number, data: Partial<Order>): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = { ...list[index], ...data };
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function reserveOrder(id: number, courierId: number): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  const now = Date.now();
+  const until = order.reserved_until ? new Date(order.reserved_until).getTime() : 0;
+  if (order.status === 'reserved' && until > now && order.reserved_by !== courierId) {
+    return undefined;
+  }
+  if (order.status !== 'open' && !(order.status === 'reserved' && until <= now)) {
+    return undefined;
+  }
+  order.status = 'reserved';
+  order.reserved_by = courierId;
+  order.reserved_until = new Date(now + 90 * 1000).toISOString();
+  order.transitions.push({ status: 'reserved', at: new Date(now).toISOString() });
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function assignOrder(id: number, courierId: number): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  const now = Date.now();
+  const until = order.reserved_until ? new Date(order.reserved_until).getTime() : 0;
+  if (order.status !== 'reserved' || order.reserved_by !== courierId || until < now) {
+    return undefined;
+  }
+  order.status = 'assigned';
+  order.courier_id = courierId;
+  order.reserved_by = null;
+  order.reserved_until = null;
+  order.transitions.push({ status: 'assigned', at: new Date(now).toISOString() });
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function updateOrderStatus(id: number, status: OrderStatus): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  order.status = status;
+  order.transitions.push({ status, at: new Date().toISOString() });
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function addPickupProof(id: number, proof: string): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  order.pickup_proof = proof;
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function addDeliveryProof(id: number, proof: string): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  order.delivery_proof = proof;
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function openDispute(id: number): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  if (!order.dispute) {
+    order.dispute = {
+      status: 'open',
+      messages: [],
+      opened_at: new Date().toISOString(),
+    };
+  }
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function addDisputeMessage(
+  id: number,
+  author: 'courier' | 'client' | 'moderator',
+  text: string,
+): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  if (!order.dispute) return undefined;
+  order.dispute.messages.push({ author, text, created_at: new Date().toISOString() });
+  list[index] = order;
+  writeAll(list);
+  return order;
+}
+
+export function resolveDispute(id: number): Order | undefined {
+  const list = readAll();
+  const index = list.findIndex(o => o.id === id);
+  if (index === -1) return undefined;
+  const order = list[index];
+  if (!order.dispute) return undefined;
+  order.dispute.status = 'resolved';
+  order.dispute.resolved_at = new Date().toISOString();
+  list[index] = order;
   writeAll(list);
   return order;
 }


### PR DESCRIPTION
## Summary
- extend Order with detailed statuses, reservation metadata and transition log
- add reservation, assignment, status and proof handling helpers
- support dispute creation and messaging on orders

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fe804db4832dab5971a4b7b26031