### PR TITLE
feat: auto expire reservations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import chatCommands from './commands/chat';
 import orderStatusCommands from './commands/orderStatus';
 import profileCommands from './commands/profile';
 import adminCommands from './commands/admin';
-import { setOrdersBot } from './services/orders';
+import { setOrdersBot, expireReservations } from './services/orders';
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
 if (!token) {
@@ -29,6 +29,8 @@ chatCommands(bot);
 orderStatusCommands(bot);
 profileCommands(bot);
 adminCommands(bot);
+
+setInterval(expireReservations, 30_000);
 
 bot.command('ping', (ctx) => ctx.reply('pong'));
 


### PR DESCRIPTION
## Summary
- auto-release reserved orders after their reservation time passes
- schedule periodic reservation expiration check
- test reservation expiration flow with notifications

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c713bb3164832d91cd787d3b2e3c61