### PR TITLE
Use moderators channel for support tickets

### DIFF
--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -97,10 +97,14 @@ export default function supportCommands(bot: Telegraf) {
         states.delete(uid);
         await ctx.reply(`Тикет #${ticket.id} создан`, Markup.removeKeyboard());
         const settings = getSettings();
-        if (settings.verify_channel_id) {
+        if (settings.moderators_channel_id) {
           await ctx.telegram.sendMessage(
-            settings.verify_channel_id,
+            settings.moderators_channel_id,
             `Тикет #${ticket.id} по заказу #${ticket.order_id}\nТема: ${ticket.topic}\nТекст: ${ticket.text ?? ''}`
+          );
+        } else {
+          await ctx.reply(
+            'Канал модераторов не привязан, модераторы пока не уведомлены.'
           );
         }
         return;
@@ -126,11 +130,15 @@ export default function supportCommands(bot: Telegraf) {
     states.delete(uid);
     await ctx.reply(`Тикет #${ticket.id} создан`, Markup.removeKeyboard());
     const settings = getSettings();
-    if (settings.verify_channel_id) {
+    if (settings.moderators_channel_id) {
       await ctx.telegram.sendPhoto(
-        settings.verify_channel_id,
+        settings.moderators_channel_id,
         photo.file_id,
         { caption: `Тикет #${ticket.id} по заказу #${ticket.order_id}\nТема: ${ticket.topic}` }
+      );
+    } else {
+      await ctx.reply(
+        'Канал модераторов не привязан, модераторы пока не уведомлены.'
       );
     }
   });

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createTicket, getTicket } from '../src/services/tickets';
+
+function setup() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'support-test-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  return { dir, prev };
+}
+
+function teardown(dir: string, prev: string) {
+  process.chdir(prev);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('create ticket with text', () => {
+  const { dir, prev } = setup();
+  try {
+    const ticket = createTicket({
+      order_id: 1,
+      user_id: 1,
+      topic: 'topic',
+      text: 'hello',
+    });
+    assert.equal(ticket.text, 'hello');
+    const saved = getTicket(ticket.id)!;
+    assert.equal(saved.text, 'hello');
+  } finally {
+    teardown(dir, prev);
+  }
+});
+
+test('create ticket with photo', () => {
+  const { dir, prev } = setup();
+  try {
+    const ticket = createTicket({
+      order_id: 1,
+      user_id: 1,
+      topic: 'topic',
+      photo: 'file_id',
+    });
+    assert.equal(ticket.photo, 'file_id');
+    const saved = getTicket(ticket.id)!;
+    assert.equal(saved.photo, 'file_id');
+  } finally {
+    teardown(dir, prev);
+  }
+});


### PR DESCRIPTION
## Summary
- send support tickets to moderators channel instead of verify channel
- inform user when moderators channel is not bound
- add tests for ticket creation with text and photo

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c74dd468a0832d99f0a674a9a005c9