### PR TITLE
feat: add order status notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node --transpile-only src/index.ts",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "node --require ts-node/register --test tests/orders.test.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  setOrdersBot,
+  createOrder,
+  updateOrderStatus,
+  updateOrder,
+  openDispute,
+  addDisputeMessage,
+  resolveDispute,
+} from '../src/services/orders';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orders-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const messages: { id: number; text: string }[] = [];
+  setOrdersBot({
+    telegram: {
+      sendMessage: (id: number, text: string) => {
+        messages.push({ id, text });
+        return Promise.resolve();
+      },
+    },
+  } as any);
+  return { dir, prev, messages };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('status update notifies client and courier', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    assert.deepEqual(messages, [
+      { id: 100, text: 'Курьер назначен' },
+      { id: 200, text: 'Заказ назначен' },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});
+
+test('payment confirmation notifies both parties', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    messages.splice(0);
+    updateOrder(order.id, { payment_status: 'paid' });
+    assert.deepEqual(messages, [
+      { id: 100, text: `Оплата заказа #${order.id} подтверждена` },
+      { id: 200, text: `Оплата по заказу #${order.id} получена` },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});
+
+test('dispute lifecycle notifies participants', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    messages.splice(0);
+
+    openDispute(order.id);
+    assert.deepEqual(messages, [
+      { id: 100, text: `Открыт спор по заказу #${order.id}` },
+      { id: 200, text: `Открыт спор по заказу #${order.id}` },
+    ]);
+
+    messages.splice(0);
+    addDisputeMessage(order.id, 'client', 'привет');
+    assert.deepEqual(messages, [
+      { id: 200, text: 'Сообщение от клиента: привет' },
+    ]);
+
+    messages.splice(0);
+    resolveDispute(order.id);
+    assert.deepEqual(messages, [
+      { id: 100, text: `Спор по заказу #${order.id} завершён` },
+      { id: 200, text: `Спор по заказу #${order.id} завершён` },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});


### PR DESCRIPTION
## Summary
- send short status updates to client and courier using botRef
- notify parties on payment confirmation and dispute events
- add node-based tests for status, payment, and dispute notifications

## Testing
- `npm test`
- `npm run check`
- `npm run dev` (fails: Cannot find module '../services/users.js')

------
https://chatgpt.com/codex/tasks/task_e_68c70eb6af44832dbba4b493485cbb3d