### PR TITLE
Ensure reserved_until column exists for orders

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -70,6 +70,9 @@ CREATE TABLE IF NOT EXISTS orders (
   updated_at TIMESTAMPTZ DEFAULT now()
 );
 
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS reserved_until TIMESTAMPTZ;
+
 CREATE INDEX IF NOT EXISTS orders_pickup_gix ON orders USING GIST (pickup);
 CREATE INDEX IF NOT EXISTS orders_dropoff_gix ON orders USING GIST (dropoff);
 CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);


### PR DESCRIPTION
## Summary
- Add safeguard ALTER TABLE for reserved_until column in orders schema

## Testing
- `npm run migrate` *(fails: connect ECONNREFUSED ::1:5432)*
- `npm test` *(hangs with no output, manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c822dd31a8832db6e9de4a4912409e