### PR TITLE
Track payment proof and auto-dispute overdue payments

### DIFF
--- a/src/commands/driver.ts
+++ b/src/commands/driver.ts
@@ -62,7 +62,7 @@ function buildOrderKeyboard(status: OrderStatus) {
       break;
     case 'awaiting_confirm':
     case 'delivered':
-      buttons.push(['Оплату получил']);
+      buttons.push(['Оплату получил'], ['Поступление проверил']);
       break;
   }
   buttons.push(
@@ -407,6 +407,15 @@ export default function driverCommands(bot: Telegraf) {
     updateOrderStatus(order.id, 'closed');
     markOrderChatDelivered(order.id);
     await ctx.reply('Заказ завершён.', Markup.removeKeyboard());
+  });
+
+  bot.hears('Поступление проверил', async (ctx) => {
+    const order = getCourierActiveOrder(ctx.from!.id);
+    if (!order || order.status !== 'awaiting_confirm') {
+      return ctx.reply('Неверный этап.');
+    }
+    openDispute(order.id);
+    await ctx.reply('Спор открыт, модераторы свяжутся.', buildOrderKeyboard('awaiting_confirm'));
   });
 
   bot.on('photo', async (ctx) => {

--- a/src/commands/order.ts
+++ b/src/commands/order.ts
@@ -11,6 +11,7 @@ import {
   updateOrder,
   getOrder,
   updateOrderStatus,
+  addPaymentProof,
 } from '../services/orders';
 import { geocodeAddress, reverseGeocode } from '../utils/geocode';
 import { formatAddress } from '../utils/address';
@@ -205,6 +206,7 @@ export default function registerOrderCommands(bot: Telegraf<Context>) {
                 caption: `Клиент отправил подтверждение оплаты по заказу #${order.id}`,
               })
               .catch(() => {});
+          addPaymentProof(order.id, fileId);
         } else if (msg.text) {
           if (order.courier_id)
             ctx.telegram
@@ -213,6 +215,7 @@ export default function registerOrderCommands(bot: Telegraf<Context>) {
                 `Клиент отправил подтверждение оплаты по заказу #${order.id}: ${msg.text}`
               )
               .catch(() => {});
+          addPaymentProof(order.id, msg.text);
         } else {
           await ctx.reply('Отправьте скриншот или ID перевода.');
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import chatCommands from './commands/chat';
 import orderStatusCommands from './commands/orderStatus';
 import profileCommands from './commands/profile';
 import adminCommands from './commands/admin';
-import { setOrdersBot, expireReservations, expireMovementTimers } from './services/orders';
+import { setOrdersBot, expireReservations, expireMovementTimers, expireAwaitingConfirm } from './services/orders';
 import { rollupDailyMetrics } from './services/metrics';
 
 const token = process.env.TELEGRAM_BOT_TOKEN;
@@ -33,6 +33,7 @@ adminCommands(bot);
 
 setInterval(expireReservations, 30_000);
 setInterval(expireMovementTimers, 30_000);
+setInterval(expireAwaitingConfirm, 30_000);
 
 rollupDailyMetrics();
 setInterval(rollupDailyMetrics, 24 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- Save payment confirmations in orders and add driver button "Поступление проверил"
- Auto-open disputes if payment confirmation isn't verified within 15 minutes
- Cover new behaviors with tests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c7d1151588832d87e70b9d220d0d24