### PR TITLE
Add SEC-definer set_updated_at and triggers

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_users_updated ON users;
+CREATE TRIGGER trg_users_updated
+BEFORE UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_courier_profiles_updated ON courier_profiles;
+CREATE TRIGGER trg_courier_profiles_updated
+BEFORE UPDATE ON courier_profiles
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_courier_verifications_updated ON courier_verifications;
+CREATE TRIGGER trg_courier_verifications_updated
+BEFORE UPDATE ON courier_verifications
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_app_settings_updated ON app_settings;
+CREATE TRIGGER trg_app_settings_updated
+BEFORE UPDATE ON app_settings
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_orders_updated ON orders;
+CREATE TRIGGER trg_orders_updated
+BEFORE UPDATE ON orders
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_disputes_updated ON disputes;
+CREATE TRIGGER trg_disputes_updated
+BEFORE UPDATE ON disputes
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_support_tickets_updated ON support_tickets;
+CREATE TRIGGER trg_support_tickets_updated
+BEFORE UPDATE ON support_tickets
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_channel_bindings_updated ON channel_bindings;
+CREATE TRIGGER trg_channel_bindings_updated
+BEFORE UPDATE ON channel_bindings
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary
- redefine set_updated_at with SECURITY DEFINER and pg_catalog search_path
- recreate updated_at triggers for core tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c828b8e040832d944a475bce220d6e