### PR TITLE
feat: parse 2gis routes

### DIFF
--- a/src/utils/twoGis.ts
+++ b/src/utils/twoGis.ts
@@ -3,7 +3,9 @@ export interface Point { lat: number; lon: number }
 function inLat(v: number) { return v >= -90 && v <= 90 }
 function inLon(v: number) { return v >= -180 && v <= 180 }
 
-export async function parse2GisLink(url: string): Promise<Point | null> {
+export async function parse2GisLink(
+  url: string
+): Promise<{ point: Point } | { from: Point; to: Point } | null> {
   let finalUrl = url.trim();
   try {
     if (/go\.2gis\.com/.test(finalUrl)) {
@@ -14,11 +16,23 @@ export async function parse2GisLink(url: string): Promise<Point | null> {
     // ignore network errors
   }
 
+  const routeMatch = finalUrl.match(
+    /routeSearch\/points\/(-?\d+\.\d+),(-?\d+\.\d+);(-?\d+\.\d+),(-?\d+\.\d+)/
+  );
+  if (routeMatch) {
+    const [, lon1, lat1, lon2, lat2] = routeMatch;
+    const from = { lon: Number(lon1), lat: Number(lat1) };
+    const to = { lon: Number(lon2), lat: Number(lat2) };
+    if (inLat(from.lat) && inLon(from.lon) && inLat(to.lat) && inLon(to.lon)) {
+      return { from, to };
+    }
+  }
+
   const nums = (finalUrl.match(/-?\d+\.\d+/g) || []).map(Number);
   for (let i = 0; i + 1 < nums.length; i++) {
     const a = nums[i], b = nums[i + 1];
-    if (inLat(b) && inLon(a)) return { lat: b, lon: a };
-    if (inLat(a) && inLon(b)) return { lat: a, lon: b };
+    if (inLat(b) && inLon(a)) return { point: { lat: b, lon: a } };
+    if (inLat(a) && inLon(b)) return { point: { lat: a, lon: b } };
   }
   return null;
 }

--- a/tests/twoGis.test.ts
+++ b/tests/twoGis.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parse2GisLink } from '../src/utils/twoGis';
+
+(test('parse single 2GIS link', async () => {
+  const res = await parse2GisLink('https://2gis.kz/almaty?m=76.95,43.25');
+  assert.deepEqual(res, { point: { lon: 76.95, lat: 43.25 } });
+}));
+
+(test('parse route 2GIS link', async () => {
+  const res = await parse2GisLink(
+    'https://2gis.kz/almaty/routeSearch/points/76.94,43.24;76.95,43.25'
+  );
+  assert.deepEqual(res, {
+    from: { lon: 76.94, lat: 43.24 },
+    to: { lon: 76.95, lat: 43.25 },
+  });
+}));


### PR DESCRIPTION
## Summary
- support parsing two-point 2GIS route links
- allow order command to accept single points or routes
- add tests for 2GIS link parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73a63eb50832da3b3fda023e25934