### PR TITLE
Add no-movement handling for orders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import chatCommands from './commands/chat';
 import orderStatusCommands from './commands/orderStatus';
 import profileCommands from './commands/profile';
 import adminCommands from './commands/admin';
-import { setOrdersBot, expireReservations } from './services/orders';
+import { setOrdersBot, expireReservations, expireMovementTimers } from './services/orders';
 import { rollupDailyMetrics } from './services/metrics';
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
@@ -32,6 +32,7 @@ profileCommands(bot);
 adminCommands(bot);
 
 setInterval(expireReservations, 30_000);
+setInterval(expireMovementTimers, 30_000);
 
 rollupDailyMetrics();
 setInterval(rollupDailyMetrics, 24 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- track inactivity deadlines for assigned/going order statuses
- periodically reopen stalled orders or escalate to dispute and log no-movement
- notify client and courier when orders are removed or escalated

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c7417ece18832dbc19022953149444