### PR TITLE
Add extra address fields to orders

### DIFF
--- a/src/commands/driver.ts
+++ b/src/commands/driver.ts
@@ -25,6 +25,7 @@ import {
 import { getSettings } from '../services/settings';
 import { routeToDeeplink } from '../utils/twoGis';
 import { reverseGeocode } from '../utils/geocode';
+import { formatAddress } from '../utils/address';
 import { rateLimit } from '../utils/rateLimiter';
 
 interface ProofState {
@@ -169,8 +170,18 @@ export default function driverCommands(bot: Telegraf) {
       await ctx.answerCbQuery('Не найдено');
       return;
     }
-    const fromAddr = await reverseGeocode(order.from);
-    const toAddr = await reverseGeocode(order.to);
+    const fromAddr = formatAddress(await reverseGeocode(order.from), {
+      entrance: order.from_entrance || undefined,
+      floor: order.from_floor || undefined,
+      flat: order.from_flat || undefined,
+      intercom: order.from_intercom || undefined,
+    });
+    const toAddr = formatAddress(await reverseGeocode(order.to), {
+      entrance: order.to_entrance || undefined,
+      floor: order.to_floor || undefined,
+      flat: order.to_flat || undefined,
+      intercom: order.to_intercom || undefined,
+    });
     const pay =
       order.pay_type === 'card'
         ? 'Карта'

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -92,6 +92,14 @@ export interface Order {
   courier_id?: number | null;
   from: Point;
   to: Point;
+  from_entrance?: string | null;
+  from_floor?: string | null;
+  from_flat?: string | null;
+  from_intercom?: string | null;
+  to_entrance?: string | null;
+  to_floor?: string | null;
+  to_flat?: string | null;
+  to_intercom?: string | null;
   type: string;
   time: string;
   options: string | null;
@@ -210,6 +218,14 @@ interface CreateOrderInput {
   customer_id: number;
   from: Point;
   to: Point;
+  from_entrance?: string | null;
+  from_floor?: string | null;
+  from_flat?: string | null;
+  from_intercom?: string | null;
+  to_entrance?: string | null;
+  to_floor?: string | null;
+  to_flat?: string | null;
+  to_intercom?: string | null;
   type: string;
   time: string;
   options: string | null;
@@ -236,6 +252,14 @@ export function createOrder(input: CreateOrderInput): Order {
     customer_id: input.customer_id,
     from: input.from,
     to: input.to,
+    from_entrance: input.from_entrance ?? null,
+    from_floor: input.from_floor ?? null,
+    from_flat: input.from_flat ?? null,
+    from_intercom: input.from_intercom ?? null,
+    to_entrance: input.to_entrance ?? null,
+    to_floor: input.to_floor ?? null,
+    to_flat: input.to_flat ?? null,
+    to_intercom: input.to_intercom ?? null,
     type: input.type,
     time: input.time,
     options: input.options,

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,0 +1,16 @@
+export interface AddrExtras {
+  entrance?: string | null;
+  floor?: string | null;
+  flat?: string | null;
+  intercom?: string | null;
+}
+
+export function formatAddress(addr: string, extras: AddrExtras): string {
+  const parts: string[] = [];
+  if (extras.entrance) parts.push(`Подъезд ${extras.entrance}`);
+  if (extras.floor) parts.push(`Этаж ${extras.floor}`);
+  if (extras.flat) parts.push(`Кв. ${extras.flat}`);
+  if (extras.intercom) parts.push(`Домофон ${extras.intercom}`);
+  return parts.length ? `${addr} (${parts.join(', ')})` : addr;
+}
+


### PR DESCRIPTION
## Summary
- allow entering подъезд, этаж, кв. and домофон via inline buttons after selecting an address
- persist additional address fields in orders and show them in summaries and driver cards
- add helper for formatting addresses with extra details

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c75cee7590832d99456abc8361e076