### PR TITLE
Refine executor verification for courier and driver roles

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -3,7 +3,7 @@ import { Markup, Telegraf } from 'telegraf';
 import type { BotContext } from '../types';
 import { phoneCollect } from '../utils/phone-collect';
 
-type RoleKey = 'client' | 'courier' | 'taxi_driver';
+type RoleKey = 'courier' | 'driver';
 
 interface RoleOption {
   key: RoleKey;
@@ -13,18 +13,13 @@ interface RoleOption {
 
 const ROLE_OPTIONS: RoleOption[] = [
   {
-    key: 'client',
-    label: '🧑‍💼 Я клиент',
-    description: 'Оформление заказов на доставку и такси.',
-  },
-  {
     key: 'courier',
     label: '🚚 Я курьер',
     description: 'Получение заказов на доставку и управление сменами.',
   },
   {
-    key: 'taxi_driver',
-    label: '🚕 Я водитель такси',
+    key: 'driver',
+    label: '🚗 Я водитель',
     description: 'Получение заказов на поездки и управление сменами.',
   },
 ];

--- a/src/bot/flows/executor/roleCopy.ts
+++ b/src/bot/flows/executor/roleCopy.ts
@@ -18,11 +18,11 @@ const ROLE_COPY: Record<ExecutorRole, ExecutorRoleCopy> = {
     genitive: 'курьера',
     pluralGenitive: 'курьеров',
   },
-  taxi_driver: {
-    emoji: '🚕',
-    noun: 'водитель такси',
-    genitive: 'водителя такси',
-    pluralGenitive: 'водителей такси',
+  driver: {
+    emoji: '🚗',
+    noun: 'водитель',
+    genitive: 'водителя',
+    pluralGenitive: 'водителей',
   },
 };
 

--- a/src/bot/flows/executor/roleSelect.ts
+++ b/src/bot/flows/executor/roleSelect.ts
@@ -6,7 +6,7 @@ import { ensureExecutorState, showExecutorMenu } from './menu';
 import { getExecutorRoleCopy } from './roleCopy';
 
 const ROLE_COURIER_ACTION = 'role:courier';
-const ROLE_TAXI_DRIVER_ACTION = 'role:taxi_driver';
+const ROLE_DRIVER_ACTION = 'role:driver';
 
 const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise<void> => {
   if (ctx.chat?.type !== 'private') {
@@ -37,7 +37,7 @@ export const registerExecutorRoleSelect = (bot: Telegraf<BotContext>): void => {
     await handleRoleSelection(ctx, 'courier');
   });
 
-  bot.action(ROLE_TAXI_DRIVER_ACTION, async (ctx) => {
-    await handleRoleSelection(ctx, 'taxi_driver');
+  bot.action(ROLE_DRIVER_ACTION, async (ctx) => {
+    await handleRoleSelection(ctx, 'driver');
   });
 };

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -27,8 +27,9 @@ export const registerExecutorSubscription = (bot: Telegraf<BotContext>): void =>
     const state = ensureExecutorState(ctx);
     const copy = getExecutorRoleCopy(state.role);
     const channelLabel = `канал ${copy.pluralGenitive}`;
+    const verification = state.verification[state.role];
 
-    if (state.verification.status !== 'submitted') {
+    if (verification.status !== 'submitted') {
       const message = await ctx.reply('Сначала завершите проверку документов, чтобы получить ссылку на канал.');
       ctx.session.ephemeralMessages.push(message.message_id);
       return;

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -1,22 +1,32 @@
 import type { MiddlewareFn } from 'telegraf';
 
 import {
+  EXECUTOR_ROLES,
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
   type BotContext,
   type ClientFlowState,
   type ClientOrderDraftState,
   type ExecutorFlowState,
+  type ExecutorVerificationState,
   type SessionState,
   type UiSessionState,
 } from '../types';
 
+const createVerificationState = (): ExecutorVerificationState => {
+  const verification = {} as ExecutorVerificationState;
+  for (const role of EXECUTOR_ROLES) {
+    verification[role] = {
+      status: 'idle',
+      requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+      uploadedPhotos: [],
+    };
+  }
+  return verification;
+};
+
 const createExecutorState = (): ExecutorFlowState => ({
   role: 'courier',
-  verification: {
-    status: 'idle',
-    requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
-    uploadedPhotos: [],
-  },
+  verification: createVerificationState(),
   subscription: {},
 });
 

--- a/src/bot/services/verify.ts
+++ b/src/bot/services/verify.ts
@@ -16,13 +16,12 @@ export const buildVerificationPrompt = (
 ): string => {
   const required = Math.max(1, options.requiredPhotos ?? EXECUTOR_VERIFICATION_PHOTO_COUNT);
   const lines = [
-    'Для доступа к заказам пришлите фотографии документов:',
-    '1. Удостоверение личности — лицевая сторона.',
-    '2. Удостоверение личности — обратная сторона.',
-    '3. Селфи с удостоверением в руках.',
+    `Для доступа к заказам пришлите ${required} фотографии документов:`,
+    '1. Фото удостоверения личности (лицевая сторона).',
+    '2. Селфи с удостоверением в руках.',
   ];
 
-  if (required > 3) {
+  if (required > 2) {
     lines.push(`Дополнительно требуется всего фотографий: ${required}.`);
   }
 
@@ -41,8 +40,10 @@ export const buildVerificationSummary = (
 ): string => {
   const applicant = ctx.session.user;
   const copy = getExecutorRoleCopy(state.role);
+  const verification = state.verification[state.role];
   const lines = [
     `🆕 Новая заявка на верификацию ${copy.genitive}.`,
+    `Роль: ${copy.noun} (${state.role})`,
     `Telegram ID: ${ctx.from?.id ?? 'неизвестно'}`,
   ];
 
@@ -63,11 +64,11 @@ export const buildVerificationSummary = (
     lines.push(`Телефон: ${ctx.session.phoneNumber}`);
   }
 
-  const uploaded = options.photoCount ?? state.verification.uploadedPhotos.length;
-  lines.push(`Фотографии: ${uploaded}/${state.verification.requiredPhotos}.`);
+  const uploaded = options.photoCount ?? verification.uploadedPhotos.length;
+  lines.push(`Фотографии: ${uploaded}/${verification.requiredPhotos}.`);
 
-  if (state.verification.submittedAt) {
-    lines.push(`Отправлено: ${new Date(state.verification.submittedAt).toLocaleString('ru-RU')}`);
+  if (verification.submittedAt) {
+    lines.push(`Отправлено: ${new Date(verification.submittedAt).toLocaleString('ru-RU')}`);
   }
 
   return lines.join('\n');
@@ -78,11 +79,12 @@ export const remainingVerificationCooldown = (
   now = Date.now(),
   cooldownMs = DEFAULT_COOLDOWN_MS,
 ): number => {
-  if (!state.verification.submittedAt) {
+  const verification = state.verification[state.role];
+  if (!verification.submittedAt) {
     return 0;
   }
 
-  const until = state.verification.submittedAt + cooldownMs;
+  const until = verification.submittedAt + cooldownMs;
   return Math.max(0, remainingTime(until, now) ?? 0);
 };
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -2,7 +2,11 @@ import type { Context } from 'telegraf';
 
 import type { OrderLocation, OrderPriceDetails } from '../types';
 
-export const EXECUTOR_VERIFICATION_PHOTO_COUNT = 3;
+export const EXECUTOR_VERIFICATION_PHOTO_COUNT = 2;
+
+export type ExecutorRole = 'courier' | 'driver';
+
+export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
 
 export interface SessionUser {
   id: number;
@@ -18,7 +22,7 @@ export interface ExecutorUploadedPhoto {
 
 export type ExecutorVerificationStatus = 'idle' | 'collecting' | 'submitted';
 
-export interface ExecutorVerificationState {
+export interface ExecutorVerificationRoleState {
   status: ExecutorVerificationStatus;
   requiredPhotos: number;
   uploadedPhotos: ExecutorUploadedPhoto[];
@@ -31,7 +35,7 @@ export interface ExecutorSubscriptionState {
   lastIssuedAt?: number;
 }
 
-export type ExecutorRole = 'courier' | 'taxi_driver';
+export type ExecutorVerificationState = Record<ExecutorRole, ExecutorVerificationRoleState>;
 
 export interface ExecutorFlowState {
   role: ExecutorRole;


### PR DESCRIPTION
## Summary
- limit role selection to courier and driver and refresh driver-facing copy
- rework executor verification to track two required photos per role with role-specific prompts and moderation summaries
- align session defaults, subscription gating, and verification helpers with the per-role workflow

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c951674a5c832d8a5a0cdcb6db5dea