### PR TITLE
Refactor services to use async filesystem APIs

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -18,7 +18,7 @@ export default function chatCommands(bot: Telegraf) {
       return ctx.reply('Неверный номер заказа');
     }
     const text = args.slice(1).join(' ');
-    const order = getOrder(orderId);
+    const order = await getOrder(orderId);
     if (!order) {
       return ctx.reply('Заказ не найден');
     }

--- a/src/commands/orderStatus.ts
+++ b/src/commands/orderStatus.ts
@@ -17,7 +17,7 @@ export default function orderStatusCommands(bot: Telegraf) {
     const statusMap = { new: 'open', assigned: 'assigned', delivered: 'delivered' } as const;
     const status = statusMap[statusArg as keyof typeof statusMap];
     const courierId = statusArg === 'assigned' ? ctx.from!.id : undefined;
-    const order = updateOrderStatus(id, status, courierId);
+    const order = await updateOrderStatus(id, status, courierId);
     if (!order) return ctx.reply('Order not found');
     await ctx.reply('Статус обновлён');
     await ctx.telegram.sendMessage(order.customer_id, `Статус заказа #${order.id}: ${order.status}`);

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -170,7 +170,7 @@ export default function profileCommands(bot: Telegraf) {
           ['Поддержка'],
         ]).resize()
       );
-      const settings = getSettings();
+      const settings = await getSettings();
       if (settings.couriers_channel_id) {
         try {
           const link = await ctx.telegram.exportChatInviteLink(settings.couriers_channel_id);
@@ -194,7 +194,7 @@ export default function profileCommands(bot: Telegraf) {
 async function finalize(ctx: Context, uid: number, data: Required<CourierProfile>) {
   const profile: CourierProfile = { ...data, id: uid, status: 'pending' };
   upsertCourier(profile);
-  const settings = getSettings();
+  const settings = await getSettings();
   if (settings.verify_channel_id) {
     const metrics = getCourierMetrics(uid);
     const metricsText = metrics

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -27,7 +27,7 @@ async function sendStepSupport(
 
 async function startSupportWizard(ctx: Context) {
   const uid = ctx.from!.id;
-  const orders = getOrdersByClient(uid);
+  const orders = await getOrdersByClient(uid);
   if (orders.length === 0) {
     await ctx.reply('У вас нет заказов.');
     return;
@@ -96,7 +96,7 @@ export default function supportCommands(bot: Telegraf) {
           await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
         states.delete(uid);
         await ctx.reply(`Тикет #${ticket.id} создан`, Markup.removeKeyboard());
-        const settings = getSettings();
+        const settings = await getSettings();
         if (settings.moderators_channel_id) {
           await ctx.telegram.sendMessage(
             settings.moderators_channel_id,
@@ -129,7 +129,7 @@ export default function supportCommands(bot: Telegraf) {
       await ctx.telegram.deleteMessage(ctx.chat!.id, state.msgId).catch(() => {});
     states.delete(uid);
     await ctx.reply(`Тикет #${ticket.id} создан`, Markup.removeKeyboard());
-    const settings = getSettings();
+    const settings = await getSettings();
     if (settings.moderators_channel_id) {
       await ctx.telegram.sendPhoto(
         settings.moderators_channel_id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ import chatCommands from './commands/chat';
 import orderStatusCommands from './commands/orderStatus';
 import profileCommands from './commands/profile';
 import adminCommands from './commands/admin';
-import { setOrdersBot, expireReservations, expireMovementTimers, expireAwaitingConfirm } from './services/orders';
+import {
+  setOrdersBot,
+  expireReservations,
+  expireMovementTimers,
+  expireAwaitingConfirm,
+} from './services/orders';
 import { rollupDailyMetrics } from './services/metrics';
 import { resetTelegramSession } from './utils/telegramSession';
 
@@ -32,12 +37,20 @@ orderStatusCommands(bot);
 profileCommands(bot);
 adminCommands(bot);
 
-setInterval(expireReservations, 30_000);
-setInterval(expireMovementTimers, 30_000);
-setInterval(expireAwaitingConfirm, 30_000);
+setInterval(() => {
+  expireReservations().catch(err => console.error('Failed to expire reservations', err));
+}, 30_000);
+setInterval(() => {
+  expireMovementTimers().catch(err => console.error('Failed to expire movement timers', err));
+}, 30_000);
+setInterval(() => {
+  expireAwaitingConfirm().catch(err => console.error('Failed to expire awaiting confirmations', err));
+}, 30_000);
 
-rollupDailyMetrics();
-setInterval(rollupDailyMetrics, 24 * 60 * 60 * 1000);
+rollupDailyMetrics().catch(err => console.error('Failed to roll up daily metrics', err));
+setInterval(() => {
+  rollupDailyMetrics().catch(err => console.error('Failed to roll up daily metrics', err));
+}, 24 * 60 * 60 * 1000);
 
 bot.command('ping', (ctx) => ctx.reply('pong'));
 

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -12,8 +12,9 @@ export function etaMinutes(distanceKmVal: number): number {
   const speedKmH = 28;
   return Math.max(5, Math.round((distanceKmVal / speedKmH) * 60));
 }
-export function isInAlmaty(p: Point): boolean {
-  const poly = getSettings().city_polygon;
+export async function isInAlmaty(p: Point): Promise<boolean> {
+  const settings = await getSettings();
+  const poly = settings.city_polygon;
   return poly ? pointInPolygon(p, poly) : true;
 }
 

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -1,14 +1,14 @@
 import { getSettings } from '../services/settings';
 
-export function calcPrice(
+export async function calcPrice(
   distanceKm: number,
   size: 'S' | 'M' | 'L' = 'M',
   now = new Date(),
   type: 'docs' | 'parcel' | 'food' | 'other' = 'other',
   options: string[] = [],
   waitMinutes = 0
-): { price: number; nightApplied: boolean } {
-  const settings = getSettings();
+): Promise<{ price: number; nightApplied: boolean }> {
+  const settings = await getSettings();
   const base = settings.base_price ?? 500;
   let perKm = settings.per_km ?? 180;
   const waitFree = settings.wait_free ?? 0;

--- a/tests/courier.test.ts
+++ b/tests/courier.test.ts
@@ -27,7 +27,7 @@ function teardown(dir: string, prev: string) {
 test('reservation holds order for 90 seconds', async () => {
   const { dir, prev, bot, messages } = setup();
   try {
-    const order = createOrder({
+    const order = await createOrder({
       customer_id: 100,
       from: { lat: 43.2, lon: 76.9 },
       to: { lat: 43.25, lon: 76.95 },
@@ -54,7 +54,8 @@ test('reservation holds order for 90 seconds', async () => {
         data: `reserve:${order.id}`,
       } as any,
     });
-    const updated = getOrder(order.id)!;
+    const updated = await getOrder(order.id);
+    if (!updated) throw new Error('Order not found');
     const diff = new Date(updated.reserved_until!).getTime() - before;
     assert.equal(updated.status, 'reserved');
     assert.equal(updated.reserved_by, 200);
@@ -70,7 +71,7 @@ test('reservation holds order for 90 seconds', async () => {
 test('details include order options', async () => {
   const { dir, prev, bot, messages } = setup();
   try {
-    const order = createOrder({
+    const order = await createOrder({
       customer_id: 100,
       from: { lat: 43.2, lon: 76.9 },
       to: { lat: 43.25, lon: 76.95 },
@@ -106,7 +107,7 @@ test('details include order options', async () => {
 test('chat ttl set after delivery', async () => {
   const { dir, prev, bot } = setup();
   try {
-    const order = createOrder({
+    const order = await createOrder({
       customer_id: 100,
       from: { lat: 43.2, lon: 76.9 },
       to: { lat: 43.25, lon: 76.95 },

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -18,12 +18,12 @@ function teardown(dir: string, prev: string) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-test('option surcharges are added to price', () => {
+test('option surcharges are added to price', async () => {
   const { dir, prev } = setup();
   try {
-    updateSetting('surcharge_thermobox', 100);
-    updateSetting('surcharge_change', 50);
-    const { price, nightApplied } = calcPrice(
+    await updateSetting('surcharge_thermobox', 100);
+    await updateSetting('surcharge_change', 50);
+    const { price, nightApplied } = await calcPrice(
       1,
       'M',
       new Date('2024-01-01T12:00:00Z'),
@@ -37,11 +37,11 @@ test('option surcharges are added to price', () => {
   }
 });
 
-test('night coefficient is applied when active', () => {
+test('night coefficient is applied when active', async () => {
   const { dir, prev } = setup();
   try {
-    updateSetting('night_active', true);
-    const { price, nightApplied } = calcPrice(
+    await updateSetting('night_active', true);
+    const { price, nightApplied } = await calcPrice(
       1,
       'M',
       new Date('2024-01-01T23:00:00Z'),
@@ -55,12 +55,12 @@ test('night coefficient is applied when active', () => {
   }
 });
 
-test('waiting over free limit adds to price', () => {
+test('waiting over free limit adds to price', async () => {
   const { dir, prev } = setup();
   try {
-    updateSetting('wait_free', 5);
-    updateSetting('wait_per_min', 20);
-    const { price, nightApplied } = calcPrice(
+    await updateSetting('wait_free', 5);
+    await updateSetting('wait_per_min', 20);
+    const { price, nightApplied } = await calcPrice(
       1,
       'M',
       new Date('2024-01-01T12:00:00Z'),

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -56,7 +56,7 @@ test('create ticket with photo', () => {
 test('support wizard lists client orders', async () => {
   const { dir, prev } = setup();
   try {
-    const order1 = createOrder({
+    const order1 = await createOrder({
       customer_id: 1,
       from: { lat: 0, lon: 0 },
       to: { lat: 1, lon: 1 },
@@ -68,7 +68,7 @@ test('support wizard lists client orders', async () => {
       comment: null,
       price: 10,
     });
-    const order2 = createOrder({
+    const order2 = await createOrder({
       customer_id: 1,
       from: { lat: 0, lon: 0 },
       to: { lat: 1, lon: 1 },
@@ -80,7 +80,7 @@ test('support wizard lists client orders', async () => {
       comment: null,
       price: 10,
     });
-    createOrder({
+    await createOrder({
       customer_id: 2,
       from: { lat: 0, lon: 0 },
       to: { lat: 1, lon: 1 },


### PR DESCRIPTION
## Summary
- replace synchronous filesystem usage in order, settings, and metrics services with fs.promises helpers and error handling
- update bot command handlers and interval tasks to await the new asynchronous service APIs
- adjust unit tests to await the updated services and cover the async behaviors

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86dc0b3bc832d9c012e257df5daaa