### PR TITLE
feat: request role before phone

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -3,8 +3,8 @@ import { upsertUser } from '../services/users';
 import { startProfileWizard } from './profile';
 
 interface StartState {
-  step: 'phone' | 'role' | 'consent';
-  data: { phone?: string; city?: string };
+  step: 'role' | 'phone' | 'consent';
+  data: { role?: 'client' | 'courier'; phone?: string; city?: string };
   msgId?: number;
 }
 
@@ -14,10 +14,40 @@ export default function registerStart(bot: Telegraf<Context>) {
   bot.start(async (ctx) => {
     const uid = ctx.from!.id;
     const msg = await ctx.reply(
-      'Добро пожаловать! Пожалуйста, отправьте ваш номер телефона.',
+      'Добро пожаловать! Выберите действие:',
+      Markup.keyboard([['Заказать доставку'], ['Стать исполнителем']]).resize()
+    );
+    states.set(uid, { step: 'role', data: {}, msgId: msg.message_id });
+  });
+
+  bot.hears('Заказать доставку', async (ctx) => {
+    const uid = ctx.from!.id;
+    const state = states.get(uid);
+    if (!state || state.step !== 'role') return;
+    if (state.msgId)
+      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
+    state.data.role = 'client';
+    state.step = 'phone';
+    const msg = await ctx.reply(
+      'Пожалуйста, отправьте ваш номер телефона.',
       Markup.keyboard([[Markup.button.contactRequest('Отправить телефон')]]).resize()
     );
-    states.set(uid, { step: 'phone', data: {}, msgId: msg.message_id });
+    state.msgId = msg.message_id;
+  });
+
+  bot.hears('Стать исполнителем', async (ctx) => {
+    const uid = ctx.from!.id;
+    const state = states.get(uid);
+    if (!state || state.step !== 'role') return;
+    if (state.msgId)
+      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
+    state.data.role = 'courier';
+    state.step = 'phone';
+    const msg = await ctx.reply(
+      'Пожалуйста, отправьте ваш номер телефона.',
+      Markup.keyboard([[Markup.button.contactRequest('Отправить телефон')]]).resize()
+    );
+    state.msgId = msg.message_id;
   });
 
   bot.on('contact', async (ctx) => {
@@ -28,41 +58,23 @@ export default function registerStart(bot: Telegraf<Context>) {
       await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
     const phone = ctx.message.contact.phone_number;
     state.data.phone = phone;
-    state.step = 'role';
-    upsertUser({ id: uid, phone, city: 'Алматы' });
-    const msg = await ctx.reply(
-      'Вы клиент или курьер?',
-      Markup.keyboard([['Клиент'], ['Курьер']]).resize()
-    );
-    state.msgId = msg.message_id;
-  });
-
-  bot.hears('Клиент', async (ctx) => {
-    const uid = ctx.from!.id;
-    const state = states.get(uid);
-    if (!state || state.step !== 'role') return;
-    if (state.msgId)
-      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
+    const role = state.data.role;
     const city = 'Алматы';
     state.data.city = city;
-    state.step = 'consent';
-    upsertUser({ id: uid, phone: state.data.phone, role: 'client', city });
-    const msg = await ctx.reply(
-      'Согласны ли вы с условиями сервиса?',
-      Markup.keyboard([['Да'], ['Нет']]).resize()
-    );
-    state.msgId = msg.message_id;
-  });
-
-  bot.hears('Курьер', async (ctx) => {
-    const uid = ctx.from!.id;
-    const state = states.get(uid);
-    if (!state || state.step !== 'role') return;
-    if (state.msgId)
-      await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
-    upsertUser({ id: uid, phone: state.data.phone, role: 'courier', city: 'Алматы' });
-    states.delete(uid);
-    await startProfileWizard(ctx);
+    upsertUser({ id: uid, phone, role, city });
+    if (role === 'client') {
+      state.step = 'consent';
+      const msg = await ctx.reply(
+        'Согласны ли вы с условиями сервиса?',
+        Markup.keyboard([['Да'], ['Нет']]).resize()
+      );
+      state.msgId = msg.message_id;
+    } else if (role === 'courier') {
+      states.delete(uid);
+      await startProfileWizard(ctx);
+    } else {
+      states.delete(uid);
+    }
   });
 
   bot.on('text', async (ctx) => {

--- a/tests/start.test.ts
+++ b/tests/start.test.ts
@@ -43,7 +43,7 @@ test('phone collection and consent flow', async () => {
         from: { id: 1, is_bot: false, first_name: 'A' },
         chat: { id: 1, type: 'private' },
         date: 0,
-        contact: { phone_number: '+777', first_name: 'A', user_id: 1 },
+        text: 'Заказать доставку',
       } as any,
     });
     await sendUpdate(bot, {
@@ -53,7 +53,7 @@ test('phone collection and consent flow', async () => {
         from: { id: 1, is_bot: false, first_name: 'A' },
         chat: { id: 1, type: 'private' },
         date: 0,
-        text: 'Клиент',
+        contact: { phone_number: '+777', first_name: 'A', user_id: 1 },
       } as any,
     });
     await sendUpdate(bot, {
@@ -73,8 +73,8 @@ test('phone collection and consent flow', async () => {
     assert.deepEqual(
       messages.map((m) => m.text),
       [
-        'Добро пожаловать! Пожалуйста, отправьте ваш номер телефона.',
-        'Вы клиент или курьер?',
+        'Добро пожаловать! Выберите действие:',
+        'Пожалуйста, отправьте ваш номер телефона.',
         'Согласны ли вы с условиями сервиса?',
         'Главное меню',
       ]


### PR DESCRIPTION
## Summary
- show "Заказать доставку" and "Стать исполнителем" options on /start
- ask for contact after choosing a role and continue flow
- adjust start tests for new selection-first flow

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c7ccc703d0832d981f6707bc4324d3