### PR TITLE
feat: create and broadcast orders

### DIFF
--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -46,8 +46,13 @@ export interface Order {
   courier_id?: number | null;
   from: Point;
   to: Point;
+  type: string;
+  time: string;
+  options: string | null;
+  size: 'S' | 'M' | 'L';
+  pay_type: 'cash' | 'card' | 'receiver';
   comment: string | null;
-  price_estimate: number;
+  price: number;
   status: OrderStatus;
   reserved_by: number | null;
   reserved_until: string | null;
@@ -62,8 +67,13 @@ interface CreateOrderInput {
   customer_id: number;
   from: Point;
   to: Point;
+  type: string;
+  time: string;
+  options: string | null;
+  size: 'S' | 'M' | 'L';
+  pay_type: 'cash' | 'card' | 'receiver';
   comment: string | null;
-  price_estimate: number;
+  price: number;
 }
 
 function readAll(): Order[] {
@@ -83,8 +93,13 @@ export function createOrder(input: CreateOrderInput): Order {
     customer_id: input.customer_id,
     from: input.from,
     to: input.to,
+    type: input.type,
+    time: input.time,
+    options: input.options,
+    size: input.size,
+    pay_type: input.pay_type,
     comment: input.comment,
-    price_estimate: input.price_estimate,
+    price: input.price,
     status: 'open',
     reserved_by: null,
     reserved_until: null,


### PR DESCRIPTION
## Summary
- create orders after price calculation and include payment and size details
- broadcast new orders to drivers channel with reserve button
- allow couriers to reserve orders before assignment

## Testing
- `npm run check`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7081e8858832daa4753db713ac660