### PR TITLE
feat: set up telegraf bot scaffolding

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,38 @@
+import { Telegraf } from 'telegraf';
+
+import { auth } from './bot/middlewares/auth';
+import { autoDelete } from './bot/middlewares/auto-delete';
+import { errorBoundary } from './bot/middlewares/error-boundary';
+import { session } from './bot/middlewares/session';
+import type { BotContext } from './bot/types';
+import { config, logger } from './config';
+
+export const app = new Telegraf<BotContext>(config.bot.token);
+
+app.catch((error, ctx) => {
+  logger.error({ err: error, update: ctx.update }, 'Unhandled error in Telegraf');
+});
+
+app.use(errorBoundary());
+app.use(session());
+app.use(autoDelete());
+app.use(auth());
+
+let gracefulShutdownConfigured = false;
+
+export const setupGracefulShutdown = (bot: Telegraf<BotContext>): void => {
+  if (gracefulShutdownConfigured) {
+    return;
+  }
+  gracefulShutdownConfigured = true;
+
+  const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+  for (const signal of signals) {
+    process.once(signal, () => {
+      logger.info({ signal }, 'Received shutdown signal, stopping bot');
+      void bot.stop(`Received ${signal}`);
+    });
+  }
+};
+
+setupGracefulShutdown(app);

--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -1,0 +1,21 @@
+import type { MiddlewareFn } from 'telegraf';
+
+import { logger } from '../../config';
+import type { BotContext } from '../types';
+
+export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
+  if (!ctx.from) {
+    logger.warn({ update: ctx.update }, 'Received update without sender information');
+    return;
+  }
+
+  ctx.session.user = {
+    id: ctx.from.id,
+    username: ctx.from.username ?? undefined,
+    firstName: ctx.from.first_name ?? undefined,
+    lastName: ctx.from.last_name ?? undefined,
+  };
+  ctx.session.isAuthenticated = true;
+
+  await next();
+};

--- a/src/bot/middlewares/auto-delete.ts
+++ b/src/bot/middlewares/auto-delete.ts
@@ -1,0 +1,25 @@
+import type { MiddlewareFn } from 'telegraf';
+
+import { logger } from '../../config';
+import type { BotContext } from '../types';
+
+export const autoDelete = (): MiddlewareFn<BotContext> => async (ctx, next) => {
+  if (ctx.chat?.id && ctx.session.ephemeralMessages.length > 0) {
+    const chatId = ctx.chat.id;
+    const messages = [...ctx.session.ephemeralMessages];
+    ctx.session.ephemeralMessages = [];
+
+    for (const messageId of messages) {
+      try {
+        await ctx.telegram.deleteMessage(chatId, messageId);
+      } catch (error) {
+        logger.warn(
+          { err: error, chatId, messageId },
+          'Failed to auto-delete message',
+        );
+      }
+    }
+  }
+
+  await next();
+};

--- a/src/bot/middlewares/error-boundary.ts
+++ b/src/bot/middlewares/error-boundary.ts
@@ -1,0 +1,26 @@
+import type { MiddlewareFn } from 'telegraf';
+
+import { logger } from '../../config';
+import type { BotContext } from '../types';
+
+export const errorBoundary = (): MiddlewareFn<BotContext> =>
+  async (ctx, next) => {
+    try {
+      await next();
+    } catch (error) {
+      logger.error(
+        { err: error, update: ctx.update },
+        'Unhandled error while processing update',
+      );
+
+      if (!ctx.chat) {
+        return;
+      }
+
+      try {
+        await ctx.reply('Произошла непредвиденная ошибка. Попробуйте позже.');
+      } catch (replyError) {
+        logger.error({ err: replyError }, 'Failed to notify user about error');
+      }
+    }
+  };

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -1,0 +1,50 @@
+import type { MiddlewareFn } from 'telegraf';
+
+import type { BotContext, SessionState } from '../types';
+
+const createDefaultState = (): SessionState => ({
+  ephemeralMessages: [],
+  isAuthenticated: false,
+});
+
+const resolveSessionKey = (ctx: BotContext): string | undefined => {
+  if (ctx.chat?.id !== undefined) {
+    return `chat:${ctx.chat.id}`;
+  }
+
+  if (ctx.from?.id !== undefined) {
+    return `user:${ctx.from.id}`;
+  }
+
+  return undefined;
+};
+
+const store = new Map<string, SessionState>();
+
+export const clearSession = (ctx: BotContext): void => {
+  const key = resolveSessionKey(ctx);
+  if (key) {
+    store.delete(key);
+  }
+};
+
+export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
+  const key = resolveSessionKey(ctx);
+  if (!key) {
+    await next();
+    return;
+  }
+
+  const existing = store.get(key);
+  const state = existing ?? createDefaultState();
+
+  ctx.session = state;
+
+  try {
+    await next();
+  } finally {
+    store.set(key, ctx.session);
+  }
+};
+
+export type { SessionState };

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -1,0 +1,18 @@
+import type { Context } from 'telegraf';
+
+export interface SessionUser {
+  id: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+export interface SessionState {
+  ephemeralMessages: number[];
+  isAuthenticated: boolean;
+  user?: SessionUser;
+}
+
+export type BotContext = Context & {
+  session: SessionState;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,16 @@
-import { startBot } from './bot';
+import { app, setupGracefulShutdown } from './app';
+import { logger } from './config';
 
-startBot();
+const start = async (): Promise<void> => {
+  try {
+    await app.launch();
+    logger.info('Bot started using long polling');
+  } catch (error) {
+    logger.fatal({ err: error }, 'Failed to launch bot');
+    process.exitCode = 1;
+  }
+};
+
+setupGracefulShutdown(app);
+
+void start();


### PR DESCRIPTION
## Summary
- create the Telegraf application, load configuration, and wire core middlewares
- add foundational middlewares for error handling, sessions, auto-deletion, and auth context setup
- start the bot from the entrypoint with long polling and graceful shutdown handling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8ff63c840832d9d8934282395bf15