### PR TITLE
Default city and dynamic menus after registration

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -3,8 +3,9 @@ import { upsertUser } from '../services/users.js';
 import { startProfileWizard } from './profile.js';
 
 interface StartState {
-  step: 'phone' | 'role' | 'city' | 'consent';
+  step: 'phone' | 'role' | 'consent';
   data: { phone?: string; city?: string };
+  msgId?: number;
 }
 
 const states = new Map<number, StartState>();
@@ -12,41 +13,54 @@ const states = new Map<number, StartState>();
 export default function registerStart(bot: Telegraf<Context>) {
   bot.start(async (ctx) => {
     const uid = ctx.from!.id;
-    states.set(uid, { step: 'phone', data: {} });
-    await ctx.reply(
+    const msg = await ctx.reply(
       'Добро пожаловать! Пожалуйста, отправьте ваш номер телефона.',
       Markup.keyboard([[Markup.button.contactRequest('Отправить телефон')]]).resize()
     );
+    states.set(uid, { step: 'phone', data: {}, msgId: msg.message_id });
   });
 
   bot.on('contact', async (ctx) => {
     const uid = ctx.from!.id;
     const state = states.get(uid);
     if (!state || state.step !== 'phone') return;
+    if (state.msgId)
+      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
     const phone = ctx.message.contact.phone_number;
     state.data.phone = phone;
     state.step = 'role';
-    upsertUser({ id: uid, phone });
-    await ctx.reply(
+    upsertUser({ id: uid, phone, city: 'Алматы' });
+    const msg = await ctx.reply(
       'Вы клиент или курьер?',
       Markup.keyboard([['Клиент'], ['Курьер']]).resize()
     );
+    state.msgId = msg.message_id;
   });
 
   bot.hears('Клиент', async (ctx) => {
     const uid = ctx.from!.id;
     const state = states.get(uid);
     if (!state || state.step !== 'role') return;
-    state.step = 'city';
-    upsertUser({ id: uid, phone: state.data.phone, role: 'client' });
-    await ctx.reply('Укажите ваш город', Markup.keyboard([['Алматы']]).resize());
+    if (state.msgId)
+      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
+    const city = 'Алматы';
+    state.data.city = city;
+    state.step = 'consent';
+    upsertUser({ id: uid, phone: state.data.phone, role: 'client', city });
+    const msg = await ctx.reply(
+      'Согласны ли вы с условиями сервиса?',
+      Markup.keyboard([['Да'], ['Нет']]).resize()
+    );
+    state.msgId = msg.message_id;
   });
 
   bot.hears('Курьер', async (ctx) => {
     const uid = ctx.from!.id;
     const state = states.get(uid);
     if (!state || state.step !== 'role') return;
-    upsertUser({ id: uid, phone: state.data.phone, role: 'courier' });
+    if (state.msgId)
+      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
+    upsertUser({ id: uid, phone: state.data.phone, role: 'courier', city: 'Алматы' });
     states.delete(uid);
     await startProfileWizard(ctx);
   });
@@ -56,26 +70,15 @@ export default function registerStart(bot: Telegraf<Context>) {
     const state = states.get(uid);
     if (!state) return;
     const text = ctx.message.text.trim();
-    if (state.step === 'city') {
-      state.data.city = text;
-      state.step = 'consent';
-      upsertUser({
-        id: uid,
-        phone: state.data.phone,
-        role: 'client',
-        city: text,
-      });
-      await ctx.reply(
-        'Согласны ли вы с условиями сервиса?',
-        Markup.keyboard([['Да'], ['Нет']]).resize()
-      );
-    } else if (state.step === 'consent') {
+    if (state.step === 'consent') {
+      if (state.msgId)
+        await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
       if (text.toLowerCase() === 'да') {
         upsertUser({
           id: uid,
           phone: state.data.phone,
           role: 'client',
-          city: state.data.city,
+          city: state.data.city || 'Алматы',
           consent: true,
         });
         states.delete(uid);
@@ -88,9 +91,9 @@ export default function registerStart(bot: Telegraf<Context>) {
           ]).resize()
         );
       } else {
-        await ctx.reply('Для продолжения необходимо согласие.');
+        const msg = await ctx.reply('Для продолжения необходимо согласие.');
+        state.msgId = msg.message_id;
       }
     }
   });
 }
-


### PR DESCRIPTION
## Summary
- Default all new users to city Алматы and streamline start flow
- Show role/status-specific menus after questionnaire completion
- Clean up wizard prompts by deleting service messages at each step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c70a312d0c832da89c113ef97b6b87