### PR TITLE
Add UI step helper with tracked cleanup

### DIFF
--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -1,4 +1,5 @@
 import { Telegraf } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import { publishOrderToDriversChannel, type PublishOrderStatus } from '../../../channels/ordersChannel';
 import { logger } from '../../../config';
@@ -20,6 +21,8 @@ import { rememberEphemeralMessage, clearInlineKeyboard } from '../../services/cl
 import { ensurePrivateCallback, isPrivateChat } from '../../services/access';
 import { buildConfirmCancelKeyboard } from '../../keyboards/common';
 import type { BotContext, ClientOrderDraftState } from '../../types';
+import { ui } from '../../ui';
+import { CLIENT_MENU_ACTION } from './menu';
 
 export const START_DELIVERY_ORDER_ACTION = 'client:order:delivery:start';
 const CONFIRM_DELIVERY_ORDER_ACTION = 'client:order:delivery:confirm';
@@ -27,21 +30,35 @@ const CANCEL_DELIVERY_ORDER_ACTION = 'client:order:delivery:cancel';
 
 const getDraft = (ctx: BotContext): ClientOrderDraftState => ctx.session.client.delivery;
 
+const DELIVERY_STEP_ID = 'client:delivery:step';
+
+const updateDeliveryStep = (
+  ctx: BotContext,
+  text: string,
+  keyboard?: InlineKeyboardMarkup,
+) =>
+  ui.step(ctx, {
+    id: DELIVERY_STEP_ID,
+    text,
+    keyboard,
+    homeAction: CLIENT_MENU_ACTION,
+  });
+
 const requestPickupAddress = async (ctx: BotContext): Promise<void> => {
-  const prompt = await ctx.reply(
+  await updateDeliveryStep(
+    ctx,
     [
       'Укажите адрес, откуда курьер заберёт посылку.',
       'Например: «Абылайхана 10, офис 5».',
     ].join('\n'),
   );
-  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
 const requestDropoffAddress = async (ctx: BotContext, pickup: CompletedOrderDraft['pickup']): Promise<void> => {
-  const prompt = await ctx.reply(
+  await updateDeliveryStep(
+    ctx,
     [`Адрес забора: ${pickup.address}.`, 'Теперь укажите адрес доставки.'].join('\n'),
   );
-  rememberEphemeralMessage(ctx, prompt.message_id);
 };
 
 const handleGeocodingFailure = async (ctx: BotContext): Promise<void> => {
@@ -77,8 +94,8 @@ const showConfirmation = async (ctx: BotContext, draft: CompletedOrderDraft): Pr
   });
 
   const keyboard = buildConfirmationKeyboard();
-  const message = await ctx.reply(summary, { reply_markup: keyboard });
-  draft.confirmationMessageId = message.message_id;
+  const result = await updateDeliveryStep(ctx, summary, keyboard);
+  draft.confirmationMessageId = result?.messageId;
 };
 
 const applyDropoffAddress = async (

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -1,10 +1,17 @@
 import { Markup, Telegraf } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import { getChannelBinding } from '../../../channels';
 import { logger } from '../../../config';
 import type { BotContext } from '../../types';
-import { EXECUTOR_SUBSCRIPTION_ACTION, ensureExecutorState, showExecutorMenu } from './menu';
+import {
+  EXECUTOR_MENU_ACTION,
+  EXECUTOR_SUBSCRIPTION_ACTION,
+  ensureExecutorState,
+  showExecutorMenu,
+} from './menu';
 import { getExecutorRoleCopy } from './roleCopy';
+import { ui } from '../../ui';
 
 const capitalise = (value: string): string =>
   value.length > 0 ? value[0].toUpperCase() + value.slice(1) : value;
@@ -45,15 +52,19 @@ export const registerExecutorSubscription = (bot: Telegraf<BotContext>): void =>
       state.subscription.lastInviteLink = invite.invite_link;
       state.subscription.lastIssuedAt = Date.now();
 
-      await ctx.reply(
-        [
+      const keyboard: InlineKeyboardMarkup = Markup.inlineKeyboard([
+        [Markup.button.url('Отправить заявку', invite.invite_link)],
+      ]).reply_markup;
+
+      await ui.step(ctx, {
+        id: 'executor:subscription:step',
+        text: [
           `Отправьте заявку на вступление в ${channelLabel} Freedom Bot.`,
           'После одобрения вы будете получать новые заказы и уведомления о сменах.',
         ].join('\n'),
-        Markup.inlineKeyboard([
-          [Markup.button.url('Отправить заявку', invite.invite_link)],
-        ]),
-      );
+        keyboard,
+        homeAction: EXECUTOR_MENU_ACTION,
+      });
     } catch (error) {
       logger.error(
         { err: error, chatId: binding.chatId, role: state.role },

--- a/src/bot/middlewares/auto-delete.ts
+++ b/src/bot/middlewares/auto-delete.ts
@@ -21,5 +21,31 @@ export const autoDelete = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     }
   }
 
+  if (
+    ctx.callbackQuery &&
+    'data' in ctx.callbackQuery &&
+    ctx.session.ui.homeActions.includes(ctx.callbackQuery.data)
+  ) {
+    const stepEntries = Object.entries(ctx.session.ui.steps);
+    if (stepEntries.length > 0) {
+      for (const [stepId, step] of stepEntries) {
+        if (!step || !step.cleanup) {
+          continue;
+        }
+
+        try {
+          await ctx.telegram.deleteMessage(step.chatId, step.messageId);
+        } catch (error) {
+          logger.debug(
+            { err: error, chatId: step.chatId, messageId: step.messageId, stepId },
+            'Failed to delete step message when navigating home',
+          );
+        }
+
+        delete ctx.session.ui.steps[stepId];
+      }
+    }
+  }
+
   await next();
 };

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -7,6 +7,7 @@ import {
   type ClientOrderDraftState,
   type ExecutorFlowState,
   type SessionState,
+  type UiSessionState,
 } from '../types';
 
 const createExecutorState = (): ExecutorFlowState => ({
@@ -28,12 +29,18 @@ const createClientState = (): ClientFlowState => ({
   delivery: createClientOrderDraft(),
 });
 
+const createUiState = (): UiSessionState => ({
+  steps: {},
+  homeActions: [],
+});
+
 const createDefaultState = (): SessionState => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
   executor: createExecutorState(),
   client: createClientState(),
+  ui: createUiState(),
 });
 
 const resolveSessionKey = (ctx: BotContext): string | undefined => {
@@ -66,6 +73,10 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
 
   const existing = store.get(key);
   const state = existing ?? createDefaultState();
+
+  if (!state.ui) {
+    state.ui = createUiState();
+  }
 
   ctx.session = state;
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -37,7 +37,6 @@ export interface ExecutorFlowState {
   role: ExecutorRole;
   verification: ExecutorVerificationState;
   subscription: ExecutorSubscriptionState;
-  menuMessageId?: number;
 }
 
 export type ClientOrderStage =
@@ -58,7 +57,17 @@ export interface ClientOrderDraftState {
 export interface ClientFlowState {
   taxi: ClientOrderDraftState;
   delivery: ClientOrderDraftState;
-  menuMessageId?: number;
+}
+
+export interface UiTrackedStepState {
+  chatId: number;
+  messageId: number;
+  cleanup: boolean;
+}
+
+export interface UiSessionState {
+  steps: Record<string, UiTrackedStepState | undefined>;
+  homeActions: string[];
 }
 
 export interface SessionState {
@@ -69,6 +78,7 @@ export interface SessionState {
   user?: SessionUser;
   executor: ExecutorFlowState;
   client: ClientFlowState;
+  ui: UiSessionState;
 }
 
 export type BotContext = Context & {

--- a/src/bot/ui.ts
+++ b/src/bot/ui.ts
@@ -1,0 +1,112 @@
+import type {
+  InlineKeyboardMarkup,
+  LinkPreviewOptions,
+  ParseMode,
+} from 'telegraf/typings/core/types/typegram';
+
+import { logger } from '../config';
+import { mergeInlineKeyboards, buildInlineKeyboard } from './keyboards/common';
+import type { BotContext, UiSessionState } from './types';
+
+const HOME_BUTTON_LABEL = '🏠 На главную';
+
+const ensureUiState = (ctx: BotContext): UiSessionState => {
+  if (!ctx.session.ui) {
+    ctx.session.ui = {
+      steps: {},
+      homeActions: [],
+    } satisfies UiSessionState;
+  }
+
+  return ctx.session.ui;
+};
+
+const registerHomeAction = (state: UiSessionState, action: string): void => {
+  if (!state.homeActions.includes(action)) {
+    state.homeActions.push(action);
+  }
+};
+
+const appendHomeButton = (
+  keyboard: InlineKeyboardMarkup | undefined,
+  action: string,
+  label = HOME_BUTTON_LABEL,
+): InlineKeyboardMarkup => {
+  const homeKeyboard = buildInlineKeyboard([[{ label, action }]]);
+  return mergeInlineKeyboards(keyboard, homeKeyboard) ?? homeKeyboard;
+};
+
+export interface UiStepOptions {
+  /** Unique identifier used to track the step message. */
+  id: string;
+  /** Text displayed in the step message. */
+  text: string;
+  /** Optional keyboard shown alongside the message. */
+  keyboard?: InlineKeyboardMarkup;
+  /** Parse mode used when sending the message. */
+  parseMode?: ParseMode;
+  /** Link preview behaviour configuration. */
+  linkPreviewOptions?: LinkPreviewOptions;
+  /**
+   * Action triggered when the user presses the automatically added
+   * «На главную» button. When omitted, the button is not rendered.
+   */
+  homeAction?: string;
+  /** Custom label for the «На главную» button. */
+  homeLabel?: string;
+  /** Whether the step should be removed when navigating home. */
+  cleanup?: boolean;
+}
+
+export interface UiStepResult {
+  /** Identifier of the Telegram message associated with the step. */
+  messageId: number;
+  /** Indicates whether a brand new message was sent. */
+  sent: boolean;
+}
+
+export const ui = {
+  step: async (ctx: BotContext, options: UiStepOptions): Promise<UiStepResult | undefined> => {
+    const chatId = ctx.chat?.id;
+    if (!chatId) {
+      return undefined;
+    }
+
+    const state = ensureUiState(ctx);
+    const cleanup = options.cleanup ?? Boolean(options.homeAction);
+
+    let replyMarkup = options.keyboard;
+    if (options.homeAction) {
+      registerHomeAction(state, options.homeAction);
+      replyMarkup = appendHomeButton(replyMarkup, options.homeAction, options.homeLabel);
+    }
+
+    const existing = state.steps[options.id];
+    if (existing && existing.chatId === chatId) {
+      try {
+        await ctx.telegram.editMessageText(chatId, existing.messageId, undefined, options.text, {
+          parse_mode: options.parseMode,
+          reply_markup: replyMarkup,
+          link_preview_options: options.linkPreviewOptions,
+        });
+        existing.cleanup = cleanup;
+        return { messageId: existing.messageId, sent: false };
+      } catch (error) {
+        logger.debug(
+          { err: error, chatId, messageId: existing.messageId, stepId: options.id },
+          'Failed to edit step message, sending a new one',
+        );
+      }
+    }
+
+    const message = await ctx.reply(options.text, {
+      reply_markup: replyMarkup,
+      parse_mode: options.parseMode,
+      link_preview_options: options.linkPreviewOptions,
+    });
+
+    const messageId = message.message_id;
+    state.steps[options.id] = { chatId, messageId, cleanup };
+    return { messageId, sent: true };
+  },
+};


### PR DESCRIPTION
## Summary
- add a reusable `ui.step` helper that edits existing messages, appends the "На главную" control and records home actions
- persist UI step metadata in session state and extend the auto-delete middleware to clean tracked steps when navigating home
- refactor client and executor flows to render menus and order steps through the helper for consistent cleanup behaviour

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9433b9058832d8d61863aad13300f