### PR TITLE
Document environment variable requirements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,32 @@
+# Required tokens and chat bindings
 TELEGRAM_BOT_TOKEN=123456:ABCDEF
-COURIERS_CHANNEL_ID=
-MODERATORS_CHANNEL_ID=
+ADMIN_ID=123456789
+COURIERS_CHANNEL_ID=-1001234567890
+MODERATORS_CHANNEL_ID=-1000987654321
+
+# Optional channel used for courier verification requests
+VERIFY_CHANNEL_ID=
+
+# Optional payment provider token (enable Telegram Payments when set)
+PROVIDER_TOKEN=
+
+# Optional encryption secret (defaults to default_secret_key_32_bytes_long!)
+COURIER_SECRET=
+
+# Bot configuration defaults
 CITY=almaty
+
+# Optional pricing overrides (defaults shown)
+BASE_PRICE=500
+PER_KM=180
+SURCHARGE_S=0
+SURCHARGE_M=0
+SURCHARGE_L=0
+SURCHARGE_THERMOBOX=0
+SURCHARGE_CHANGE=0
+MIN_PRICE=0
+WAIT_FREE=0
+WAIT_PER_MIN=0
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres

--- a/README.md
+++ b/README.md
@@ -12,10 +12,27 @@ npm run migrate
 
 Core bot environment variables are defined in `.env.example`:
 
-- `TELEGRAM_BOT_TOKEN`
-- `COURIERS_CHANNEL_ID`
-- `MODERATORS_CHANNEL_ID`
-- `CITY`
+- `TELEGRAM_BOT_TOKEN` (required): Bot token issued by [@BotFather](https://t.me/BotFather).
+- `ADMIN_ID` (required): Numeric Telegram user ID allowed to execute admin commands.
+- `COURIERS_CHANNEL_ID` (required): Channel chat ID used for courier coordination.
+- `MODERATORS_CHANNEL_ID` (required): Channel chat ID for moderator alerts.
+- `CITY` (optional, default `almaty`): Default service city.
+- `VERIFY_CHANNEL_ID` (optional): Channel chat ID that receives courier verification requests.
+- `PROVIDER_TOKEN` (optional): Telegram payments provider token; leave unset to disable payments.
+- `COURIER_SECRET` (optional, default `default_secret_key_32_bytes_long!`): Secret used to encrypt stored courier card data.
+
+Optional pricing overrides can also be provided through environment variables. Each falls back to the default shown in `.env.example` when not set:
+
+- `BASE_PRICE`
+- `PER_KM`
+- `SURCHARGE_S`
+- `SURCHARGE_M`
+- `SURCHARGE_L`
+- `SURCHARGE_THERMOBOX`
+- `SURCHARGE_CHANGE`
+- `MIN_PRICE`
+- `WAIT_FREE`
+- `WAIT_PER_MIN`
 
 Environment variables for the database are also defined in `.env.example`:
 


### PR DESCRIPTION
## Summary
- add admin, verification, provider, and security environment variables to `.env.example`
- document the required and defaulted environment variables in the README, including optional pricing overrides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c843f8b234832d9dc6421d252471ab