### PR TITLE
Handle invalid Telegram token errors during launch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,11 @@ async function launchBot() {
             continue;
           }
           console.error('Exceeded retry attempts after Telegram deleteWebhook errors.');
+        } else if (errorCode === 400 || err.description?.includes('Logged out')) {
+          console.error(
+            'Invalid or revoked TELEGRAM_BOT_TOKEN. Request a new token from @BotFather and set it in your environment.',
+          );
+          process.exit(1);
         } else {
           console.error('Bot launch failed', err);
         }


### PR DESCRIPTION
## Summary
- log a clear message when Telegram returns a 400 or logged out error
- exit immediately without retrying when the bot token is invalid

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c861aa5fec832d83b8962d2826ef40