### PR TITLE
Add wait time pricing and tests

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -5,11 +5,14 @@ export function calcPrice(
   size: 'S' | 'M' | 'L' = 'M',
   now = new Date(),
   type: 'docs' | 'parcel' | 'food' | 'other' = 'other',
-  options: string[] = []
+  options: string[] = [],
+  waitMinutes = 0
 ): { price: number; nightApplied: boolean } {
   const settings = getSettings();
   const base = settings.base_price ?? 500;
   let perKm = settings.per_km ?? 180;
+  const waitFree = settings.wait_free ?? 0;
+  const waitPerMin = settings.wait_per_min ?? 0;
   const isNight = now.getHours() >= 22 || now.getHours() < 7;
   let nightApplied = false;
   if (isNight && settings.night_active) {
@@ -32,12 +35,14 @@ export function calcPrice(
     (sum, o) => sum + (optionSurcharges[o] || 0),
     0
   );
+  const waitCost = Math.max(0, waitMinutes - waitFree) * waitPerMin;
   let price =
     base +
     perKm * Math.max(1, distanceKm) +
     surcharge +
     typeSurcharge[type] +
-    optionsTotal;
+    optionsTotal +
+    waitCost;
   price = Math.round(price / 10) * 10;
   return { price, nightApplied };
 }

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -54,3 +54,23 @@ test('night coefficient is applied when active', () => {
     teardown(dir, prev);
   }
 });
+
+test('waiting over free limit adds to price', () => {
+  const { dir, prev } = setup();
+  try {
+    updateSetting('wait_free', 5);
+    updateSetting('wait_per_min', 20);
+    const { price, nightApplied } = calcPrice(
+      1,
+      'M',
+      new Date('2024-01-01T12:00:00Z'),
+      'other',
+      [],
+      10
+    );
+    assert.equal(price, 780);
+    assert.equal(nightApplied, false);
+  } finally {
+    teardown(dir, prev);
+  }
+});


### PR DESCRIPTION
## Summary
- Add waitMinutes pricing calculation using settings `wait_free` and `wait_per_min`
- Test pricing with paid waiting minutes

## Testing
- `npm run check`
- `npm test`
- `node --require ts-node/register --test tests/pricing.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c7c80bcb74832daf22e25640a9824f