### PR TITLE
feat(db): introduce migrations

### DIFF
--- a/db/migrations/001-initial.sql
+++ b/db/migrations/001-initial.sql
@@ -63,20 +63,13 @@ CREATE TABLE IF NOT EXISTS orders (
   -- human readable addresses
   pickup_addr TEXT,
   dropoff_addr TEXT,
-  -- reservation fields
-  reserved_by UUID,
-  reserved_until TIMESTAMPTZ,
   created_at TIMESTAMPTZ DEFAULT now(),
   updated_at TIMESTAMPTZ DEFAULT now()
 );
 
-ALTER TABLE orders
-  ADD COLUMN IF NOT EXISTS reserved_until TIMESTAMPTZ;
-
 CREATE INDEX IF NOT EXISTS orders_pickup_gix ON orders USING GIST (pickup);
 CREATE INDEX IF NOT EXISTS orders_dropoff_gix ON orders USING GIST (dropoff);
 CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);
-CREATE INDEX IF NOT EXISTS idx_orders_reserved_until ON orders(reserved_until);
 CREATE INDEX IF NOT EXISTS idx_orders_client ON orders(client_id);
 CREATE INDEX IF NOT EXISTS idx_orders_courier ON orders(courier_id);
 
@@ -399,70 +392,6 @@ LANGUAGE sql STABLE AS $$
   ORDER BY created_at DESC
   LIMIT p_limit;
 $$;
-
--- Helper functions for atomic order operations
-
--- Attempt to reserve an open order for a courier
-CREATE OR REPLACE FUNCTION fn_try_reserve_order(
-  p_order_id INT,
-  p_courier UUID,
-  p_hold_seconds INT DEFAULT 90
-)
-RETURNS BOOLEAN
-LANGUAGE plpgsql AS $$
-DECLARE v_rowcount INT;
-BEGIN
-  UPDATE orders
-     SET status='reserved',
-         reserved_by = p_courier,
-         reserved_until = now() + make_interval(secs => p_hold_seconds),
-         updated_at = now()
-   WHERE id = p_order_id
-     AND status = 'open'
-     AND (reserved_until IS NULL OR reserved_until < now());
-
-  GET DIAGNOSTICS v_rowcount = ROW_COUNT;
-  RETURN v_rowcount = 1;
-END$$;
-
--- Confirm start and assign courier to an order
-CREATE OR REPLACE FUNCTION fn_confirm_start(
-  p_order_id INT,
-  p_courier UUID
-)
-RETURNS BOOLEAN
-LANGUAGE plpgsql AS $$
-DECLARE v_rowcount INT;
-BEGIN
-  UPDATE orders
-     SET status='assigned',
-         courier_id = p_courier,
-         updated_at = now()
-   WHERE id = p_order_id
-     AND status = 'reserved'
-     AND reserved_by = p_courier
-     AND reserved_until > now();
-
-  GET DIAGNOSTICS v_rowcount = ROW_COUNT;
-  RETURN v_rowcount = 1;
-END$$;
-
--- Reopen orders whose reservations have expired
-CREATE OR REPLACE FUNCTION fn_reopen_expired_reservations()
-RETURNS INTEGER
-LANGUAGE plpgsql AS $$
-DECLARE v_cnt INT;
-BEGIN
-  UPDATE orders
-     SET status='open',
-         reserved_by = NULL,
-         reserved_until = NULL,
-         updated_at = now()
-   WHERE status='reserved' AND reserved_until < now();
-
-  GET DIAGNOSTICS v_cnt = ROW_COUNT;
-  RETURN v_cnt;
-END$$;
 
 -- Validate and advance order status
 CREATE OR REPLACE FUNCTION fn_advance_status(

--- a/db/migrations/002-add-reservation-fields.sql
+++ b/db/migrations/002-add-reservation-fields.sql
@@ -1,0 +1,68 @@
+-- Add reservation fields to orders
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS reserved_by UUID,
+  ADD COLUMN IF NOT EXISTS reserved_until TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_orders_reserved_until ON orders(reserved_until);
+
+-- Attempt to reserve an open order for a courier
+CREATE OR REPLACE FUNCTION fn_try_reserve_order(
+  p_order_id INT,
+  p_courier UUID,
+  p_hold_seconds INT DEFAULT 90
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql AS $$
+DECLARE v_rowcount INT;
+BEGIN
+  UPDATE orders
+     SET status='reserved',
+         reserved_by = p_courier,
+         reserved_until = now() + make_interval(secs => p_hold_seconds),
+         updated_at = now()
+   WHERE id = p_order_id
+     AND status = 'open'
+     AND (reserved_until IS NULL OR reserved_until < now());
+
+  GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+  RETURN v_rowcount = 1;
+END$$;
+
+-- Confirm start and assign courier to an order
+CREATE OR REPLACE FUNCTION fn_confirm_start(
+  p_order_id INT,
+  p_courier UUID
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql AS $$
+DECLARE v_rowcount INT;
+BEGIN
+  UPDATE orders
+     SET status='assigned',
+         courier_id = p_courier,
+         updated_at = now()
+   WHERE id = p_order_id
+     AND status = 'reserved'
+     AND reserved_by = p_courier
+     AND reserved_until > now();
+
+  GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+  RETURN v_rowcount = 1;
+END$$;
+
+-- Reopen orders whose reservations have expired
+CREATE OR REPLACE FUNCTION fn_reopen_expired_reservations()
+RETURNS INTEGER
+LANGUAGE plpgsql AS $$
+DECLARE v_cnt INT;
+BEGIN
+  UPDATE orders
+     SET status='open',
+         reserved_by = NULL,
+         reserved_until = NULL,
+         updated_at = now()
+   WHERE status='reserved' AND reserved_until < now();
+
+  GET DIAGNOSTICS v_cnt = ROW_COUNT;
+  RETURN v_cnt;
+END$$;


### PR DESCRIPTION
## Summary
- add basic migration runner that tracks applied SQL files
- split schema.sql into versioned migrations with reservation fields added separately

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c823badcf0832dbdfd09e7385badd6