### PR TITLE
Remove RLS from spatial_ref_sys in schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -162,7 +162,6 @@ BEFORE UPDATE ON support_tickets
 FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
 -- Enable row level security on all tables
-ALTER TABLE spatial_ref_sys ENABLE ROW LEVEL SECURITY;
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE courier_profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE courier_verifications ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- remove spatial_ref_sys RLS enabling from schema

## Testing
- `DB_HOST=localhost DB_USER=bot DB_PASS=bot DB_NAME=freedom_bot npm run migrate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7e2c56ebc832d8995b813ca2dd761