### PR TITLE
Add database client and migrations

### DIFF
--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type { PoolClient } from 'pg';
+
+import { pool, withTx } from '../src/db/client';
+
+const MIGRATIONS_DIR = path.resolve(__dirname, 'sql');
+const MIGRATIONS_TABLE = 'schema_migrations';
+
+const readMigrationFiles = async (): Promise<string[]> => {
+  const entries = await fs.readdir(MIGRATIONS_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort();
+};
+
+const ensureMigrationsTable = async (client: PoolClient) => {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      id bigserial PRIMARY KEY,
+      name text UNIQUE NOT NULL,
+      executed_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+};
+
+const loadAppliedMigrations = async (client: PoolClient): Promise<Set<string>> => {
+  const { rows } = await client.query<{ name: string }>(
+    `SELECT name FROM ${MIGRATIONS_TABLE} ORDER BY name ASC`,
+  );
+  return new Set(rows.map((row) => row.name));
+};
+
+const applyMigration = async (
+  client: PoolClient,
+  fileName: string,
+  sql: string,
+): Promise<void> => {
+  const trimmed = sql.trim();
+  if (!trimmed) {
+    console.log(`Skipping empty migration ${fileName}`);
+    return;
+  }
+
+  console.log(`Applying migration ${fileName}...`);
+  await client.query(trimmed);
+  await client.query(`INSERT INTO ${MIGRATIONS_TABLE} (name) VALUES ($1)`, [fileName]);
+};
+
+const runMigrations = async (): Promise<void> => {
+  const files = await readMigrationFiles();
+
+  await withTx(async (client) => {
+    await ensureMigrationsTable(client);
+    const applied = await loadAppliedMigrations(client);
+
+    for (const file of files) {
+      if (applied.has(file)) {
+        console.log(`Skipping already applied migration ${file}`);
+        continue;
+      }
+
+      const fullPath = path.join(MIGRATIONS_DIR, file);
+      const sql = await fs.readFile(fullPath, 'utf-8');
+      await applyMigration(client, file, sql);
+    }
+  });
+};
+
+const main = async () => {
+  try {
+    await runMigrations();
+    console.log('Migrations complete.');
+  } finally {
+    await pool.end();
+  }
+};
+
+main().catch((error) => {
+  console.error('Migration failed:', error);
+  process.exitCode = 1;
+});

--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -1,0 +1,232 @@
+-- Base schema for the Freedom Bot database.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS users (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    telegram_id bigint NOT NULL,
+    username text,
+    first_name text,
+    last_name text,
+    phone text,
+    role text NOT NULL DEFAULT 'customer',
+    status text NOT NULL DEFAULT 'active',
+    city text NOT NULL DEFAULT 'almaty',
+    language_code text DEFAULT 'ru',
+    is_blocked boolean NOT NULL DEFAULT false,
+    is_courier boolean NOT NULL DEFAULT false,
+    courier_rating numeric(4, 2) DEFAULT 0,
+    referral_code text UNIQUE,
+    referred_by uuid REFERENCES users(id),
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    last_active_at timestamptz,
+    UNIQUE (telegram_id)
+);
+
+CREATE TABLE IF NOT EXISTS verifications (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status text NOT NULL DEFAULT 'pending',
+    type text NOT NULL DEFAULT 'courier',
+    city text,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    rejection_reason text,
+    reviewed_by uuid REFERENCES users(id),
+    reviewed_at timestamptz,
+    verified_at timestamptz,
+    expires_at timestamptz,
+    channel_id bigint,
+    message_id bigint,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS verification_documents (
+    id bigserial PRIMARY KEY,
+    verification_id uuid NOT NULL REFERENCES verifications(id) ON DELETE CASCADE,
+    file_id text NOT NULL,
+    file_type text,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS verification_messages (
+    id bigserial PRIMARY KEY,
+    verification_id uuid NOT NULL REFERENCES verifications(id) ON DELETE CASCADE,
+    author_id uuid REFERENCES users(id),
+    author_role text NOT NULL,
+    message text NOT NULL,
+    attachments jsonb NOT NULL DEFAULT '[]'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    chat_id bigint NOT NULL,
+    plan text NOT NULL,
+    tier text,
+    status text NOT NULL DEFAULT 'active',
+    currency text NOT NULL DEFAULT 'KZT',
+    amount integer NOT NULL,
+    interval text NOT NULL DEFAULT 'month',
+    interval_count integer NOT NULL DEFAULT 1,
+    next_billing_at timestamptz,
+    grace_until timestamptz,
+    cancel_at_period_end boolean NOT NULL DEFAULT false,
+    cancelled_at timestamptz,
+    ended_at timestamptz,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, chat_id)
+);
+
+CREATE TABLE IF NOT EXISTS subscription_payments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id uuid NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    amount integer NOT NULL,
+    currency text NOT NULL DEFAULT 'KZT',
+    status text NOT NULL,
+    payment_provider text,
+    provider_payment_id text,
+    provider_customer_id text,
+    invoice_url text,
+    period_start timestamptz,
+    period_end timestamptz,
+    paid_at timestamptz,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (provider_payment_id)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+    courier_id uuid REFERENCES users(id) ON DELETE SET NULL,
+    subscription_id uuid REFERENCES subscriptions(id) ON DELETE SET NULL,
+    verification_id uuid REFERENCES verifications(id) ON DELETE SET NULL,
+    status text NOT NULL DEFAULT 'draft',
+    type text NOT NULL DEFAULT 'delivery',
+    city text NOT NULL,
+    channel_id bigint,
+    message_id bigint,
+    pickup_address text NOT NULL,
+    pickup_latitude numeric(9, 6),
+    pickup_longitude numeric(9, 6),
+    pickup_comment text,
+    pickup_floor text,
+    pickup_entrance text,
+    pickup_apartment text,
+    dropoff_address text NOT NULL,
+    dropoff_latitude numeric(9, 6),
+    dropoff_longitude numeric(9, 6),
+    dropoff_comment text,
+    dropoff_floor text,
+    dropoff_entrance text,
+    dropoff_apartment text,
+    recipient_name text,
+    recipient_phone text,
+    contactless boolean NOT NULL DEFAULT false,
+    need_change integer,
+    needs_thermobox boolean NOT NULL DEFAULT false,
+    weight_kg numeric(6, 2),
+    distance_meters integer,
+    duration_minutes integer,
+    cost_estimated integer,
+    cost_final integer,
+    courier_fee integer,
+    courier_payout integer,
+    currency text NOT NULL DEFAULT 'KZT',
+    pricing jsonb NOT NULL DEFAULT '{}'::jsonb,
+    items jsonb NOT NULL DEFAULT '[]'::jsonb,
+    comment text,
+    internal_comment text,
+    published_at timestamptz,
+    accepted_at timestamptz,
+    assigned_at timestamptz,
+    picked_up_at timestamptz,
+    delivered_at timestamptz,
+    cancelled_at timestamptz,
+    cancellation_reason text,
+    failure_reason text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS order_assignments (
+    id bigserial PRIMARY KEY,
+    order_id uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    courier_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    assigned_by uuid REFERENCES users(id),
+    status text NOT NULL DEFAULT 'pending',
+    comment text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    accepted_at timestamptz,
+    declined_at timestamptz,
+    decline_reason text
+);
+
+CREATE TABLE IF NOT EXISTS order_status_history (
+    id bigserial PRIMARY KEY,
+    order_id uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    status text NOT NULL,
+    previous_status text,
+    changed_by uuid REFERENCES users(id),
+    comment text,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS order_messages (
+    id bigserial PRIMARY KEY,
+    order_id uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    author_id uuid REFERENCES users(id),
+    author_role text NOT NULL,
+    recipient_id uuid REFERENCES users(id),
+    message text NOT NULL,
+    attachments jsonb NOT NULL DEFAULT '[]'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS order_broadcasts (
+    id bigserial PRIMARY KEY,
+    order_id uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    channel_id bigint NOT NULL,
+    message_id bigint,
+    delivered boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+    id bigserial PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_settings (
+    user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    notifications_enabled boolean NOT NULL DEFAULT true,
+    accepts_cash boolean NOT NULL DEFAULT true,
+    accepts_card boolean NOT NULL DEFAULT false,
+    preferred_language text,
+    preferred_city text,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+CREATE INDEX IF NOT EXISTS idx_users_telegram ON users(telegram_id);
+CREATE INDEX IF NOT EXISTS idx_verifications_user ON verifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_verifications_status ON verifications(status);
+CREATE INDEX IF NOT EXISTS idx_orders_user ON orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_orders_courier ON orders(courier_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);
+CREATE INDEX IF NOT EXISTS idx_orders_city_status ON orders(city, status);
+CREATE INDEX IF NOT EXISTS idx_order_assignments_order ON order_assignments(order_id);
+CREATE INDEX IF NOT EXISTS idx_order_status_history_order ON order_status_history(order_id);
+CREATE INDEX IF NOT EXISTS idx_order_messages_order ON order_messages(order_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user ON subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_subscription ON subscription_payments(subscription_id);

--- a/db/sql/001_patch.sql
+++ b/db/sql/001_patch.sql
@@ -1,0 +1,78 @@
+-- Follow-up adjustments and additional supporting tables.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email text,
+    ADD COLUMN IF NOT EXISTS timezone text,
+    ADD COLUMN IF NOT EXISTS marketing_opt_in boolean NOT NULL DEFAULT false;
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS customer_rating integer CHECK (customer_rating BETWEEN 1 AND 5),
+    ADD COLUMN IF NOT EXISTS courier_rating integer CHECK (courier_rating BETWEEN 1 AND 5),
+    ADD COLUMN IF NOT EXISTS rated_at timestamptz;
+
+CREATE TABLE IF NOT EXISTS order_feedback (
+    id bigserial PRIMARY KEY,
+    order_id uuid NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    author_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    rating integer CHECK (rating BETWEEN 1 AND 5),
+    comment text,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_order_feedback_unique ON order_feedback(order_id, author_id);
+
+CREATE TABLE IF NOT EXISTS subscription_events (
+    id bigserial PRIMARY KEY,
+    subscription_id uuid NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    event_type text NOT NULL,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_events_subscription ON subscription_events(subscription_id);
+
+ALTER TABLE subscription_payments
+    ADD COLUMN IF NOT EXISTS receipt_url text,
+    ADD COLUMN IF NOT EXISTS failure_reason text;
+
+ALTER TABLE verifications
+    ADD COLUMN IF NOT EXISTS notes text,
+    ADD COLUMN IF NOT EXISTS reviewer_comment text;
+
+DO $$
+BEGIN
+    ALTER TABLE verifications
+        ADD CONSTRAINT verifications_status_check CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled'));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+    ALTER TABLE orders
+        ADD CONSTRAINT orders_status_check CHECK (status IN (
+            'draft',
+            'pending',
+            'published',
+            'assigned',
+            'accepted',
+            'in_progress',
+            'picked_up',
+            'delivered',
+            'cancelled',
+            'failed'
+        ));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+    ALTER TABLE subscriptions
+        ADD CONSTRAINT subscriptions_status_check CHECK (status IN ('active', 'trialing', 'past_due', 'canceled', 'expired', 'paused'));
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END
+$$;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,81 @@
+import { Pool, PoolClient, PoolConfig } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const parseBoolean = (value?: string): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 't', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'f', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+};
+
+const defaultPort = Number.parseInt(process.env.DB_PORT ?? '5432', 10);
+
+const baseConfig: PoolConfig = {
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number.isNaN(defaultPort) ? 5432 : defaultPort,
+  user: process.env.DB_USER ?? 'postgres',
+  password: process.env.DB_PASS ?? 'postgres',
+  database: process.env.DB_NAME ?? 'freedom_bot',
+};
+
+const sslEnabled = parseBoolean(process.env.DB_SSL);
+if (sslEnabled === true) {
+  const rejectUnauthorized =
+    parseBoolean(process.env.DB_SSL_REJECT_UNAUTHORIZED) ?? false;
+
+  baseConfig.ssl = { rejectUnauthorized };
+} else if (sslEnabled === false) {
+  baseConfig.ssl = false;
+}
+
+export const pool = new Pool(baseConfig);
+
+export type TransactionCallback<T> = (client: PoolClient) => Promise<T>;
+export interface TransactionOptions {
+  isolationLevel?: 'read committed' | 'repeatable read' | 'serializable';
+}
+
+export const withTx = async <T>(
+  callback: TransactionCallback<T>,
+  options: TransactionOptions = {},
+): Promise<T> => {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+    if (options.isolationLevel) {
+      await client.query(
+        `SET TRANSACTION ISOLATION LEVEL ${options.isolationLevel.toUpperCase()}`,
+      );
+    }
+
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to rollback transaction', rollbackError);
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export default pool;
+export type { PoolClient } from 'pg';

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './client';


### PR DESCRIPTION
## Summary
- add a shared PostgreSQL pool with a typed transaction helper
- define the base schema and follow-up patch migrations
- add a TypeScript migration runner wired to `npm run migrate`

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8fa3733f4832dbf7700925bdfcb44