### PR TITLE
Send receiver invoice on dropoff start

### DIFF
--- a/src/commands/order.ts
+++ b/src/commands/order.ts
@@ -362,17 +362,6 @@ export default function registerOrderCommands(bot: Telegraf<Context>) {
         }
 
         await ctx.reply(`Заказ #${order.id} создан. Ожидайте курьера.`);
-
-        if (s.payment === 'Получатель платит' && process.env.PROVIDER_TOKEN) {
-          await ctx.replyWithInvoice({
-            title: 'Оплата доставки',
-            description: `Заказ на ~${price} ₸`,
-            provider_token: process.env.PROVIDER_TOKEN,
-            currency: 'KZT',
-            prices: [{ label: 'Доставка', amount: Math.round(price * 100) }],
-            payload: 'order_payment',
-          });
-        }
         sessions.delete(ctx.from!.id);
         break;
     }


### PR DESCRIPTION
## Summary
- Send invoice to receiver when courier starts heading to drop-off and remind courier about payment
- Implement `sendInvoiceToReceiver` to dispatch invoice and log `payment.requested`
- Remove early invoice sending on order creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c75ab549e0832d9c3e5ffd78524f8e