### PR TITLE
refactor: standardize dispute handling and customer id

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -8,7 +8,7 @@ import {
   suspendUser,
   banUser,
   unbanUser,
-  resolveDispute,
+  logDisputeResolution,
   getModerationInfo,
 } from '../services/moderation';
 import { getCourierMetrics, getCourierAudit } from '../services/couriers';
@@ -161,8 +161,10 @@ export default function adminCommands(bot: Telegraf) {
     const parts = ((ctx.message as any)?.text ?? '').split(' ');
     const orderId = Number(parts[1]);
     const resolution = parts.slice(2).join(' ');
-    if (!orderId || !resolution) return ctx.reply('Использование: /resolve_dispute <orderId> <resolution>');
-    resolveDispute(orderId, resolution);
+    if (!orderId || !resolution)
+      return ctx.reply('Использование: /resolve_dispute <orderId> <resolution>');
+    resolveDispute(orderId);
+    logDisputeResolution(orderId, resolution);
     ctx.reply('Спор закрыт');
   });
 
@@ -212,7 +214,7 @@ export default function adminCommands(bot: Telegraf) {
     } catch {}
     try {
       await ctx.telegram.sendMessage(
-        order.client_id,
+        order.customer_id,
         `Ответ по спору заказа #${order.id}: ${text}`
       );
     } catch {}
@@ -236,7 +238,7 @@ export default function adminCommands(bot: Telegraf) {
     } catch {}
     try {
       await ctx.telegram.sendMessage(
-        order.client_id,
+        order.customer_id,
         `Спор по заказу #${order.id} закрыт`
       );
     } catch {}

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -42,10 +42,10 @@ export default function chatCommands(bot: Telegraf) {
     if (!chat) return next();
     const fromId = ctx.from!.id;
     let toId: number | undefined;
-    if (chat.client_id === fromId) {
+    if (chat.customer_id === fromId) {
       toId = chat.courier_id;
     } else if (chat.courier_id === fromId) {
-      toId = chat.client_id;
+      toId = chat.customer_id;
     }
     if (!toId) {
       return ctx.reply('Собеседник пока не подключен к чату');

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -14,7 +14,7 @@ interface ChatMessage {
 
 export interface OrderChat {
   order_id: number;
-  client_id: number;
+  customer_id: number;
   courier_id: number;
   created_at: string;
   expires_at?: string;
@@ -50,10 +50,10 @@ function saveChatSessions(sessions: OrderChat[]) {
   writeFileSync(CHAT_SESSIONS, JSON.stringify(sessions, null, 2));
 }
 
-export function createOrderChat(order_id: number, client_id: number, courier_id: number) {
+export function createOrderChat(order_id: number, customer_id: number, courier_id: number) {
   const sessions = loadChatSessions();
   if (!sessions.find((s) => s.order_id === order_id)) {
-    sessions.push({ order_id, client_id, courier_id, created_at: new Date().toISOString() });
+    sessions.push({ order_id, customer_id, courier_id, created_at: new Date().toISOString() });
     saveChatSessions(sessions);
   }
 }
@@ -72,7 +72,7 @@ export function getActiveChatByUser(userId: number): OrderChat | undefined {
   const now = Date.now();
   return sessions.find(
     (s) => (!s.expires_at || new Date(s.expires_at).getTime() > now) &&
-      (s.client_id === userId || s.courier_id === userId)
+      (s.customer_id === userId || s.courier_id === userId)
   );
 }
 

--- a/src/services/moderation.ts
+++ b/src/services/moderation.ts
@@ -58,7 +58,7 @@ export function getModerationInfo(id: number): ModerationInfo | undefined {
   return store[id];
 }
 
-export function resolveDispute(orderId: number, resolution: string) {
+export function logDisputeResolution(orderId: number, resolution: string) {
   if (!existsSync('data')) mkdirSync('data');
   const line = JSON.stringify({ order_id: orderId, resolution, timestamp: new Date().toISOString() });
   appendFileSync(DISPUTE_LOG, line + '\n');

--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import registerOrder from '../src/commands/order';
 import { createMockBot, sendUpdate } from './helpers';
+import { updateSetting } from '../src/services/settings';
 
 function setup() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'order-test-'));
@@ -13,6 +14,8 @@ function setup() {
   const messages: { id: number; text: string }[] = [];
   const bot = createMockBot(messages);
   registerOrder(bot);
+  updateSetting('order_hours_start', 0);
+  updateSetting('order_hours_end', 24);
   return { dir, prev, bot, messages };
 }
 


### PR DESCRIPTION
## Summary
- rename moderation dispute logger to `logDisputeResolution` and call it from admin commands
- replace all `client_id` references with `customer_id`
- align `resolveDispute` admin handler with orders service signature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c74b8de478832d858e9fac39ad0aaa