### PR TITLE
Add dedicated verify and drivers channel bindings

### DIFF
--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -24,6 +24,16 @@ CREATE TABLE IF NOT EXISTS users (
     UNIQUE (telegram_id)
 );
 
+CREATE TABLE IF NOT EXISTS channels (
+    id boolean PRIMARY KEY DEFAULT true,
+    verify_channel_id bigint,
+    drivers_channel_id bigint
+);
+
+INSERT INTO channels (id)
+VALUES (true)
+ON CONFLICT (id) DO NOTHING;
+
 CREATE TABLE IF NOT EXISTS verifications (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -55,39 +55,39 @@ const submitForModeration = async (
     return false;
   }
 
-  const moderation = await getChannelBinding('moderation');
-  if (!moderation) {
-    const message = await ctx.reply('Канал модерации пока не настроен. Попробуйте позже.');
+  const verifyChannel = await getChannelBinding('verify');
+  if (!verifyChannel) {
+    const message = await ctx.reply('Канал верификации пока не настроен. Попробуйте позже.');
     ctx.session.ephemeralMessages.push(message.message_id);
     return false;
   }
 
   try {
     const summary = buildModerationSummary(ctx, state);
-    const summaryMessage = await ctx.telegram.sendMessage(moderation.chatId, summary);
+    const summaryMessage = await ctx.telegram.sendMessage(verifyChannel.chatId, summary);
     state.verification.moderationThreadMessageId = summaryMessage.message_id;
 
     for (const photo of state.verification.uploadedPhotos) {
       try {
-        await ctx.telegram.copyMessage(moderation.chatId, chatId, photo.messageId);
+        await ctx.telegram.copyMessage(verifyChannel.chatId, chatId, photo.messageId);
       } catch (error) {
         logger.warn(
           {
             err: error,
-            chatId: moderation.chatId,
+            chatId: verifyChannel.chatId,
             userChatId: chatId,
             messageId: photo.messageId,
           },
-          'Failed to copy verification photo to moderation channel',
+          'Failed to copy verification photo to verification channel',
         );
       }
     }
   } catch (error) {
     logger.error(
-      { err: error, chatId: moderation.chatId },
-      'Failed to submit courier verification to moderation channel',
+      { err: error, chatId: verifyChannel.chatId },
+      'Failed to submit courier verification to verification channel',
     );
-    const message = await ctx.reply('Не удалось отправить документы на модерацию. Попробуйте позже.');
+    const message = await ctx.reply('Не удалось отправить документы на проверку. Попробуйте позже.');
     ctx.session.ephemeralMessages.push(message.message_id);
     return false;
   }

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -183,7 +183,7 @@ const buildPaymentMessage = (payment: PaymentReviewItem): string => {
 
 const queue: ModerationQueue<PaymentReviewItem> = createModerationQueue<PaymentReviewItem>({
   type: 'payment',
-  channelType: 'moderation',
+  channelType: 'verify',
   defaultRejectionReasons: DEFAULT_REASONS,
   renderMessage: buildPaymentMessage,
 });

--- a/src/bot/moderation/verifyQueue.ts
+++ b/src/bot/moderation/verifyQueue.ts
@@ -114,7 +114,7 @@ const buildVerificationMessage = (application: VerificationApplication): string 
 
 const queue: ModerationQueue<VerificationApplication> = createModerationQueue<VerificationApplication>({
   type: 'verify',
-  channelType: 'moderation',
+  channelType: 'verify',
   defaultRejectionReasons: DEFAULT_REASONS,
   renderMessage: buildVerificationMessage,
 });


### PR DESCRIPTION
## Summary
- add /bind_verify_channel and /bind_drivers_channel commands with updated usage hints
- migrate channel persistence to the new verify/drivers schema and align queue consumers
- seed the channels table in the base SQL so the bot can update bindings safely

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c92fdab9f0832db72451d46f750cd7