### PR TITLE
Create environment configuration and logger modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dotenv": "^16.4.0",
         "pg": "^8.16.3",
+        "pino": "^9.9.5",
         "telegraf": "^4.15.0"
       },
       "devDependencies": {
@@ -161,6 +162,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -238,6 +248,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -278,6 +297,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/p-timeout": {
@@ -378,6 +406,43 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/pino": {
+      "version": "9.9.5",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
+      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -417,6 +482,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/safe-compare": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
@@ -426,6 +522,15 @@
         "buffer-alloc": "^1.2.0"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sandwich-stream": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
@@ -433,6 +538,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/split2": {
@@ -464,6 +578,15 @@
       },
       "engines": {
         "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "dotenv": "^16.4.0",
     "pg": "^8.16.3",
+    "pino": "^9.9.5",
     "telegraf": "^4.15.0"
   },
   "devDependencies": {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,1 +1,10 @@
-export {};
+import { config, logger } from '../config';
+
+export function startBot(): void {
+  logger.info(
+    {
+      environment: config.nodeEnv,
+    },
+    'Bot entry point initialised',
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,81 @@
+import { config as loadEnv } from 'dotenv';
+import type { LevelWithSilent } from 'pino';
+
+loadEnv();
+
+const REQUIRED_ENV_VARS = ['BOT_TOKEN', 'DATABASE_URL'] as const;
+
+type RequiredEnvVar = (typeof REQUIRED_ENV_VARS)[number];
+
+const LOG_LEVELS: LevelWithSilent[] = [
+  'fatal',
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'trace',
+  'silent',
+];
+
+const missingVars = REQUIRED_ENV_VARS.filter((key) => {
+  const value = process.env[key];
+  return value === undefined || value.trim() === '';
+});
+
+if (missingVars.length > 0) {
+  throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
+}
+
+const parseBoolean = (value: string | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  switch (value.toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+      return true;
+    default:
+      return false;
+  }
+};
+
+const resolveLogLevel = (value: string | undefined): LevelWithSilent => {
+  if (!value) {
+    return 'info';
+  }
+
+  const normalised = value.toLowerCase() as LevelWithSilent;
+  if (!LOG_LEVELS.includes(normalised)) {
+    throw new Error(`Unsupported LOG_LEVEL provided: ${value}`);
+  }
+
+  return normalised;
+};
+
+export interface AppConfig {
+  nodeEnv: string;
+  logLevel: LevelWithSilent;
+  bot: {
+    token: string;
+  };
+  database: {
+    url: string;
+    ssl: boolean;
+  };
+}
+
+export const config: AppConfig = Object.freeze({
+  nodeEnv: process.env.NODE_ENV ?? 'development',
+  logLevel: resolveLogLevel(process.env.LOG_LEVEL),
+  bot: {
+    token: process.env.BOT_TOKEN as string,
+  },
+  database: {
+    url: process.env.DATABASE_URL as string,
+    ssl: parseBoolean(process.env.DATABASE_SSL),
+  },
+});
+
+export type { RequiredEnvVar };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,1 +1,4 @@
-export {};
+export { config } from './env';
+export type { AppConfig, RequiredEnvVar } from './env';
+export { logger } from './logger';
+export type { Logger } from './logger';

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,0 +1,19 @@
+import pino from 'pino';
+
+import { config } from './env';
+
+export type Logger = pino.Logger;
+
+export const logger: Logger = pino({
+  level: config.logLevel,
+  base: {
+    service: 'freedom-bot',
+    environment: config.nodeEnv,
+  },
+  formatters: {
+    level(label) {
+      return { level: label };
+    },
+  },
+  timestamp: pino.stdTimeFunctions.isoTime,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+import { startBot } from './bot';
+
+startBot();


### PR DESCRIPTION
## Summary
- add an environment configuration module that loads `.env` and validates required variables
- provide a JSON-configured `pino` logger powered by the shared configuration
- update the bot entry point to consume the new configuration and logger modules

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8f85d0bfc832d85a6b4ef3d229785