### PR TITLE
feat: add order status notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node --transpile-only src/index.ts",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "node --require ts-node/register --test tests/orders.test.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 import { Telegraf, Context } from 'telegraf';
-import { updateSetting, getSettings } from '../services/settings.js';
-import type { Settings } from '../services/settings.js';
-import { getAllUsers } from '../services/users.js';
+import { updateSetting, getSettings } from '../services/settings';
+import type { Settings } from '../services/settings';
+import { getAllUsers } from '../services/users';
 import {
   warnUser,
   suspendUser,
@@ -10,9 +10,9 @@ import {
   unbanUser,
   resolveDispute,
   getModerationInfo,
-} from '../services/moderation.js';
-import { getCourierMetrics } from '../services/couriers.js';
-import { addDisputeMessage, resolveDispute } from '../services/orders.js';
+} from '../services/moderation';
+import { getCourierMetrics } from '../services/couriers';
+import { addDisputeMessage, resolveDispute } from '../services/orders';
 
 function isAdmin(ctx: Context): boolean {
   const adminId = Number(process.env.ADMIN_ID);

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
 import { Telegraf } from 'telegraf';
-import { getOrder } from '../services/orders.js';
+import { getOrder } from '../services/orders';
 import {
   sendProxyMessage,
   getActiveChatByUser,
   cleanupOldChats,
-} from '../services/chat.js';
+} from '../services/chat';
 
 export default function chatCommands(bot: Telegraf) {
   bot.command('msg', async (ctx) => {

--- a/src/commands/driver.ts
+++ b/src/commands/driver.ts
@@ -11,15 +11,15 @@ import {
   updateOrder,
   openDispute,
   addDisputeMessage,
-} from '../services/orders.js';
-import type { OrderStatus } from '../services/orders.js';
+} from '../services/orders';
+import type { OrderStatus } from '../services/orders';
 import {
   toggleCourierOnline,
   isCourierOnline,
   hideOrderForCourier,
   isOrderHiddenForCourier
-} from '../services/courierState.js';
-import { getSettings } from '../services/settings.js';
+} from '../services/courierState';
+import { getSettings } from '../services/settings';
 import { routeToDeeplink } from '../utils/twoGis';
 import { reverseGeocode } from '../utils/geocode';
 

--- a/src/commands/order.ts
+++ b/src/commands/order.ts
@@ -4,8 +4,8 @@ import type { Point } from '../utils/twoGis';
 import { parse2GisLink, routeToDeeplink } from '../utils/twoGis';
 import { distanceKm, etaMinutes, isInAlmaty } from '../utils/geo';
 import { calcPrice } from '../utils/pricing';
-import { getSettings } from '../services/settings.js';
-import { createOrder } from '../services/orders.js';
+import { getSettings } from '../services/settings';
+import { createOrder } from '../services/orders';
 import { geocodeAddress, reverseGeocode } from '../utils/geocode';
 
 interface OrderSession {

--- a/src/commands/orderStatus.ts
+++ b/src/commands/orderStatus.ts
@@ -1,6 +1,6 @@
 import { Telegraf } from 'telegraf';
-import { updateOrderStatus } from '../services/orders.js';
-import { cleanupOldChats } from '../services/chat.js';
+import { updateOrderStatus } from '../services/orders';
+import { cleanupOldChats } from '../services/chat';
 
 export default function orderStatusCommands(bot: Telegraf) {
   bot.command('order_status', async (ctx) => {

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,12 +1,12 @@
 import { Telegraf, Markup, Context } from 'telegraf';
-import { getUser } from '../services/users.js';
+import { getUser } from '../services/users';
 import {
   getCourier,
   upsertCourier,
   scheduleCardMessageDeletion,
-} from '../services/couriers.js';
-import type { CourierProfile } from '../services/couriers.js';
-import { getSettings } from '../services/settings.js';
+} from '../services/couriers';
+import type { CourierProfile } from '../services/couriers';
+import { getSettings } from '../services/settings';
 
 interface ProfileState {
   step: 'transport' | 'fullname' | 'id_photo' | 'selfie' | 'card';

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,6 +1,6 @@
 import { Telegraf, Context, Markup } from 'telegraf';
-import { upsertUser } from '../services/users.js';
-import { startProfileWizard } from './profile.js';
+import { upsertUser } from '../services/users';
+import { startProfileWizard } from './profile';
 
 interface StartState {
   step: 'phone' | 'role' | 'consent';

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 import { Telegraf, Markup, Context } from 'telegraf';
-import { getOrdersByClient } from '../services/orders.js';
-import { createTicket, updateTicketStatus, getTicket } from '../services/tickets.js';
-import { getSettings } from '../services/settings.js';
+import { getOrdersByClient } from '../services/orders';
+import { createTicket, updateTicketStatus, getTicket } from '../services/tickets';
+import { getSettings } from '../services/settings';
 
 interface SupportState {
   step: 'order' | 'topic' | 'content';

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,5 +1,5 @@
 import type { Point } from './twoGis';
-import { getSettings } from '../services/settings.js';
+import { getSettings } from '../services/settings';
 const R = 6371;
 export function distanceKm(a: Point, b: Point): number {
   const dLat = toRad(b.lat - a.lat);

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,4 +1,4 @@
-import { getSettings } from '../services/settings.js';
+import { getSettings } from '../services/settings';
 
 export function calcPrice(
   distanceKm: number,

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  setOrdersBot,
+  createOrder,
+  updateOrderStatus,
+  updateOrder,
+  openDispute,
+  addDisputeMessage,
+  resolveDispute,
+} from '../src/services/orders';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'orders-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const messages: { id: number; text: string }[] = [];
+  setOrdersBot({
+    telegram: {
+      sendMessage: (id: number, text: string) => {
+        messages.push({ id, text });
+        return Promise.resolve();
+      },
+    },
+  } as any);
+  return { dir, prev, messages };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('status update notifies client and courier', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    assert.deepEqual(messages, [
+      { id: 100, text: 'Курьер назначен' },
+      { id: 200, text: 'Заказ назначен' },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});
+
+test('payment confirmation notifies both parties', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    messages.splice(0);
+    updateOrder(order.id, { payment_status: 'paid' });
+    assert.deepEqual(messages, [
+      { id: 100, text: `Оплата заказа #${order.id} подтверждена` },
+      { id: 200, text: `Оплата по заказу #${order.id} получена` },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});
+
+test('dispute lifecycle notifies participants', () => {
+  const { dir, prev, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 0, lon: 0 },
+      to: { lat: 1, lon: 1 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'S',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    updateOrderStatus(order.id, 'assigned', 200);
+    messages.splice(0);
+
+    openDispute(order.id);
+    assert.deepEqual(messages, [
+      { id: 100, text: `Открыт спор по заказу #${order.id}` },
+      { id: 200, text: `Открыт спор по заказу #${order.id}` },
+    ]);
+
+    messages.splice(0);
+    addDisputeMessage(order.id, 'client', 'привет');
+    assert.deepEqual(messages, [
+      { id: 200, text: 'Сообщение от клиента: привет' },
+    ]);
+
+    messages.splice(0);
+    resolveDispute(order.id);
+    assert.deepEqual(messages, [
+      { id: 100, text: `Спор по заказу #${order.id} завершён` },
+      { id: 200, text: `Спор по заказу #${order.id} завершён` },
+    ]);
+  } finally {
+    teardown(dir, prev);
+  }
+});


### PR DESCRIPTION
## Summary
- send short status updates to client and courier using botRef
- notify parties on payment confirmation and dispute events
- add node-based tests for status, payment, and dispute notifications
- drop `.js` extensions from internal imports to fix module resolution in dev mode

## Testing
- `npm test`
- `npm run check`
- `TELEGRAM_BOT_TOKEN=123 npm run dev` (fails: request to https://api.telegram.org/bot123/getMe failed, reason: ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68c70eb6af44832dbba4b493485cbb3d