### PR TITLE
Avoid logging out Telegram session during reset

### DIFF
--- a/src/utils/telegramSession.ts
+++ b/src/utils/telegramSession.ts
@@ -1,0 +1,34 @@
+import type { Telegram } from 'telegraf';
+
+export type TelegramSessionApi = Pick<Telegram, 'deleteWebhook' | 'close'>;
+
+export type Logger = Pick<Console, 'warn' | 'error'>;
+
+export async function resetTelegramSession(
+  telegram: TelegramSessionApi,
+  logger: Logger = console,
+): Promise<boolean> {
+  let resetPerformed = false;
+
+  try {
+    await telegram.deleteWebhook({ drop_pending_updates: true });
+    logger.warn('Deleted previous Telegram webhook via Telegram API.');
+    resetPerformed = true;
+  } catch (deleteError) {
+    logger.warn('Failed to delete previous Telegram webhook via Telegram API.', deleteError);
+  }
+
+  try {
+    await telegram.close();
+    logger.warn('Closed previous Telegram session via Telegram API.');
+    resetPerformed = true;
+  } catch (closeError) {
+    logger.warn('Failed to close previous Telegram session with close()', closeError);
+  }
+
+  if (!resetPerformed) {
+    logger.error('Unable to reset Telegram session; all reset attempts failed.');
+  }
+
+  return resetPerformed;
+}

--- a/tests/telegramSession.test.ts
+++ b/tests/telegramSession.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resetTelegramSession, type Logger, type TelegramSessionApi } from '../src/utils/telegramSession';
+
+test('resetTelegramSession performs webhook delete and close steps', async () => {
+  const calls: string[] = [];
+  const telegram: TelegramSessionApi = {
+    deleteWebhook: async () => {
+      calls.push('deleteWebhook');
+      return true;
+    },
+    close: async () => {
+      calls.push('close');
+      return true;
+    },
+  };
+  const logs: { level: 'warn' | 'error'; args: unknown[] }[] = [];
+  const logger: Logger = {
+    warn: (...args: unknown[]) => {
+      logs.push({ level: 'warn', args });
+    },
+    error: (...args: unknown[]) => {
+      logs.push({ level: 'error', args });
+    },
+  };
+
+  const result = await resetTelegramSession(telegram, logger);
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, ['deleteWebhook', 'close']);
+  const warnMessages = logs.filter((log) => log.level === 'warn').map((log) => String(log.args[0]));
+  assert(warnMessages.includes('Deleted previous Telegram webhook via Telegram API.'));
+  assert(warnMessages.includes('Closed previous Telegram session via Telegram API.'));
+  assert.equal(logs.filter((log) => log.level === 'error').length, 0);
+});
+
+test('resetTelegramSession resolves when close succeeds after delete failure', async () => {
+  const calls: string[] = [];
+  const telegram: TelegramSessionApi = {
+    deleteWebhook: async () => {
+      calls.push('deleteWebhook');
+      throw new Error('delete failed');
+    },
+    close: async () => {
+      calls.push('close');
+      return true;
+    },
+  };
+  const logs: { level: 'warn' | 'error'; args: unknown[] }[] = [];
+  const logger: Logger = {
+    warn: (...args: unknown[]) => {
+      logs.push({ level: 'warn', args });
+    },
+    error: (...args: unknown[]) => {
+      logs.push({ level: 'error', args });
+    },
+  };
+
+  const result = await resetTelegramSession(telegram, logger);
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, ['deleteWebhook', 'close']);
+  const warnMessages = logs.filter((log) => log.level === 'warn').map((log) => String(log.args[0]));
+  assert(warnMessages.includes('Failed to delete previous Telegram webhook via Telegram API.'));
+  assert(warnMessages.includes('Closed previous Telegram session via Telegram API.'));
+  assert.equal(logs.filter((log) => log.level === 'error').length, 0);
+});
+
+test('resetTelegramSession reports failure when no step succeeds', async () => {
+  const telegram: TelegramSessionApi = {
+    deleteWebhook: async () => {
+      throw new Error('delete failed');
+    },
+    close: async () => {
+      throw new Error('close failed');
+    },
+  };
+  const logs: { level: 'warn' | 'error'; args: unknown[] }[] = [];
+  const logger: Logger = {
+    warn: (...args: unknown[]) => {
+      logs.push({ level: 'warn', args });
+    },
+    error: (...args: unknown[]) => {
+      logs.push({ level: 'error', args });
+    },
+  };
+
+  const result = await resetTelegramSession(telegram, logger);
+
+  assert.equal(result, false);
+  const warnMessages = logs.filter((log) => log.level === 'warn').map((log) => String(log.args[0]));
+  assert(warnMessages.includes('Failed to delete previous Telegram webhook via Telegram API.'));
+  assert(warnMessages.includes('Failed to close previous Telegram session with close()'));
+  const errorMessages = logs.filter((log) => log.level === 'error').map((log) => String(log.args[0]));
+  assert(errorMessages.includes('Unable to reset Telegram session; all reset attempts failed.'));
+});


### PR DESCRIPTION
## Summary
- stop calling the Telegram `logOut` API in the reset helper so relaunches keep working against the cloud Bot API
- keep deleting the webhook and closing the prior long-polling session, and adjust unit tests to reflect the new sequence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c85ba2acc0832d95be3675e1e2c97a