### PR TITLE
feat: add new order types

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -3,7 +3,8 @@ import { getSettings } from '../services/settings';
 export function calcPrice(
   distanceKm: number,
   size: 'S' | 'M' | 'L' = 'M',
-  now = new Date()
+  now = new Date(),
+  type: 'docs' | 'parcel' | 'food' | 'other' = 'other'
 ): number {
   const settings = getSettings();
   const base = settings.base_price ?? 500;
@@ -14,7 +15,17 @@ export function calcPrice(
   }
   const surcharge =
     (settings as any)[`surcharge_${size}` as const] ?? 0;
-  let price = base + perKm * Math.max(1, distanceKm) + surcharge;
+  const typeSurcharge: Record<typeof type, number> = {
+    docs: 0,
+    parcel: 200,
+    food: 150,
+    other: 0,
+  };
+  let price =
+    base +
+    perKm * Math.max(1, distanceKm) +
+    surcharge +
+    typeSurcharge[type];
   price = Math.round(price / 10) * 10;
   return price;
 }

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -42,7 +42,7 @@ test('geofence rejects points outside city', async () => {
         from: { id: 1, is_bot: false, first_name: 'A' },
         chat: { id: 1, type: 'private' },
         date: 0,
-        text: 'Доставка',
+        text: 'Документы',
       } as any,
     });
     await sendUpdate(bot, {


### PR DESCRIPTION
## Summary
- support documents, parcels, food and other order types with normalized values
- include order type in price calculation and driver card
- adjust tests for new type selection

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c737ba6ee8832d96a0c521059f26af