### PR TITLE
Add bot interaction tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js",
     "dev": "ts-node --transpile-only src/index.ts",
     "check": "tsc --noEmit",
-    "test": "node --require ts-node/register --test tests/orders.test.ts"
+    "test": "node --require ts-node/register --test --test-concurrency=1 tests/*.test.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/tests/driver.test.ts
+++ b/tests/driver.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import driverCommands from '../src/commands/driver';
+import { createOrder, getOrder } from '../src/services/orders';
+import { setCourierOnline } from '../src/services/courierState';
+import { createMockBot, sendUpdate } from './helpers';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'driver-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const messages: { id: number; text: string }[] = [];
+  const bot = createMockBot(messages);
+  driverCommands(bot as any);
+  return { dir, prev, bot, messages };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('reservation holds order for 90 seconds', async () => {
+  const { dir, prev, bot, messages } = setup();
+  try {
+    const order = createOrder({
+      customer_id: 100,
+      from: { lat: 43.2, lon: 76.9 },
+      to: { lat: 43.25, lon: 76.95 },
+      type: 'delivery',
+      time: 'now',
+      options: null,
+      size: 'M',
+      pay_type: 'cash',
+      comment: null,
+      price: 10,
+    });
+    setCourierOnline(200, true);
+    const before = Date.now();
+    await sendUpdate(bot, {
+      update_id: 1,
+      callback_query: {
+        id: '1',
+        from: { id: 200, is_bot: false, first_name: 'C' },
+        message: {
+          message_id: 10,
+          text: 'card',
+          chat: { id: -100, type: 'channel' },
+        } as any,
+        data: `reserve:${order.id}`,
+      } as any,
+    });
+    const updated = getOrder(order.id)!;
+    const diff = new Date(updated.reserved_until!).getTime() - before;
+    assert.equal(updated.status, 'reserved');
+    assert.equal(updated.reserved_by, 200);
+    assert.ok(diff >= 89_000 && diff <= 91_000);
+    assert.ok(
+      messages.at(-1)?.text.includes(`Заказ #${order.id} зарезервирован`)
+    );
+  } finally {
+    teardown(dir, prev);
+  }
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,22 @@
+import { Telegraf, Context } from 'telegraf';
+
+export function createMockBot(messages: { id: number; text: string }[]) {
+  const bot = new Telegraf<Context>('test');
+  (bot as any).botInfo = { id: 0, is_bot: true, username: 'test' };
+  bot.telegram.getMe = () => Promise.resolve((bot as any).botInfo);
+  let msgId = 0;
+  bot.telegram.callApi = (method: string, data: any) => {
+    if (method === 'sendMessage') {
+      messages.push({ id: data.chat_id, text: data.text });
+      return Promise.resolve({ message_id: ++msgId } as any);
+    }
+    return Promise.resolve(true as any);
+  };
+  return bot;
+}
+
+export async function sendUpdate(bot: Telegraf<Context>, update: any) {
+  const ctx = new Context(update, bot.telegram, (bot as any).botInfo);
+  Object.assign(ctx, bot.context);
+  await bot.middleware()(ctx, () => Promise.resolve());
+}

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import registerOrder from '../src/commands/order';
+import { createMockBot, sendUpdate } from './helpers';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'order-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const messages: { id: number; text: string }[] = [];
+  const bot = createMockBot(messages);
+  registerOrder(bot);
+  return { dir, prev, bot, messages };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('geofence rejects points outside city', async () => {
+  const { dir, prev, bot, messages } = setup();
+  try {
+    await sendUpdate(bot, {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        text: '/order',
+        entities: [{ offset: 0, length: 6, type: 'bot_command' }],
+      } as any,
+    });
+    await sendUpdate(bot, {
+      update_id: 2,
+      message: {
+        message_id: 2,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        text: 'Доставка',
+      } as any,
+    });
+    await sendUpdate(bot, {
+      update_id: 3,
+      message: {
+        message_id: 3,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        location: { latitude: 44.0, longitude: 75.0 },
+      } as any,
+    });
+    assert.equal(
+      messages.at(-1)?.text,
+      'Не удалось определить точку в пределах Алматы. Попробуйте ещё раз.'
+    );
+  } finally {
+    teardown(dir, prev);
+  }
+});

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import registerStart from '../src/commands/start';
+import { getUser } from '../src/services/users';
+import { createMockBot, sendUpdate } from './helpers';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'start-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const messages: { id: number; text: string }[] = [];
+  const bot = createMockBot(messages);
+  registerStart(bot);
+  return { dir, prev, bot, messages };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('phone collection and consent flow', async () => {
+  const { dir, prev, bot, messages } = setup();
+  try {
+    await sendUpdate(bot, {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        text: '/start',
+        entities: [{ offset: 0, length: 6, type: 'bot_command' }],
+      } as any,
+    });
+    await sendUpdate(bot, {
+      update_id: 2,
+      message: {
+        message_id: 2,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        contact: { phone_number: '+777', first_name: 'A', user_id: 1 },
+      } as any,
+    });
+    await sendUpdate(bot, {
+      update_id: 3,
+      message: {
+        message_id: 3,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        text: 'Клиент',
+      } as any,
+    });
+    await sendUpdate(bot, {
+      update_id: 4,
+      message: {
+        message_id: 4,
+        from: { id: 1, is_bot: false, first_name: 'A' },
+        chat: { id: 1, type: 'private' },
+        date: 0,
+        text: 'Да',
+      } as any,
+    });
+    const user = getUser(1)!;
+    assert.equal(user.phone, '+777');
+    assert.equal(user.role, 'client');
+    assert.equal(user.consent, true);
+    assert.deepEqual(
+      messages.map((m) => m.text),
+      [
+        'Добро пожаловать! Пожалуйста, отправьте ваш номер телефона.',
+        'Вы клиент или курьер?',
+        'Согласны ли вы с условиями сервиса?',
+        'Главное меню',
+      ]
+    );
+  } finally {
+    teardown(dir, prev);
+  }
+});


### PR DESCRIPTION
## Summary
- expand test coverage for onboarding, ordering flow and driver reservations
- mock Telegraf interactions to validate geofence and 90‑second booking logic
- run all TypeScript tests via npm

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c733432830832d848d7cf7c9e0a3a0