### PR TITLE
feat: add shared bot services and utilities

### DIFF
--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -1,69 +1,31 @@
-import { Markup, Telegraf } from 'telegraf';
+import { Telegraf } from 'telegraf';
 
 import { publishOrderToDriversChannel, type PublishOrderStatus } from '../../../channels/ordersChannel';
 import { logger } from '../../../config';
 import { createOrder } from '../../../db/orders';
-import { geocodeAddress, type GeocodingResult } from '../../../services/geocoding';
-import { estimateDeliveryPrice } from '../../../services/pricing';
+import type { OrderRecord } from '../../../types';
+import {
+  buildCustomerName,
+  buildOrderSummary,
+  isOrderDraftComplete,
+  resetClientOrderDraft,
+  type CompletedOrderDraft,
+} from '../../services/orders';
+import { geocodeOrderLocation } from '../../services/geocode';
+import {
+  estimateDeliveryPrice,
+  formatPriceAmount,
+} from '../../services/pricing';
+import { rememberEphemeralMessage, clearInlineKeyboard } from '../../services/cleanup';
+import { ensurePrivateCallback, isPrivateChat } from '../../services/access';
+import { buildConfirmCancelKeyboard } from '../../keyboards/common';
 import type { BotContext, ClientOrderDraftState } from '../../types';
-import type { OrderLocation, OrderRecord } from '../../../types';
 
 export const START_DELIVERY_ORDER_ACTION = 'client:order:delivery:start';
 const CONFIRM_DELIVERY_ORDER_ACTION = 'client:order:delivery:confirm';
 const CANCEL_DELIVERY_ORDER_ACTION = 'client:order:delivery:cancel';
 
-const ensurePrivateChat = (ctx: BotContext): boolean => ctx.chat?.type === 'private';
-
 const getDraft = (ctx: BotContext): ClientOrderDraftState => ctx.session.client.delivery;
-
-const resetDraft = (draft: ClientOrderDraftState): void => {
-  draft.stage = 'idle';
-  draft.pickup = undefined;
-  draft.dropoff = undefined;
-  draft.price = undefined;
-  draft.confirmationMessageId = undefined;
-};
-
-const toOrderLocation = (location: GeocodingResult): OrderLocation => ({
-  query: location.query,
-  address: location.address,
-  latitude: location.latitude,
-  longitude: location.longitude,
-});
-
-const formatPrice = (amount: number, currency: string): string =>
-  `${new Intl.NumberFormat('ru-RU').format(amount)} ${currency}`;
-
-const formatDistance = (distanceKm: number): string => {
-  if (!Number.isFinite(distanceKm)) {
-    return 'н/д';
-  }
-
-  if (distanceKm < 0.1) {
-    return '<0.1';
-  }
-
-  return distanceKm.toFixed(1);
-};
-
-const buildSummary = (draft: ClientOrderDraftState): string => {
-  if (!draft.pickup || !draft.dropoff || !draft.price) {
-    throw new Error('Cannot build summary for incomplete delivery order draft');
-  }
-
-  const lines = [
-    '🚚 Доставка курьером',
-    '',
-    `📦 Забор: ${draft.pickup.address}`,
-    `📮 Доставка: ${draft.dropoff.address}`,
-    `📏 Расстояние: ${formatDistance(draft.price.distanceKm)} км`,
-    `💰 Оценка стоимости: ${formatPrice(draft.price.amount, draft.price.currency)}`,
-    '',
-    'Подтвердите заказ или отмените оформление.',
-  ];
-
-  return lines.join('\n');
-};
 
 const requestPickupAddress = async (ctx: BotContext): Promise<void> => {
   const prompt = await ctx.reply(
@@ -72,34 +34,51 @@ const requestPickupAddress = async (ctx: BotContext): Promise<void> => {
       'Например: «Абылайхана 10, офис 5».',
     ].join('\n'),
   );
-  ctx.session.ephemeralMessages.push(prompt.message_id);
+  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
-const requestDropoffAddress = async (ctx: BotContext, pickup: OrderLocation): Promise<void> => {
+const requestDropoffAddress = async (ctx: BotContext, pickup: CompletedOrderDraft['pickup']): Promise<void> => {
   const prompt = await ctx.reply(
     [`Адрес забора: ${pickup.address}.`, 'Теперь укажите адрес доставки.'].join('\n'),
   );
-  ctx.session.ephemeralMessages.push(prompt.message_id);
+  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
 const handleGeocodingFailure = async (ctx: BotContext): Promise<void> => {
   const message = await ctx.reply(
     'Не удалось распознать адрес. Пожалуйста, уточните формулировку и попробуйте снова.',
   );
-  ctx.session.ephemeralMessages.push(message.message_id);
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const applyPickupAddress = async (ctx: BotContext, draft: ClientOrderDraftState, text: string) => {
-  const result = await geocodeAddress(text);
-  if (!result) {
+  const pickup = await geocodeOrderLocation(text);
+  if (!pickup) {
     await handleGeocodingFailure(ctx);
     return;
   }
 
-  draft.pickup = toOrderLocation(result);
+  draft.pickup = pickup;
   draft.stage = 'collectingDropoff';
 
-  await requestDropoffAddress(ctx, draft.pickup);
+  await requestDropoffAddress(ctx, pickup);
+};
+
+const buildConfirmationKeyboard = () =>
+  buildConfirmCancelKeyboard(CONFIRM_DELIVERY_ORDER_ACTION, CANCEL_DELIVERY_ORDER_ACTION);
+
+const showConfirmation = async (ctx: BotContext, draft: CompletedOrderDraft): Promise<void> => {
+  const summary = buildOrderSummary(draft, {
+    title: '🚚 Доставка курьером',
+    pickupLabel: '📦 Забор',
+    dropoffLabel: '📮 Доставка',
+    distanceLabel: '📏 Расстояние',
+    priceLabel: '💰 Оценка стоимости',
+  });
+
+  const keyboard = buildConfirmationKeyboard();
+  const message = await ctx.reply(summary, { reply_markup: keyboard });
+  draft.confirmationMessageId = message.message_id;
 };
 
 const applyDropoffAddress = async (
@@ -107,13 +86,13 @@ const applyDropoffAddress = async (
   draft: ClientOrderDraftState,
   text: string,
 ): Promise<void> => {
-  const result = await geocodeAddress(text);
-  if (!result) {
+  const dropoff = await geocodeOrderLocation(text);
+  if (!dropoff) {
     await handleGeocodingFailure(ctx);
     return;
   }
 
-  draft.dropoff = toOrderLocation(result);
+  draft.dropoff = dropoff;
 
   if (!draft.pickup) {
     logger.warn('Delivery order draft is missing pickup after dropoff geocode');
@@ -121,60 +100,20 @@ const applyDropoffAddress = async (
     return;
   }
 
-  draft.price = estimateDeliveryPrice(draft.pickup, draft.dropoff);
+  draft.price = estimateDeliveryPrice(draft.pickup, dropoff);
   draft.stage = 'awaitingConfirmation';
 
-  const summary = buildSummary(draft);
-  const keyboard = Markup.inlineKeyboard([
-    [Markup.button.callback('✅ Подтвердить', CONFIRM_DELIVERY_ORDER_ACTION)],
-    [Markup.button.callback('❌ Отменить', CANCEL_DELIVERY_ORDER_ACTION)],
-  ]);
-  const message = await ctx.reply(summary, keyboard);
-  draft.confirmationMessageId = message.message_id;
-};
-
-const removeConfirmationKeyboard = async (
-  ctx: BotContext,
-  draft: ClientOrderDraftState,
-): Promise<void> => {
-  if (!draft.confirmationMessageId || !ctx.chat) {
-    return;
-  }
-
-  try {
-    await ctx.telegram.editMessageReplyMarkup(
-      ctx.chat.id,
-      draft.confirmationMessageId,
-      undefined,
-      undefined,
-    );
-  } catch (error) {
-    logger.debug(
-      { err: error, chatId: ctx.chat.id, messageId: draft.confirmationMessageId },
-      'Failed to clear confirmation keyboard for delivery order',
-    );
+  if (isOrderDraftComplete(draft)) {
+    await showConfirmation(ctx, draft);
   }
 };
 
 const cancelOrderDraft = async (ctx: BotContext, draft: ClientOrderDraftState): Promise<void> => {
-  await removeConfirmationKeyboard(ctx, draft);
-  resetDraft(draft);
+  await clearInlineKeyboard(ctx, draft.confirmationMessageId);
+  resetClientOrderDraft(draft);
 
   const message = await ctx.reply('Оформление доставки отменено.');
-  ctx.session.ephemeralMessages.push(message.message_id);
-};
-
-type CompletedDeliveryDraft = ClientOrderDraftState &
-  Required<Pick<ClientOrderDraftState, 'pickup' | 'dropoff' | 'price'>>;
-
-const ensureCompletion = (draft: ClientOrderDraftState): draft is CompletedDeliveryDraft =>
-  Boolean(draft.pickup && draft.dropoff && draft.price);
-
-const buildCustomerName = (ctx: BotContext): string | undefined => {
-  const first = ctx.session.user?.firstName?.trim();
-  const last = ctx.session.user?.lastName?.trim();
-  const full = [first, last].filter(Boolean).join(' ').trim();
-  return full || undefined;
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const notifyOrderCreated = async (
@@ -184,7 +123,7 @@ const notifyOrderCreated = async (
 ): Promise<void> => {
   const lines = [
     `Заказ на доставку №${order.id} создан.`,
-    `Стоимость по расчёту: ${formatPrice(order.price.amount, order.price.currency)}.`,
+    `Стоимость по расчёту: ${formatPriceAmount(order.price.amount, order.price.currency)}.`,
   ];
 
   if (publishStatus === 'missing_channel') {
@@ -192,14 +131,14 @@ const notifyOrderCreated = async (
   }
 
   const message = await ctx.reply(lines.join('\n'));
-  ctx.session.ephemeralMessages.push(message.message_id);
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Promise<void> => {
-  if (!ensureCompletion(draft)) {
+  if (!isOrderDraftComplete(draft)) {
     const warning = await ctx.reply('Не удалось подтвердить заказ: отсутствуют данные адресов.');
-    ctx.session.ephemeralMessages.push(warning.message_id);
-    resetDraft(draft);
+    rememberEphemeralMessage(ctx, warning.message_id);
+    resetClientOrderDraft(draft);
     return;
   }
 
@@ -229,10 +168,10 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
   } catch (error) {
     logger.error({ err: error }, 'Failed to create delivery order');
     const failure = await ctx.reply('Не удалось создать заказ. Попробуйте позже.');
-    ctx.session.ephemeralMessages.push(failure.message_id);
+    rememberEphemeralMessage(ctx, failure.message_id);
   } finally {
-    await removeConfirmationKeyboard(ctx, draft);
-    resetDraft(draft);
+    await clearInlineKeyboard(ctx, draft.confirmationMessageId);
+    resetClientOrderDraft(draft);
   }
 };
 
@@ -251,7 +190,7 @@ const processCancellationText = async (
 };
 
 const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
+  if (!isPrivateChat(ctx)) {
     await next();
     return;
   }
@@ -293,7 +232,7 @@ const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): P
       const reminder = await ctx.reply(
         'Используйте кнопки ниже, чтобы подтвердить или отменить заказ.',
       );
-      ctx.session.ephemeralMessages.push(reminder.message_id);
+      rememberEphemeralMessage(ctx, reminder.message_id);
       break;
     }
     default:
@@ -302,40 +241,31 @@ const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): P
 };
 
 const handleStart = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Оформление заказа доступно только в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, undefined, 'Оформление заказа доступно только в личном чате с ботом.'))) {
     return;
   }
 
-  await ctx.answerCbQuery();
-
   const draft = getDraft(ctx);
-  resetDraft(draft);
+  resetClientOrderDraft(draft);
   draft.stage = 'collectingPickup';
-  resetDraft(ctx.session.client.taxi);
+  resetClientOrderDraft(ctx.session.client.taxi);
 
   await requestPickupAddress(ctx);
 };
 
 const handleConfirmationAction = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Подтвердите заказ в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, undefined, 'Подтвердите заказ в личном чате с ботом.'))) {
     return;
   }
-
-  await ctx.answerCbQuery();
 
   const draft = getDraft(ctx);
   await confirmOrder(ctx, draft);
 };
 
 const handleCancellationAction = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Отмените заказ в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, 'Оформление отменено.', 'Отмените заказ в личном чате с ботом.'))) {
     return;
   }
-
-  await ctx.answerCbQuery('Оформление отменено.');
 
   const draft = getDraft(ctx);
   await cancelOrderDraft(ctx, draft);
@@ -355,14 +285,14 @@ export const registerDeliveryOrderFlow = (bot: Telegraf<BotContext>): void => {
   });
 
   bot.command('delivery', async (ctx) => {
-    if (!ensurePrivateChat(ctx)) {
+    if (!isPrivateChat(ctx)) {
       return;
     }
 
     const draft = getDraft(ctx);
-    resetDraft(draft);
+    resetClientOrderDraft(draft);
     draft.stage = 'collectingPickup';
-    resetDraft(ctx.session.client.taxi);
+    resetClientOrderDraft(ctx.session.client.taxi);
 
     await requestPickupAddress(ctx);
   });

--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -1,102 +1,78 @@
-import { Markup, Telegraf } from 'telegraf';
+import { Telegraf } from 'telegraf';
 
 import { publishOrderToDriversChannel, type PublishOrderStatus } from '../../../channels/ordersChannel';
 import { logger } from '../../../config';
 import { createOrder } from '../../../db/orders';
-import { geocodeAddress, type GeocodingResult } from '../../../services/geocoding';
-import { estimateTaxiPrice } from '../../../services/pricing';
+import type { OrderRecord } from '../../../types';
+import {
+  buildCustomerName,
+  buildOrderSummary,
+  isOrderDraftComplete,
+  resetClientOrderDraft,
+  type CompletedOrderDraft,
+} from '../../services/orders';
+import { geocodeOrderLocation } from '../../services/geocode';
+import { estimateTaxiPrice, formatPriceAmount } from '../../services/pricing';
+import { rememberEphemeralMessage, clearInlineKeyboard } from '../../services/cleanup';
+import { ensurePrivateCallback, isPrivateChat } from '../../services/access';
+import { buildConfirmCancelKeyboard } from '../../keyboards/common';
 import type { BotContext, ClientOrderDraftState } from '../../types';
-import type { OrderLocation, OrderRecord } from '../../../types';
 
 export const START_TAXI_ORDER_ACTION = 'client:order:taxi:start';
 const CONFIRM_TAXI_ORDER_ACTION = 'client:order:taxi:confirm';
 const CANCEL_TAXI_ORDER_ACTION = 'client:order:taxi:cancel';
 
-const ensurePrivateChat = (ctx: BotContext): boolean => ctx.chat?.type === 'private';
-
 const getDraft = (ctx: BotContext): ClientOrderDraftState => ctx.session.client.taxi;
-
-const resetDraft = (draft: ClientOrderDraftState): void => {
-  draft.stage = 'idle';
-  draft.pickup = undefined;
-  draft.dropoff = undefined;
-  draft.price = undefined;
-  draft.confirmationMessageId = undefined;
-};
-
-const toOrderLocation = (location: GeocodingResult): OrderLocation => ({
-  query: location.query,
-  address: location.address,
-  latitude: location.latitude,
-  longitude: location.longitude,
-});
-
-const formatPrice = (amount: number, currency: string): string =>
-  `${new Intl.NumberFormat('ru-RU').format(amount)} ${currency}`;
-
-const formatDistance = (distanceKm: number): string => {
-  if (!Number.isFinite(distanceKm)) {
-    return 'н/д';
-  }
-
-  if (distanceKm < 0.1) {
-    return '<0.1';
-  }
-
-  return distanceKm.toFixed(1);
-};
-
-const buildSummary = (draft: ClientOrderDraftState): string => {
-  if (!draft.pickup || !draft.dropoff || !draft.price) {
-    throw new Error('Cannot build summary for incomplete taxi order draft');
-  }
-
-  const lines = [
-    '🚕 Предварительный заказ такси',
-    '',
-    `📍 Подача: ${draft.pickup.address}`,
-    `🎯 Назначение: ${draft.dropoff.address}`,
-    `📏 Расстояние: ${formatDistance(draft.price.distanceKm)} км`,
-    `💰 Оценка стоимости: ${formatPrice(draft.price.amount, draft.price.currency)}`,
-    '',
-    'Подтвердите заказ или отмените оформление.',
-  ];
-
-  return lines.join('\n');
-};
 
 const requestPickupAddress = async (ctx: BotContext): Promise<void> => {
   const prompt = await ctx.reply(
     ['Введите адрес подачи такси.', 'Например: «Достык 1, подъезд 3».'].join('\n'),
   );
-  ctx.session.ephemeralMessages.push(prompt.message_id);
+  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
-const requestDropoffAddress = async (ctx: BotContext, pickup: OrderLocation): Promise<void> => {
+const requestDropoffAddress = async (ctx: BotContext, pickup: CompletedOrderDraft['pickup']): Promise<void> => {
   const prompt = await ctx.reply(
     [`Адрес подачи: ${pickup.address}.`, 'Теперь укажите пункт назначения.'].join('\n'),
   );
-  ctx.session.ephemeralMessages.push(prompt.message_id);
+  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
 const handleGeocodingFailure = async (ctx: BotContext): Promise<void> => {
   const message = await ctx.reply(
     'Не удалось распознать адрес. Пожалуйста, уточните формулировку и попробуйте снова.',
   );
-  ctx.session.ephemeralMessages.push(message.message_id);
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const applyPickupAddress = async (ctx: BotContext, draft: ClientOrderDraftState, text: string) => {
-  const result = await geocodeAddress(text);
-  if (!result) {
+  const pickup = await geocodeOrderLocation(text);
+  if (!pickup) {
     await handleGeocodingFailure(ctx);
     return;
   }
 
-  draft.pickup = toOrderLocation(result);
+  draft.pickup = pickup;
   draft.stage = 'collectingDropoff';
 
-  await requestDropoffAddress(ctx, draft.pickup);
+  await requestDropoffAddress(ctx, pickup);
+};
+
+const buildConfirmationKeyboard = () =>
+  buildConfirmCancelKeyboard(CONFIRM_TAXI_ORDER_ACTION, CANCEL_TAXI_ORDER_ACTION);
+
+const showConfirmation = async (ctx: BotContext, draft: CompletedOrderDraft): Promise<void> => {
+  const summary = buildOrderSummary(draft, {
+    title: '🚕 Предварительный заказ такси',
+    pickupLabel: '📍 Подача',
+    dropoffLabel: '🎯 Назначение',
+    distanceLabel: '📏 Расстояние',
+    priceLabel: '💰 Оценка стоимости',
+  });
+
+  const keyboard = buildConfirmationKeyboard();
+  const message = await ctx.reply(summary, { reply_markup: keyboard });
+  draft.confirmationMessageId = message.message_id;
 };
 
 const applyDropoffAddress = async (
@@ -104,13 +80,13 @@ const applyDropoffAddress = async (
   draft: ClientOrderDraftState,
   text: string,
 ): Promise<void> => {
-  const result = await geocodeAddress(text);
-  if (!result) {
+  const dropoff = await geocodeOrderLocation(text);
+  if (!dropoff) {
     await handleGeocodingFailure(ctx);
     return;
   }
 
-  draft.dropoff = toOrderLocation(result);
+  draft.dropoff = dropoff;
 
   if (!draft.pickup) {
     logger.warn('Taxi order draft is missing pickup after dropoff geocode');
@@ -118,60 +94,20 @@ const applyDropoffAddress = async (
     return;
   }
 
-  draft.price = estimateTaxiPrice(draft.pickup, draft.dropoff);
+  draft.price = estimateTaxiPrice(draft.pickup, dropoff);
   draft.stage = 'awaitingConfirmation';
 
-  const summary = buildSummary(draft);
-  const keyboard = Markup.inlineKeyboard([
-    [Markup.button.callback('✅ Подтвердить', CONFIRM_TAXI_ORDER_ACTION)],
-    [Markup.button.callback('❌ Отменить', CANCEL_TAXI_ORDER_ACTION)],
-  ]);
-  const message = await ctx.reply(summary, keyboard);
-  draft.confirmationMessageId = message.message_id;
-};
-
-const removeConfirmationKeyboard = async (
-  ctx: BotContext,
-  draft: ClientOrderDraftState,
-): Promise<void> => {
-  if (!draft.confirmationMessageId || !ctx.chat) {
-    return;
-  }
-
-  try {
-    await ctx.telegram.editMessageReplyMarkup(
-      ctx.chat.id,
-      draft.confirmationMessageId,
-      undefined,
-      undefined,
-    );
-  } catch (error) {
-    logger.debug(
-      { err: error, chatId: ctx.chat.id, messageId: draft.confirmationMessageId },
-      'Failed to clear confirmation keyboard for taxi order',
-    );
+  if (isOrderDraftComplete(draft)) {
+    await showConfirmation(ctx, draft);
   }
 };
 
 const cancelOrderDraft = async (ctx: BotContext, draft: ClientOrderDraftState): Promise<void> => {
-  await removeConfirmationKeyboard(ctx, draft);
-  resetDraft(draft);
+  await clearInlineKeyboard(ctx, draft.confirmationMessageId);
+  resetClientOrderDraft(draft);
 
   const message = await ctx.reply('Оформление заказа отменено.');
-  ctx.session.ephemeralMessages.push(message.message_id);
-};
-
-type CompletedTaxiDraft = ClientOrderDraftState &
-  Required<Pick<ClientOrderDraftState, 'pickup' | 'dropoff' | 'price'>>;
-
-const ensureCompletion = (draft: ClientOrderDraftState): draft is CompletedTaxiDraft =>
-  Boolean(draft.pickup && draft.dropoff && draft.price);
-
-const buildCustomerName = (ctx: BotContext): string | undefined => {
-  const first = ctx.session.user?.firstName?.trim();
-  const last = ctx.session.user?.lastName?.trim();
-  const full = [first, last].filter(Boolean).join(' ').trim();
-  return full || undefined;
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const notifyOrderCreated = async (
@@ -181,7 +117,7 @@ const notifyOrderCreated = async (
 ): Promise<void> => {
   const lines = [
     `Заказ №${order.id} успешно создан.`,
-    `Стоимость по расчёту: ${formatPrice(order.price.amount, order.price.currency)}.`,
+    `Стоимость по расчёту: ${formatPriceAmount(order.price.amount, order.price.currency)}.`,
   ];
 
   if (publishStatus === 'missing_channel') {
@@ -189,14 +125,14 @@ const notifyOrderCreated = async (
   }
 
   const message = await ctx.reply(lines.join('\n'));
-  ctx.session.ephemeralMessages.push(message.message_id);
+  rememberEphemeralMessage(ctx, message.message_id);
 };
 
 const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Promise<void> => {
-  if (!ensureCompletion(draft)) {
+  if (!isOrderDraftComplete(draft)) {
     const warning = await ctx.reply('Не удалось подтвердить заказ: отсутствуют данные адресов.');
-    ctx.session.ephemeralMessages.push(warning.message_id);
-    resetDraft(draft);
+    rememberEphemeralMessage(ctx, warning.message_id);
+    resetClientOrderDraft(draft);
     return;
   }
 
@@ -226,10 +162,10 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
   } catch (error) {
     logger.error({ err: error }, 'Failed to create taxi order');
     const failure = await ctx.reply('Не удалось создать заказ. Попробуйте позже.');
-    ctx.session.ephemeralMessages.push(failure.message_id);
+    rememberEphemeralMessage(ctx, failure.message_id);
   } finally {
-    await removeConfirmationKeyboard(ctx, draft);
-    resetDraft(draft);
+    await clearInlineKeyboard(ctx, draft.confirmationMessageId);
+    resetClientOrderDraft(draft);
   }
 };
 
@@ -248,7 +184,7 @@ const processCancellationText = async (
 };
 
 const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
+  if (!isPrivateChat(ctx)) {
     await next();
     return;
   }
@@ -290,7 +226,7 @@ const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): P
       const reminder = await ctx.reply(
         'Используйте кнопки ниже, чтобы подтвердить или отменить заказ.',
       );
-      ctx.session.ephemeralMessages.push(reminder.message_id);
+      rememberEphemeralMessage(ctx, reminder.message_id);
       break;
     }
     default:
@@ -299,40 +235,31 @@ const handleIncomingText = async (ctx: BotContext, next: () => Promise<void>): P
 };
 
 const handleStart = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Оформление заказа доступно только в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, undefined, 'Оформление заказа доступно только в личном чате с ботом.'))) {
     return;
   }
 
-  await ctx.answerCbQuery();
-
   const draft = getDraft(ctx);
-  resetDraft(draft);
+  resetClientOrderDraft(draft);
   draft.stage = 'collectingPickup';
-  resetDraft(ctx.session.client.delivery);
+  resetClientOrderDraft(ctx.session.client.delivery);
 
   await requestPickupAddress(ctx);
 };
 
 const handleConfirmationAction = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Подтвердите заказ в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, undefined, 'Подтвердите заказ в личном чате с ботом.'))) {
     return;
   }
-
-  await ctx.answerCbQuery();
 
   const draft = getDraft(ctx);
   await confirmOrder(ctx, draft);
 };
 
 const handleCancellationAction = async (ctx: BotContext): Promise<void> => {
-  if (!ensurePrivateChat(ctx)) {
-    await ctx.answerCbQuery('Отмените заказ в личном чате с ботом.');
+  if (!(await ensurePrivateCallback(ctx, 'Оформление отменено.', 'Отмените заказ в личном чате с ботом.'))) {
     return;
   }
-
-  await ctx.answerCbQuery('Оформление отменено.');
 
   const draft = getDraft(ctx);
   await cancelOrderDraft(ctx, draft);
@@ -352,14 +279,14 @@ export const registerTaxiOrderFlow = (bot: Telegraf<BotContext>): void => {
   });
 
   bot.command('taxi', async (ctx) => {
-    if (!ensurePrivateChat(ctx)) {
+    if (!isPrivateChat(ctx)) {
       return;
     }
 
     const draft = getDraft(ctx);
-    resetDraft(draft);
+    resetClientOrderDraft(draft);
     draft.stage = 'collectingPickup';
-    resetDraft(ctx.session.client.delivery);
+    resetClientOrderDraft(ctx.session.client.delivery);
 
     await requestPickupAddress(ctx);
   });

--- a/src/bot/keyboards/common.ts
+++ b/src/bot/keyboards/common.ts
@@ -1,0 +1,82 @@
+import { Markup } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+export interface InlineButton {
+  label: string;
+  action: string;
+}
+
+export interface UrlButton {
+  label: string;
+  url: string;
+}
+
+export type KeyboardButton = InlineButton | UrlButton;
+
+const isUrlButton = (button: KeyboardButton): button is UrlButton =>
+  'url' in button;
+
+const createButton = (button: KeyboardButton) =>
+  isUrlButton(button)
+    ? Markup.button.url(button.label, button.url)
+    : Markup.button.callback(button.label, button.action);
+
+export const buildInlineKeyboard = (
+  rows: KeyboardButton[][],
+): InlineKeyboardMarkup => ({
+  inline_keyboard: rows.map((row) => row.map(createButton)),
+});
+
+export interface ConfirmCancelKeyboardOptions {
+  confirmLabel?: string;
+  cancelLabel?: string;
+  layout?: 'horizontal' | 'vertical';
+}
+
+export const buildConfirmCancelKeyboard = (
+  confirmAction: string,
+  cancelAction: string,
+  options: ConfirmCancelKeyboardOptions = {},
+): InlineKeyboardMarkup => {
+  const confirmLabel = options.confirmLabel ?? '✅ Подтвердить';
+  const cancelLabel = options.cancelLabel ?? '❌ Отменить';
+
+  if (options.layout === 'horizontal') {
+    return buildInlineKeyboard([
+      [
+        { label: confirmLabel, action: confirmAction },
+        { label: cancelLabel, action: cancelAction },
+      ],
+    ]);
+  }
+
+  return buildInlineKeyboard([
+    [{ label: confirmLabel, action: confirmAction }],
+    [{ label: cancelLabel, action: cancelAction }],
+  ]);
+};
+
+export const buildCloseKeyboard = (
+  action: string,
+  label = '❌ Закрыть',
+): InlineKeyboardMarkup =>
+  buildInlineKeyboard([[{ label, action }]]);
+
+export const buildUrlKeyboard = (
+  label: string,
+  url: string,
+): InlineKeyboardMarkup => buildInlineKeyboard([[{ label, url }]]);
+
+export const mergeInlineKeyboards = (
+  ...keyboards: (InlineKeyboardMarkup | undefined)[]
+): InlineKeyboardMarkup | undefined => {
+  const rows = keyboards
+    .filter((keyboard): keyboard is InlineKeyboardMarkup => Boolean(keyboard))
+    .flatMap((keyboard) => keyboard.inline_keyboard ?? []);
+
+  if (rows.length === 0) {
+    return undefined;
+  }
+
+  return { inline_keyboard: rows };
+};

--- a/src/bot/services/access.ts
+++ b/src/bot/services/access.ts
@@ -1,0 +1,56 @@
+import type { BotContext } from '../types';
+
+const DEFAULT_PRIVATE_ONLY_MESSAGE = 'Доступно только в личных сообщениях с ботом.';
+
+export const isPrivateChat = (ctx: BotContext): boolean => ctx.chat?.type === 'private';
+
+export const ensurePrivateChat = async (
+  ctx: BotContext,
+  response = DEFAULT_PRIVATE_ONLY_MESSAGE,
+): Promise<boolean> => {
+  if (isPrivateChat(ctx)) {
+    return true;
+  }
+
+  if ('answerCbQuery' in ctx && ctx.callbackQuery) {
+    try {
+      await ctx.answerCbQuery(response);
+    } catch (error) {
+      // ignore failures silently; nothing we can do for closed callbacks
+    }
+    return false;
+  }
+
+  if (typeof ctx.reply === 'function') {
+    await ctx.reply(response);
+  }
+
+  return false;
+};
+
+export const ensurePrivateCallback = async (
+  ctx: BotContext,
+  successMessage?: string,
+  failureMessage = DEFAULT_PRIVATE_ONLY_MESSAGE,
+): Promise<boolean> => {
+  if (!ctx.callbackQuery) {
+    return ensurePrivateChat(ctx, failureMessage);
+  }
+
+  if (!isPrivateChat(ctx)) {
+    try {
+      await ctx.answerCbQuery(failureMessage);
+    } catch (error) {
+      // swallow telegram errors
+    }
+    return false;
+  }
+
+  try {
+    await ctx.answerCbQuery(successMessage);
+  } catch (error) {
+    // ignore failures silently
+  }
+
+  return true;
+};

--- a/src/bot/services/cleanup.ts
+++ b/src/bot/services/cleanup.ts
@@ -1,0 +1,40 @@
+import { logger } from '../../config';
+import type { BotContext } from '../types';
+
+import { safeEditReplyMarkup } from '../../utils/tg';
+
+export const rememberEphemeralMessage = (
+  ctx: BotContext,
+  messageId?: number,
+): void => {
+  if (!messageId) {
+    return;
+  }
+
+  ctx.session.ephemeralMessages.push(messageId);
+};
+
+export const clearInlineKeyboard = async (
+  ctx: BotContext,
+  messageId?: number,
+): Promise<boolean> => {
+  if (!messageId || !ctx.chat) {
+    return false;
+  }
+
+  const success = await safeEditReplyMarkup(
+    ctx.telegram,
+    ctx.chat.id,
+    messageId,
+    undefined,
+  );
+
+  if (!success) {
+    logger.debug(
+      { chatId: ctx.chat.id, messageId },
+      'Failed to clear inline keyboard',
+    );
+  }
+
+  return success;
+};

--- a/src/bot/services/geocode.ts
+++ b/src/bot/services/geocode.ts
@@ -1,0 +1,16 @@
+import { geocodeAddress, type GeocodingResult } from '../../services/geocoding';
+import type { OrderLocation } from '../../types';
+
+export const toOrderLocation = (result: GeocodingResult): OrderLocation => ({
+  query: result.query,
+  address: result.address,
+  latitude: result.latitude,
+  longitude: result.longitude,
+});
+
+export const geocodeOrderLocation = async (
+  query: string,
+): Promise<OrderLocation | null> => {
+  const result = await geocodeAddress(query);
+  return result ? toOrderLocation(result) : null;
+};

--- a/src/bot/services/orders.ts
+++ b/src/bot/services/orders.ts
@@ -1,0 +1,74 @@
+import type { BotContext, ClientOrderDraftState } from '../types';
+import type { OrderLocation, OrderPriceDetails } from '../../types';
+
+import { formatDistance, formatPriceAmount } from './pricing';
+
+export type CompletedOrderDraft = ClientOrderDraftState & {
+  pickup: OrderLocation;
+  dropoff: OrderLocation;
+  price: OrderPriceDetails;
+};
+
+export const resetClientOrderDraft = (draft: ClientOrderDraftState): void => {
+  draft.stage = 'idle';
+  draft.pickup = undefined;
+  draft.dropoff = undefined;
+  draft.price = undefined;
+  draft.confirmationMessageId = undefined;
+};
+
+export const isOrderDraftComplete = (
+  draft: ClientOrderDraftState,
+): draft is CompletedOrderDraft =>
+  Boolean(draft.pickup && draft.dropoff && draft.price);
+
+export interface OrderSummaryOptions {
+  title: string;
+  pickupLabel?: string;
+  dropoffLabel?: string;
+  distanceLabel?: string;
+  priceLabel?: string;
+  includeDistance?: boolean;
+  includePrice?: boolean;
+  instructions?: string[];
+}
+
+export const buildOrderSummary = (
+  draft: CompletedOrderDraft,
+  options: OrderSummaryOptions,
+): string => {
+  const lines = [options.title.trim(), ''];
+
+  const pickupLabel = options.pickupLabel ?? '📍 Пункт отправления';
+  const dropoffLabel = options.dropoffLabel ?? '🎯 Пункт назначения';
+  lines.push(`${pickupLabel}: ${draft.pickup.address}`);
+  lines.push(`${dropoffLabel}: ${draft.dropoff.address}`);
+
+  if (options.includeDistance ?? true) {
+    const distanceLabel = options.distanceLabel ?? '📏 Расстояние';
+    lines.push(`${distanceLabel}: ${formatDistance(draft.price.distanceKm)} км`);
+  }
+
+  if (options.includePrice ?? true) {
+    const priceLabel = options.priceLabel ?? '💰 Стоимость';
+    lines.push(`${priceLabel}: ${formatPriceAmount(draft.price.amount, draft.price.currency)}`);
+  }
+
+  const instructions = options.instructions ?? [
+    'Подтвердите заказ или отмените оформление.',
+  ];
+
+  if (instructions.length > 0) {
+    lines.push('');
+    lines.push(...instructions);
+  }
+
+  return lines.join('\n');
+};
+
+export const buildCustomerName = (ctx: BotContext): string | undefined => {
+  const first = ctx.session.user?.firstName?.trim();
+  const last = ctx.session.user?.lastName?.trim();
+  const full = [first, last].filter(Boolean).join(' ').trim();
+  return full || undefined;
+};

--- a/src/bot/services/payments.ts
+++ b/src/bot/services/payments.ts
@@ -1,0 +1,57 @@
+import { Markup } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+import { formatPriceAmount } from './pricing';
+
+export interface PaymentDetails {
+  amount: number;
+  currency: string;
+  recipient?: string;
+  description?: string | string[];
+  reference?: string;
+  url?: string;
+  urlLabel?: string;
+}
+
+const normaliseDescription = (value?: string | string[]): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+};
+
+export const buildPaymentMessage = (details: PaymentDetails): string => {
+  const lines = ['💳 Оплата заказа Freedom Bot'];
+  lines.push(`Сумма к оплате: ${formatPriceAmount(details.amount, details.currency)}.`);
+
+  if (details.recipient) {
+    lines.push(`Получатель: ${details.recipient}.`);
+  }
+
+  const description = normaliseDescription(details.description);
+  if (description.length > 0) {
+    lines.push('');
+    lines.push(...description);
+  }
+
+  if (details.reference) {
+    lines.push('');
+    lines.push(`Назначение платежа: ${details.reference}`);
+  }
+
+  lines.push('', 'После оплаты отправьте, пожалуйста, чек в этот чат.');
+
+  return lines.join('\n');
+};
+
+export const buildPaymentKeyboard = (
+  details: PaymentDetails,
+): InlineKeyboardMarkup | undefined => {
+  if (!details.url) {
+    return undefined;
+  }
+
+  const label = details.urlLabel ?? 'Перейти к оплате';
+  return Markup.inlineKeyboard([[Markup.button.url(label, details.url)]]).reply_markup;
+};

--- a/src/bot/services/pricing.ts
+++ b/src/bot/services/pricing.ts
@@ -1,0 +1,32 @@
+import type { OrderPriceDetails } from '../../types';
+
+import {
+  estimateDeliveryPrice as baseEstimateDeliveryPrice,
+  estimateTaxiPrice as baseEstimateTaxiPrice,
+  calculateDistanceKm,
+} from '../../services/pricing';
+
+const priceFormatter = new Intl.NumberFormat('ru-RU');
+
+export const formatPriceAmount = (amount: number, currency: string): string =>
+  `${priceFormatter.format(amount)} ${currency}`;
+
+export const formatPriceDetails = (price: OrderPriceDetails): string =>
+  formatPriceAmount(price.amount, price.currency);
+
+export const formatDistance = (distanceKm: number): string => {
+  if (!Number.isFinite(distanceKm)) {
+    return 'н/д';
+  }
+
+  if (distanceKm < 0.1) {
+    return '<0.1';
+  }
+
+  return distanceKm.toFixed(1);
+};
+
+export const estimateTaxiPrice = baseEstimateTaxiPrice;
+export const estimateDeliveryPrice = baseEstimateDeliveryPrice;
+
+export { calculateDistanceKm };

--- a/src/bot/services/support.ts
+++ b/src/bot/services/support.ts
@@ -1,0 +1,93 @@
+import { Markup } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+export interface SupportContact {
+  type: 'phone' | 'email' | 'telegram' | 'link';
+  value: string;
+  label?: string;
+  description?: string;
+  url?: string;
+}
+
+export interface SupportMessageOptions {
+  title?: string;
+  description?: string | string[];
+  contacts?: SupportContact[];
+  footer?: string | string[];
+}
+
+const normaliseLines = (input?: string | string[]): string[] => {
+  if (!input) {
+    return [];
+  }
+
+  return Array.isArray(input) ? input : [input];
+};
+
+const buildContactLine = (contact: SupportContact): string => {
+  const label = contact.label?.trim();
+
+  switch (contact.type) {
+    case 'phone':
+      return `📞 ${label ?? 'Телефон'}: ${contact.value}`;
+    case 'email':
+      return `✉️ ${label ?? 'Email'}: ${contact.value}`;
+    case 'telegram':
+      return `💬 ${label ?? 'Telegram'}: ${contact.value.startsWith('@') ? contact.value : `@${contact.value}`}`;
+    case 'link':
+    default:
+      return `${label ?? '🔗 Ссылка'}: ${contact.value}`;
+  }
+};
+
+export const buildSupportMessage = (options: SupportMessageOptions = {}): string => {
+  const lines: string[] = [];
+
+  if (options.title) {
+    lines.push(options.title.trim());
+  } else {
+    lines.push('🆘 Поддержка Freedom Bot');
+  }
+
+  const description = normaliseLines(options.description);
+  if (description.length > 0) {
+    lines.push('');
+    lines.push(...description);
+  }
+
+  if (options.contacts && options.contacts.length > 0) {
+    lines.push('');
+    lines.push('Свяжитесь с нами:');
+    options.contacts.forEach((contact) => {
+      const line = buildContactLine(contact);
+      lines.push(line);
+      if (contact.description) {
+        lines.push(`• ${contact.description.trim()}`);
+      }
+    });
+  }
+
+  const footer = normaliseLines(options.footer);
+  if (footer.length > 0) {
+    lines.push('');
+    lines.push(...footer);
+  }
+
+  return lines.join('\n');
+};
+
+export const buildSupportKeyboard = (
+  contacts: SupportContact[] = [],
+): InlineKeyboardMarkup | undefined => {
+  const buttons = contacts
+    .filter((contact) => Boolean(contact.url))
+    .map((contact) => [
+      Markup.button.url(contact.label ?? contact.value, contact.url as string),
+    ]);
+
+  if (buttons.length === 0) {
+    return undefined;
+  }
+
+  return Markup.inlineKeyboard(buttons).reply_markup;
+};

--- a/src/bot/services/verify.ts
+++ b/src/bot/services/verify.ts
@@ -1,0 +1,90 @@
+import type { BotContext, ExecutorFlowState } from '../types';
+import { EXECUTOR_VERIFICATION_PHOTO_COUNT } from '../types';
+
+import { MINUTE, remainingTime } from '../../utils/time';
+
+const DEFAULT_COOLDOWN_MS = 10 * MINUTE;
+
+export interface VerificationPromptOptions {
+  requiredPhotos?: number;
+}
+
+export const buildVerificationPrompt = (
+  options: VerificationPromptOptions = {},
+): string => {
+  const required = Math.max(1, options.requiredPhotos ?? EXECUTOR_VERIFICATION_PHOTO_COUNT);
+  const lines = [
+    'Для доступа к заказам пришлите фотографии документов:',
+    '1. Удостоверение личности — лицевая сторона.',
+    '2. Удостоверение личности — обратная сторона.',
+    '3. Селфи с удостоверением в руках.',
+  ];
+
+  if (required > 3) {
+    lines.push(`Дополнительно требуется всего фотографий: ${required}.`);
+  }
+
+  lines.push('', 'Отправляйте фотографии по одному сообщению в этот чат.');
+  return lines.join('\n');
+};
+
+export interface VerificationSummaryOptions {
+  photoCount?: number;
+}
+
+export const buildVerificationSummary = (
+  ctx: BotContext,
+  state: ExecutorFlowState,
+  options: VerificationSummaryOptions = {},
+): string => {
+  const applicant = ctx.session.user;
+  const lines = [
+    '🆕 Новая заявка на верификацию курьера.',
+    `Telegram ID: ${ctx.from?.id ?? 'неизвестно'}`,
+  ];
+
+  if (applicant?.username) {
+    lines.push(`Username: @${applicant.username}`);
+  }
+
+  const fullName = [applicant?.firstName, applicant?.lastName]
+    .filter((part) => Boolean(part && part.trim().length > 0))
+    .join(' ')
+    .trim();
+
+  if (fullName) {
+    lines.push(`Имя: ${fullName}`);
+  }
+
+  if (ctx.session.phoneNumber) {
+    lines.push(`Телефон: ${ctx.session.phoneNumber}`);
+  }
+
+  const uploaded = options.photoCount ?? state.verification.uploadedPhotos.length;
+  lines.push(`Фотографии: ${uploaded}/${state.verification.requiredPhotos}.`);
+
+  if (state.verification.submittedAt) {
+    lines.push(`Отправлено: ${new Date(state.verification.submittedAt).toLocaleString('ru-RU')}`);
+  }
+
+  return lines.join('\n');
+};
+
+export const remainingVerificationCooldown = (
+  state: ExecutorFlowState,
+  now = Date.now(),
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+): number => {
+  if (!state.verification.submittedAt) {
+    return 0;
+  }
+
+  const until = state.verification.submittedAt + cooldownMs;
+  return Math.max(0, remainingTime(until, now) ?? 0);
+};
+
+export const shouldThrottleVerification = (
+  state: ExecutorFlowState,
+  now = Date.now(),
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+): boolean => remainingVerificationCooldown(state, now, cooldownMs) > 0;

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,0 +1,67 @@
+const DEFAULT_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+const DEFAULT_LENGTH = 8;
+
+const isAlphabetValid = (alphabet: string): boolean =>
+  Boolean(alphabet) && new Set(alphabet).size === alphabet.length;
+
+const randomInt = (max: number): number => Math.floor(Math.random() * max);
+
+export interface ShortIdOptions {
+  /** Custom alphabet used to generate IDs. Defaults to base36 characters. */
+  alphabet?: string;
+  /** Desired length of the generated identifier. Defaults to 8 symbols. */
+  length?: number;
+}
+
+export const createShortId = (options: ShortIdOptions = {}): string => {
+  const alphabet = isAlphabetValid(options.alphabet ?? DEFAULT_ALPHABET)
+    ? options.alphabet ?? DEFAULT_ALPHABET
+    : DEFAULT_ALPHABET;
+  const length = options.length ?? DEFAULT_LENGTH;
+
+  if (length <= 0) {
+    throw new Error('Short ID length must be a positive integer');
+  }
+
+  let id = '';
+  for (let index = 0; index < length; index += 1) {
+    id += alphabet[randomInt(alphabet.length)];
+  }
+
+  return id;
+};
+
+export interface ShortCallbackIdOptions extends ShortIdOptions {
+  /** Optional delimiter used between prefix and generated identifier. */
+  delimiter?: string;
+}
+
+export const createShortCallbackId = (
+  prefix: string,
+  options: ShortCallbackIdOptions = {},
+): string => {
+  const delimiter = options.delimiter ?? ':';
+  const id = createShortId(options);
+  return `${prefix}${delimiter}${id}`;
+};
+
+export const parseShortCallbackId = (
+  value: string,
+  delimiter = ':',
+): { prefix: string; id: string } | null => {
+  if (!value.includes(delimiter)) {
+    return null;
+  }
+
+  const [prefix, id] = value.split(delimiter);
+  if (!prefix || !id) {
+    return null;
+  }
+
+  return { prefix, id };
+};
+
+export const isShortCallbackId = (value: string, prefix: string, delimiter = ':'): boolean => {
+  const parsed = parseShortCallbackId(value, delimiter);
+  return parsed?.prefix === prefix;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,3 @@
-export {};
+export * from './time';
+export * from './tg';
+export * from './ids';

--- a/src/utils/tg.ts
+++ b/src/utils/tg.ts
@@ -1,0 +1,151 @@
+import type { Telegram } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+import { sleep } from './time';
+
+const RETRYABLE_ERROR_CODES = new Set([429, 500, 502, 503, 504]);
+
+interface TelegramErrorLike {
+  message?: string;
+  description?: string;
+  error_code?: number;
+  parameters?: { retry_after?: number };
+  response?: {
+    error_code?: number;
+    description?: string;
+    parameters?: { retry_after?: number };
+  };
+}
+
+const getTelegramErrorCode = (error: unknown): number | undefined => {
+  const telegramError = error as TelegramErrorLike;
+  return telegramError?.error_code ?? telegramError?.response?.error_code;
+};
+
+const getTelegramErrorDescription = (error: unknown): string | undefined => {
+  const telegramError = error as TelegramErrorLike;
+  return (
+    telegramError?.description ??
+    telegramError?.response?.description ??
+    telegramError?.message
+  );
+};
+
+export const parseRetryAfterMs = (error: unknown): number | null => {
+  const telegramError = error as TelegramErrorLike;
+  const retryAfter =
+    telegramError?.parameters?.retry_after ??
+    telegramError?.response?.parameters?.retry_after;
+
+  if (typeof retryAfter === 'number' && Number.isFinite(retryAfter)) {
+    return retryAfter * 1000;
+  }
+
+  const description = getTelegramErrorDescription(error);
+  if (description) {
+    const match = description.match(/retry after (\d+)/i);
+    if (match) {
+      const parsed = Number.parseInt(match[1], 10);
+      if (Number.isInteger(parsed)) {
+        return parsed * 1000;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const isRetryableTelegramError = (error: unknown): boolean => {
+  const code = getTelegramErrorCode(error);
+  if (code !== undefined) {
+    return RETRYABLE_ERROR_CODES.has(code);
+  }
+
+  const description = getTelegramErrorDescription(error);
+  return Boolean(description && /retry after/i.test(description));
+};
+
+export interface TelegramRetryOptions {
+  /** Maximum number of attempts including the initial one. */
+  attempts?: number;
+  /** Delay between retries when `retry_after` is not provided. */
+  baseDelayMs?: number;
+  /** Optional cap for exponentially growing delay. */
+  maxDelayMs?: number;
+  /** Invoked before sleeping prior to the next retry attempt. */
+  onRetry?: (error: unknown, attempt: number, delayMs: number) => void;
+}
+
+export const withTelegramRetries = async <T>(
+  operation: () => Promise<T>,
+  options: TelegramRetryOptions = {},
+): Promise<T> => {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  const baseDelay = Math.max(0, options.baseDelayMs ?? 500);
+  const maxDelay = options.maxDelayMs ?? baseDelay * 10;
+
+  let lastError: unknown;
+  let delay = baseDelay;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= attempts || !isRetryableTelegramError(error)) {
+        throw error;
+      }
+
+      const retryAfter = parseRetryAfterMs(error);
+      const waitFor = retryAfter ?? Math.min(delay, maxDelay);
+      options.onRetry?.(error, attempt, waitFor);
+      await sleep(waitFor);
+      delay = Math.min(delay * 2, maxDelay);
+    }
+  }
+
+  throw lastError ?? new Error('Telegram retry operation failed');
+};
+
+export const safeEditReplyMarkup = async (
+  telegram: Telegram,
+  chatId: number,
+  messageId: number,
+  replyMarkup?: InlineKeyboardMarkup,
+): Promise<boolean> => {
+  try {
+    await withTelegramRetries(() =>
+      telegram.editMessageReplyMarkup(chatId, messageId, undefined, replyMarkup),
+    );
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const safeDeleteMessage = async (
+  telegram: Telegram,
+  chatId: number,
+  messageId: number,
+): Promise<boolean> => {
+  try {
+    await withTelegramRetries(() => telegram.deleteMessage(chatId, messageId));
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const safeAnswerCallback = async (
+  telegram: Telegram,
+  callbackQueryId: string,
+  text?: string,
+): Promise<boolean> => {
+  try {
+    await withTelegramRetries(() => telegram.answerCbQuery(callbackQueryId, text));
+    return true;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,108 @@
+const SECOND_IN_MS = 1000;
+const MINUTE_IN_MS = SECOND_IN_MS * 60;
+const HOUR_IN_MS = MINUTE_IN_MS * 60;
+const DAY_IN_MS = HOUR_IN_MS * 24;
+
+export const SECOND = SECOND_IN_MS;
+export const MINUTE = MINUTE_IN_MS;
+export const HOUR = HOUR_IN_MS;
+export const DAY = DAY_IN_MS;
+
+/**
+ * Suspends execution for the specified amount of milliseconds.
+ */
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, ms));
+  });
+
+/**
+ * Normalises the provided value into a numeric timestamp.
+ * Returns `NaN` when the value cannot be converted.
+ */
+export const toTimestamp = (value: Date | number | string | null | undefined): number => {
+  if (value === null || value === undefined) {
+    return Number.NaN;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? Number.NaN : parsed;
+  }
+
+  return Number.NaN;
+};
+
+/**
+ * Calculates the difference between two timestamps in milliseconds.
+ */
+export const diffMilliseconds = (
+  from: Date | number | string,
+  to: Date | number | string = Date.now(),
+): number => {
+  const start = toTimestamp(from);
+  const end = toTimestamp(to);
+
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return Number.NaN;
+  }
+
+  return end - start;
+};
+
+/**
+ * Determines whether the specified timestamp has elapsed by the given duration.
+ */
+export const hasElapsed = (
+  since: Date | number | string,
+  durationMs: number,
+  now: Date | number | string = Date.now(),
+): boolean => {
+  const elapsed = diffMilliseconds(since, now);
+  if (Number.isNaN(elapsed)) {
+    return false;
+  }
+
+  return elapsed >= durationMs;
+};
+
+/**
+ * Calculates the remaining time until the provided timestamp.
+ */
+export const remainingTime = (
+  until: Date | number | string,
+  now: Date | number | string = Date.now(),
+): number => {
+  const target = toTimestamp(until);
+  const current = toTimestamp(now);
+
+  if (Number.isNaN(target) || Number.isNaN(current)) {
+    return Number.NaN;
+  }
+
+  return target - current;
+};
+
+/**
+ * Adds the specified amount of milliseconds to the given timestamp and
+ * returns a JavaScript `Date` instance representing the result.
+ */
+export const addMilliseconds = (
+  value: Date | number | string,
+  ms: number,
+): Date | null => {
+  const timestamp = toTimestamp(value);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Date(timestamp + ms);
+};


### PR DESCRIPTION
## Summary
- add reusable utilities for time math, Telegram retries, and compact callback identifiers
- introduce shared bot services (orders, pricing, geocode, cleanup, access, support, payments, verify) and common keyboard builders
- refactor taxi and delivery flows to rely on the new helpers for order summaries, pricing, and cleanup

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c92278e838832db083a783c3f0c62d