### PR TITLE
Improve bot launch retries and timer cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,28 +58,57 @@ async function resetTelegramSession() {
   }
 }
 
+const MAX_LAUNCH_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1_000;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 async function launchBot() {
-  try {
-    await bot.launch();
-    console.log('Bot started');
-  } catch (err) {
-    if (err instanceof TelegramError && err.response?.error_code === 409) {
-      console.error('Bot launch failed: another instance is already running.', err);
-      const reset = await resetTelegramSession();
-      if (reset) {
-        try {
-          await bot.launch();
-          console.log('Bot started after resetting Telegram session');
-          return;
-        } catch (retryError) {
-          console.error('Bot launch failed after resetting Telegram session', retryError);
+  for (let attempt = 1; attempt <= MAX_LAUNCH_ATTEMPTS; attempt++) {
+    try {
+      await bot.launch();
+      console.log('Bot started');
+      return;
+    } catch (err) {
+      if (err instanceof TelegramError) {
+        const errorCode = err.response?.error_code;
+        const onMethod =
+          typeof err.on === 'object' && err.on !== null ? (err.on as { method?: string }).method : undefined;
+
+        if (errorCode === 409) {
+          console.error('Bot launch failed: another instance is already running.', err);
+          const reset = await resetTelegramSession();
+          if (reset && attempt < MAX_LAUNCH_ATTEMPTS) {
+            console.warn(`Retrying bot launch after resetting session (attempt ${attempt + 1} of ${MAX_LAUNCH_ATTEMPTS})`);
+            await sleep(RETRY_DELAY_MS);
+            continue;
+          }
+          if (reset) {
+            console.error('Bot launch failed after resetting Telegram session', err);
+          } else {
+            console.error('Unable to reset Telegram session; aborting bot launch.');
+          }
+        } else if (errorCode === 500 && onMethod === 'deleteWebhook') {
+          console.error('Bot launch failed while deleting webhook via Telegram API.', err);
+          if (attempt < MAX_LAUNCH_ATTEMPTS) {
+            console.warn(
+              `Retrying bot launch after Telegram deleteWebhook error (attempt ${attempt + 1} of ${MAX_LAUNCH_ATTEMPTS})`,
+            );
+            await sleep(RETRY_DELAY_MS);
+            continue;
+          }
+          console.error('Exceeded retry attempts after Telegram deleteWebhook errors.');
+        } else {
+          console.error('Bot launch failed', err);
         }
+      } else {
+        console.error('Bot launch failed', err);
       }
-    } else {
-      console.error('Bot launch failed', err);
+      break;
     }
-    process.exit(1);
   }
+  console.error('Unable to start bot after maximum retries. Exiting.');
+  process.exit(1);
 }
 
 launchBot();

--- a/src/services/couriers.ts
+++ b/src/services/couriers.ts
@@ -172,5 +172,5 @@ export function scheduleCardMessageDeletion(
 ) {
   setTimeout(() => {
     telegram.deleteMessage(chatId, messageId).catch(() => {});
-  }, 2 * 60 * 60 * 1000);
+  }, 2 * 60 * 60 * 1000).unref?.();
 }


### PR DESCRIPTION
## Summary
- add retry/backoff logic around `bot.launch()` to recover from 409 conflicts and 500 deleteWebhook errors
- ensure the delayed courier card deletion timer does not keep the process alive by unrefing the timeout

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c857d907cc832da9df50c7d32f0cf3