### PR TITLE
Improve rate limiter expiration handling

### DIFF
--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -1,9 +1,22 @@
 const hits = new Map<string, { count: number; reset: number }>();
+const CLEANUP_INTERVAL_MS = 60_000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of hits.entries()) {
+    if (entry.reset < now) {
+      hits.delete(key);
+    }
+  }
+}, CLEANUP_INTERVAL_MS).unref?.();
 
 export function rateLimit(key: string, limit: number, intervalMs: number): boolean {
   const now = Date.now();
   const entry = hits.get(key);
   if (!entry || entry.reset < now) {
+    if (entry && entry.reset < now) {
+      hits.delete(key);
+    }
     hits.set(key, { count: 1, reset: now + intervalMs });
     return true;
   }


### PR DESCRIPTION
## Summary
- clear expired rate limiter entries before creating a fresh counter
- periodically clean up expired rate limiter entries to prevent stale state

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c852a01f3c832d91e31549b44907a0