### PR TITLE
Handle incorrect statuses and courier assignment in order status command

### DIFF
--- a/src/commands/orderStatus.ts
+++ b/src/commands/orderStatus.ts
@@ -9,12 +9,18 @@ export default function orderStatusCommands(bot: Telegraf) {
       return ctx.reply('Usage: /order_status <id> <new|assigned|delivered>');
     }
     const id = Number(args[0]);
-    const status = args[1] as any;
-    const courierId = status === 'assigned' ? ctx.from!.id : undefined;
+    const statusArg = args[1];
+    const allowedStatuses = ['new', 'assigned', 'delivered'] as const;
+    if (!allowedStatuses.includes(statusArg as any)) {
+      return ctx.reply('Неверный статус. Используйте: new, assigned или delivered');
+    }
+    const statusMap = { new: 'open', assigned: 'assigned', delivered: 'delivered' } as const;
+    const status = statusMap[statusArg as keyof typeof statusMap];
+    const courierId = statusArg === 'assigned' ? ctx.from!.id : undefined;
     const order = updateOrderStatus(id, status, courierId);
     if (!order) return ctx.reply('Order not found');
     await ctx.reply('Статус обновлён');
-    await ctx.telegram.sendMessage(order.client_id, `Статус заказа #${order.id}: ${order.status}`);
+    await ctx.telegram.sendMessage(order.customer_id, `Статус заказа #${order.id}: ${order.status}`);
     if (order.courier_id) {
       await ctx.telegram.sendMessage(order.courier_id, `Статус заказа #${order.id}: ${order.status}`);
     }

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -161,12 +161,19 @@ export function assignOrder(id: number, courierId: number): Order | undefined {
   return order;
 }
 
-export function updateOrderStatus(id: number, status: OrderStatus): Order | undefined {
+export function updateOrderStatus(
+  id: number,
+  status: OrderStatus,
+  courierId?: number | null
+): Order | undefined {
   const list = readAll();
   const index = list.findIndex(o => o.id === id);
   if (index === -1) return undefined;
   const order = list[index];
   order.status = status;
+  if (courierId !== undefined) {
+    order.courier_id = courierId;
+  }
   order.transitions.push({ status, at: new Date().toISOString() });
   list[index] = order;
   writeAll(list);


### PR DESCRIPTION
## Summary
- Validate `/order_status` inputs and map acceptable status names
- Notify the order's customer instead of deprecated client field
- Extend `updateOrderStatus` to optionally set `courier_id`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7061c74b0832d9b581e3fd5423799