### PR TITLE
ci: add node workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npm run check
+      - run: npm run lint --if-present
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow with npm cache
- run tests, tsc, optional eslint and build in CI

## Testing
- `npm test`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c735705de0832d82a1f89762dc99f1