### PR TITLE
feat: improve order cards and driver reserve flow

### DIFF
--- a/src/commands/order.ts
+++ b/src/commands/order.ts
@@ -325,14 +325,18 @@ export default function registerOrderCommands(bot: Telegraf<Context>) {
 
         const settings = getSettings();
         if (settings.drivers_channel_id) {
+          const timePart = s.time === 'Сейчас' ? 'сейчас' : `к ${s.time}`;
+          const header = `Алматы • ${typeLabels[order.type as OrderType]} • ${
+            s.size || 'M'
+          } • ${timePart}`;
           const card = [
             `#${order.id}`,
-            `Тип: ${typeLabels[order.type as OrderType]}`,
+            header,
             `Откуда: ${fromAddr}`,
             `Куда: ${toAddr}`,
-            `Время: ${s.time}`,
+            `Расстояние: ${dist.toFixed(1)} км`,
+            `ETA: ~${eta} мин`,
             `Оплата: ${s.payment}`,
-            `Габариты: ${s.size}`,
             `Опции: ${s.options?.join(', ') || 'нет'}`,
             `Комментарий: ${s.comment}`,
             `Цена: ~${price} ₸`,


### PR DESCRIPTION
## Summary
- show city, type, size and delivery time in order cards with distance and ETA
- add confirm-start button for drivers to assign reserved orders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c74f4f34a8832db504a731e32b0b5b