### PR TITLE
Implement subscription payment moderation flow

### DIFF
--- a/src/bot/channels/joinRequests.ts
+++ b/src/bot/channels/joinRequests.ts
@@ -2,6 +2,7 @@ import { Telegraf } from 'telegraf';
 import type { ChatJoinRequest } from 'telegraf/typings/core/types/typegram';
 
 import { logger } from '../../config';
+import { hasActiveSubscription } from '../../db/subscriptions';
 import type { BotContext } from '../types';
 
 export interface JoinRequestDecisionContext {
@@ -22,7 +23,8 @@ export interface JoinRequestsOptions {
   onDecline?: (context: JoinRequestDecisionContext) => void | Promise<void>;
 }
 
-const defaultChecker: SubscriptionChecker = async () => false;
+const defaultChecker: SubscriptionChecker = async (userId, chatId) =>
+  hasActiveSubscription(chatId, userId);
 
 const formatUserForLog = (request: ChatJoinRequest): string => {
   const username = request.from.username ? `@${request.from.username}` : undefined;

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -1,7 +1,11 @@
 import { Markup, Telegraf } from 'telegraf';
-import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+import type {
+  Document,
+  InlineKeyboardMarkup,
+  Message,
+  PhotoSize,
+} from 'telegraf/typings/core/types/typegram';
 
-import { getChannelBinding } from '../../channels/bindings';
 import { logger } from '../../../config';
 import type { BotContext } from '../../types';
 import {
@@ -12,9 +16,243 @@ import {
 } from './menu';
 import { getExecutorRoleCopy } from './roleCopy';
 import { ui } from '../../ui';
+import {
+  SUBSCRIPTION_PERIOD_OPTIONS,
+  findSubscriptionPeriodOption,
+  formatSubscriptionAmount,
+  type SubscriptionPeriodOption,
+} from './subscriptionPlans';
+import { createShortId } from '../../../utils/ids';
+import { submitSubscriptionPaymentReview } from '../../moderation/paymentQueue';
 
-const capitalise = (value: string): string =>
-  value.length > 0 ? value[0].toUpperCase() + value.slice(1) : value;
+const SUBSCRIPTION_PERIOD_ACTION_PREFIX = 'executor:subscription:period';
+
+const KASPI_DETAILS = [
+  'Получатель: Freedom Bot',
+  'Kaspi Gold: 4400 4301 2345 6789',
+  'Телефон: +7 (700) 000-00-00',
+  'Комментарий: Подписка Freedom Bot',
+];
+
+const formatKaspiDetails = (): string[] => [
+  'Оплатите через Kaspi по реквизитам:',
+  ...KASPI_DETAILS,
+];
+
+const buildPeriodKeyboard = (): InlineKeyboardMarkup =>
+  Markup.inlineKeyboard(
+    SUBSCRIPTION_PERIOD_OPTIONS.map((option) =>
+      Markup.button.callback(
+        `${option.label} — ${formatSubscriptionAmount(option.amount, option.currency)}`,
+        `${SUBSCRIPTION_PERIOD_ACTION_PREFIX}:${option.id}`,
+      ),
+    ),
+  ).reply_markup;
+
+const buildSelectionText = (roleCopy: ReturnType<typeof getExecutorRoleCopy>): string => {
+  const lines = [
+    `${roleCopy.emoji} Подписка Freedom Bot для ${roleCopy.genitive}`,
+    '',
+    'Выберите период подписки и оплатите подходящий вариант.',
+    ...SUBSCRIPTION_PERIOD_OPTIONS.map(
+      (option) => `• ${option.label} — ${formatSubscriptionAmount(option.amount, option.currency)}`,
+    ),
+    '',
+    ...formatKaspiDetails(),
+    '',
+    'После оплаты отправьте чек в этот чат, мы проверим его и пришлём ссылку на канал.',
+  ];
+
+  return lines.join('\n');
+};
+
+const showSubscriptionStep = async (ctx: BotContext): Promise<void> => {
+  const state = ensureExecutorState(ctx);
+  const verification = state.verification[state.role];
+  const copy = getExecutorRoleCopy(state.role);
+
+  if (verification.status !== 'submitted') {
+    const message = await ctx.reply(
+      'Сначала завершите проверку документов, чтобы получить ссылку на канал.',
+    );
+    ctx.session.ephemeralMessages.push(message.message_id);
+    return;
+  }
+
+  state.subscription.status = 'selectingPeriod';
+  state.subscription.selectedPeriodId = undefined;
+  state.subscription.pendingPaymentId = undefined;
+
+  const keyboard = buildPeriodKeyboard();
+  const text = buildSelectionText(copy);
+
+  await ui.step(ctx, {
+    id: 'executor:subscription:step',
+    text,
+    keyboard,
+    homeAction: EXECUTOR_MENU_ACTION,
+  });
+};
+
+const buildPeriodConfirmationMessage = (
+  period: SubscriptionPeriodOption,
+  roleCopy: ReturnType<typeof getExecutorRoleCopy>,
+): string => {
+  const lines = [
+    `Вы выбрали подписку на ${period.label} для ${roleCopy.genitive}.`,
+    `Сумма к оплате: ${formatSubscriptionAmount(period.amount, period.currency)}.`,
+    '',
+    ...formatKaspiDetails(),
+    '',
+    'Отправьте чек об оплате в этот чат. После подтверждения модераторами мы пришлём ссылку на канал.',
+  ];
+
+  return lines.join('\n');
+};
+
+const handlePeriodSelection = async (
+  ctx: BotContext,
+  periodId: string,
+): Promise<void> => {
+  const period = findSubscriptionPeriodOption(periodId);
+  if (!period) {
+    await ctx.answerCbQuery('Неизвестный период подписки.');
+    return;
+  }
+
+  const state = ensureExecutorState(ctx);
+  state.subscription.status = 'awaitingReceipt';
+  state.subscription.selectedPeriodId = period.id;
+  state.subscription.pendingPaymentId = undefined;
+
+  await ctx.answerCbQuery(`Период: ${period.label}`);
+
+  const copy = getExecutorRoleCopy(state.role);
+  const confirmation = await ctx.reply(buildPeriodConfirmationMessage(period, copy));
+  ctx.session.ephemeralMessages.push(confirmation.message_id);
+
+  await showExecutorMenu(ctx);
+};
+
+interface ReceiptPayload {
+  type: 'photo' | 'document';
+  fileId: string;
+}
+
+const extractReceipt = (message: Message): ReceiptPayload | null => {
+  if ('photo' in message && Array.isArray(message.photo) && message.photo.length > 0) {
+    const photoSizes = message.photo as PhotoSize[];
+    const bestPhoto = photoSizes[photoSizes.length - 1];
+    return { type: 'photo', fileId: bestPhoto.file_id } satisfies ReceiptPayload;
+  }
+
+  if ('document' in message && message.document) {
+    const document = message.document as Document;
+    return { type: 'document', fileId: document.file_id } satisfies ReceiptPayload;
+  }
+
+  return null;
+};
+
+const notifyReceiptAccepted = async (ctx: BotContext): Promise<void> => {
+  const message = await ctx.reply(
+    'Спасибо! Мы передали чек модераторам. Ожидайте решения, и мы пришлём ссылку после одобрения.',
+  );
+  ctx.session.ephemeralMessages.push(message.message_id);
+};
+
+const notifyReceiptFailed = async (ctx: BotContext): Promise<void> => {
+  const message = await ctx.reply('Не удалось отправить чек на проверку. Попробуйте позже.');
+  ctx.session.ephemeralMessages.push(message.message_id);
+};
+
+const buildPaymentId = (): string => `manual-${Date.now()}-${createShortId({ length: 6 })}`;
+
+const handleReceiptUpload = async (ctx: BotContext): Promise<void> => {
+  if (ctx.chat?.type !== 'private') {
+    return;
+  }
+
+  const message = ctx.message;
+  if (!message) {
+    return;
+  }
+
+  const state = ensureExecutorState(ctx);
+  const subscription = state.subscription;
+
+  if (subscription.status !== 'awaitingReceipt') {
+    return;
+  }
+
+  const period = findSubscriptionPeriodOption(subscription.selectedPeriodId);
+  if (!period) {
+    const reminder = await ctx.reply('Выберите период подписки с помощью кнопок в меню.');
+    ctx.session.ephemeralMessages.push(reminder.message_id);
+    return;
+  }
+
+  const receipt = extractReceipt(message);
+  if (!receipt) {
+    const reminder = await ctx.reply('Отправьте, пожалуйста, фотографию или файл с чеком.');
+    ctx.session.ephemeralMessages.push(reminder.message_id);
+    return;
+  }
+
+  if (!ctx.from) {
+    const reminder = await ctx.reply('Не удалось определить отправителя. Попробуйте ещё раз позже.');
+    ctx.session.ephemeralMessages.push(reminder.message_id);
+    return;
+  }
+
+  const paymentId = buildPaymentId();
+  subscription.pendingPaymentId = paymentId;
+
+  try {
+    const result = await submitSubscriptionPaymentReview(ctx.telegram, {
+      paymentId,
+      period,
+      submittedAt: new Date(),
+      executor: {
+        role: state.role,
+        telegramId: ctx.from.id,
+        chatId: ctx.chat.id,
+        username: ctx.from.username ?? undefined,
+        firstName: ctx.from.first_name ?? undefined,
+        lastName: ctx.from.last_name ?? undefined,
+        phone: ctx.session.phoneNumber ?? undefined,
+      },
+      receipt: {
+        chatId: ctx.chat.id,
+        messageId: message.message_id,
+        fileId: receipt.fileId,
+        type: receipt.type,
+      },
+    });
+
+    if (result.status === 'missing_channel') {
+      subscription.status = 'awaitingReceipt';
+      subscription.pendingPaymentId = undefined;
+      await notifyReceiptFailed(ctx);
+      return;
+    }
+
+    subscription.status = 'pendingModeration';
+    subscription.moderationChatId = result.chatId;
+    subscription.moderationMessageId = result.messageId;
+
+    await notifyReceiptAccepted(ctx);
+    await showExecutorMenu(ctx);
+  } catch (error) {
+    logger.error(
+      { err: error, paymentId, telegramId: ctx.from.id },
+      'Failed to submit subscription payment for moderation',
+    );
+    subscription.status = 'awaitingReceipt';
+    subscription.pendingPaymentId = undefined;
+    await notifyReceiptFailed(ctx);
+  }
+};
 
 export const registerExecutorSubscription = (bot: Telegraf<BotContext>): void => {
   bot.action(EXECUTOR_SUBSCRIPTION_ACTION, async (ctx) => {
@@ -24,58 +262,31 @@ export const registerExecutorSubscription = (bot: Telegraf<BotContext>): void =>
     }
 
     await ctx.answerCbQuery();
-    const state = ensureExecutorState(ctx);
-    const copy = getExecutorRoleCopy(state.role);
-    const channelLabel = `канал ${copy.pluralGenitive}`;
-    const verification = state.verification[state.role];
+    await showSubscriptionStep(ctx);
+  });
 
-    if (verification.status !== 'submitted') {
-      const message = await ctx.reply('Сначала завершите проверку документов, чтобы получить ссылку на канал.');
-      ctx.session.ephemeralMessages.push(message.message_id);
+  const periodPattern = new RegExp(`^${SUBSCRIPTION_PERIOD_ACTION_PREFIX}:(\\d+)$`);
+  bot.action(periodPattern, async (ctx) => {
+    if (ctx.chat?.type !== 'private') {
+      await ctx.answerCbQuery('Доступно только в личных сообщениях.');
       return;
     }
 
-    const binding = await getChannelBinding('drivers');
-    if (!binding) {
-      const message = await ctx.reply(
-        `${capitalise(channelLabel)} пока не настроен. Попробуйте позже.`,
-      );
-      ctx.session.ephemeralMessages.push(message.message_id);
+    const match = ctx.match as RegExpMatchArray | undefined;
+    const periodId = match?.[1];
+    if (!periodId) {
+      await ctx.answerCbQuery('Некорректный выбор.');
       return;
     }
 
-    try {
-      const invite = await ctx.telegram.createChatInviteLink(binding.chatId, {
-        creates_join_request: true,
-        name: `Executor onboarding ${ctx.from?.id ?? ''}`.trim(),
-      });
+    await handlePeriodSelection(ctx, periodId);
+  });
 
-      state.subscription.lastInviteLink = invite.invite_link;
-      state.subscription.lastIssuedAt = Date.now();
+  bot.on('photo', async (ctx) => {
+    await handleReceiptUpload(ctx);
+  });
 
-      const keyboard: InlineKeyboardMarkup = Markup.inlineKeyboard([
-        [Markup.button.url('Отправить заявку', invite.invite_link)],
-      ]).reply_markup;
-
-      await ui.step(ctx, {
-        id: 'executor:subscription:step',
-        text: [
-          `Отправьте заявку на вступление в ${channelLabel} Freedom Bot.`,
-          'После одобрения вы будете получать новые заказы и уведомления о сменах.',
-        ].join('\n'),
-        keyboard,
-        homeAction: EXECUTOR_MENU_ACTION,
-      });
-    } catch (error) {
-      logger.error(
-        { err: error, chatId: binding.chatId, role: state.role },
-        'Failed to create executor channel invite link',
-      );
-      const message = await ctx.reply('Не удалось создать ссылку на канал. Попробуйте позже.');
-      ctx.session.ephemeralMessages.push(message.message_id);
-      return;
-    }
-
-    await showExecutorMenu(ctx);
+  bot.on('document', async (ctx) => {
+    await handleReceiptUpload(ctx);
   });
 };

--- a/src/bot/flows/executor/subscriptionPlans.ts
+++ b/src/bot/flows/executor/subscriptionPlans.ts
@@ -1,0 +1,46 @@
+export interface SubscriptionPeriodOption {
+  id: string;
+  /** Human-readable label describing the duration. */
+  label: string;
+  /** Number of days covered by the payment. */
+  days: number;
+  /** Subscription price in Kazakhstani tenge. */
+  amount: number;
+  /** Currency code used for the payment. */
+  currency: string;
+}
+
+export const SUBSCRIPTION_PERIOD_OPTIONS: readonly SubscriptionPeriodOption[] = [
+  {
+    id: '7',
+    label: '7 дней',
+    days: 7,
+    amount: 5000,
+    currency: 'KZT',
+  },
+  {
+    id: '15',
+    label: '15 дней',
+    days: 15,
+    amount: 9000,
+    currency: 'KZT',
+  },
+  {
+    id: '30',
+    label: '30 дней',
+    days: 30,
+    amount: 16000,
+    currency: 'KZT',
+  },
+] as const;
+
+export const findSubscriptionPeriodOption = (
+  id: string | undefined,
+): SubscriptionPeriodOption | undefined =>
+  SUBSCRIPTION_PERIOD_OPTIONS.find((option) => option.id === id);
+
+export const formatSubscriptionAmount = (
+  amount: number,
+  currency: string,
+): string =>
+  `${new Intl.NumberFormat('ru-RU').format(amount)} ${currency}`;

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -7,6 +7,7 @@ import {
   type ClientFlowState,
   type ClientOrderDraftState,
   type ExecutorFlowState,
+  type ExecutorSubscriptionState,
   type ExecutorVerificationState,
   type SessionState,
   type UiSessionState,
@@ -24,10 +25,14 @@ const createVerificationState = (): ExecutorVerificationState => {
   return verification;
 };
 
+const createSubscriptionState = (): ExecutorSubscriptionState => ({
+  status: 'idle',
+});
+
 const createExecutorState = (): ExecutorFlowState => ({
   role: 'courier',
   verification: createVerificationState(),
-  subscription: {},
+  subscription: createSubscriptionState(),
 });
 
 const createClientOrderDraft = (): ClientOrderDraftState => ({

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -1,12 +1,19 @@
 import { Telegraf, Telegram } from 'telegraf';
 
-import type { BotContext } from '../types';
+import { logger } from '../../config';
+import { activateSubscription } from '../../db/subscriptions';
+import { getChannelBinding } from '../channels/bindings';
+import { getExecutorRoleCopy } from '../flows/executor/roleCopy';
+import type { BotContext, ExecutorRole } from '../types';
 import {
   createModerationQueue,
+  type ModerationDecisionContext,
   type ModerationQueue,
   type ModerationQueueItemBase,
+  type ModerationRejectionContext,
   type PublishModerationResult,
 } from './queue';
+import type { SubscriptionPeriodOption } from '../flows/executor/subscriptionPlans';
 
 const DEFAULT_TITLE = '💳 Проверка платежа по подписке';
 const DEFAULT_REASONS = [
@@ -55,6 +62,32 @@ export interface PaymentPayer {
   phone?: string;
 }
 
+interface SubscriptionReceiptInfo {
+  chatId: number;
+  messageId: number;
+  fileId: string;
+  type: 'photo' | 'document';
+}
+
+interface SubscriptionPaymentMetadata {
+  role: ExecutorRole;
+  telegramId: number;
+  chatId: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  period: SubscriptionPeriodOption;
+  paymentId: string;
+  submittedAt: Date;
+  receipt: SubscriptionReceiptInfo;
+  moderation?: {
+    chatId?: number;
+    messageId?: number;
+    token?: string;
+  };
+}
+
 export interface PaymentReviewItem extends ModerationQueueItemBase<PaymentReviewItem> {
   /** Identifier of the payment under review. */
   id: string | number;
@@ -78,6 +111,24 @@ export interface PaymentReviewItem extends ModerationQueueItemBase<PaymentReview
   notes?: string[];
   /** Optional summary text inserted before the notes. */
   summary?: string | string[];
+  /** Additional subscription context used when processing moderation decisions. */
+  subscription?: SubscriptionPaymentMetadata;
+}
+
+export interface SubscriptionPaymentRequest {
+  paymentId: string;
+  period: SubscriptionPeriodOption;
+  submittedAt: Date;
+  executor: {
+    role: ExecutorRole;
+    telegramId: number;
+    chatId: number;
+    username?: string;
+    firstName?: string;
+    lastName?: string;
+    phone?: string;
+  };
+  receipt: SubscriptionReceiptInfo;
 }
 
 const buildPayerSection = (payer?: PaymentPayer): string[] => {
@@ -181,6 +232,222 @@ const buildPaymentMessage = (payment: PaymentReviewItem): string => {
   return lines.join('\n');
 };
 
+const estimatePeriodEnd = (start: Date, days: number): Date =>
+  new Date(start.getTime() + days * 24 * 60 * 60 * 1000);
+
+const createSubscriptionPaymentReviewItem = (
+  request: SubscriptionPaymentRequest,
+): PaymentReviewItem => {
+  const submittedAt = request.submittedAt ?? new Date();
+  const periodEnd = estimatePeriodEnd(submittedAt, request.period.days);
+  const roleCopy = getExecutorRoleCopy(request.executor.role);
+  const summaryLines = [
+    `Исполнитель: ${roleCopy.noun} (${request.executor.role})`,
+    `Период: ${request.period.label}`,
+    `Отправлено: ${formatDateTime(submittedAt) ?? 'неизвестно'}`,
+  ];
+
+  const notes: string[] = [];
+  if (request.executor.phone) {
+    notes.push(`Контактный телефон: ${request.executor.phone}`);
+  }
+  notes.push('Чек прикреплён отдельным сообщением.');
+
+  return {
+    id: request.paymentId,
+    title: `💳 Оплата подписки (${request.period.label})`,
+    amount: { value: request.period.amount, currency: request.period.currency },
+    payer: {
+      telegramId: request.executor.telegramId,
+      username: request.executor.username,
+      firstName: request.executor.firstName,
+      lastName: request.executor.lastName,
+      phone: request.executor.phone,
+    },
+    description: 'Квитанция приложена отдельным сообщением ниже.',
+    paidAt: submittedAt,
+    period: { start: submittedAt, end: periodEnd },
+    summary: summaryLines,
+    notes,
+    subscription: {
+      role: request.executor.role,
+      telegramId: request.executor.telegramId,
+      chatId: request.executor.chatId,
+      username: request.executor.username,
+      firstName: request.executor.firstName,
+      lastName: request.executor.lastName,
+      phone: request.executor.phone,
+      period: request.period,
+      paymentId: request.paymentId,
+      submittedAt,
+      receipt: request.receipt,
+    },
+  } satisfies PaymentReviewItem;
+};
+
+const copyReceiptToModerationChannel = async (
+  telegram: Telegram,
+  receipt: SubscriptionReceiptInfo,
+  targetChatId: number,
+  paymentId: string,
+): Promise<void> => {
+  try {
+    await telegram.copyMessage(targetChatId, receipt.chatId, receipt.messageId);
+  } catch (error) {
+    logger.warn(
+      { err: error, chatId: targetChatId, paymentId },
+      'Failed to copy subscription receipt to moderation channel',
+    );
+  }
+};
+
+const handleSubscriptionApproval = async (
+  context: ModerationDecisionContext<PaymentReviewItem>,
+): Promise<void> => {
+  const { item, telegram } = context;
+  const subscription = item.subscription;
+  if (!subscription) {
+    return;
+  }
+
+  const binding = await getChannelBinding('drivers');
+  if (!binding) {
+    logger.error(
+      { paymentId: item.id },
+      'Drivers channel is not configured, cannot issue invite link',
+    );
+    if (subscription.telegramId) {
+      try {
+        await telegram.sendMessage(
+          subscription.telegramId,
+          'Оплата подтверждена, но канал Freedom Bot временно недоступен. Мы свяжемся с вами после настройки.',
+        );
+      } catch (error) {
+        logger.error(
+          { err: error, paymentId: item.id, telegramId: subscription.telegramId },
+          'Failed to notify user about missing drivers channel',
+        );
+      }
+    }
+    return;
+  }
+
+  const paymentMetadata: Record<string, unknown> = {
+    receipt: {
+      type: subscription.receipt.type,
+      fileId: subscription.receipt.fileId,
+      chatId: subscription.receipt.chatId,
+      messageId: subscription.receipt.messageId,
+    },
+    moderation: subscription.moderation,
+    source: 'manual_review',
+  };
+
+  let activation;
+  try {
+    activation = await activateSubscription({
+      telegramId: subscription.telegramId,
+      username: subscription.username,
+      firstName: subscription.firstName,
+      lastName: subscription.lastName,
+      phone: subscription.phone,
+      chatId: binding.chatId,
+      periodDays: subscription.period.days,
+      periodLabel: subscription.period.label,
+      amount: item.amount.value,
+      currency: item.amount.currency,
+      paymentId: subscription.paymentId,
+      submittedAt: subscription.submittedAt,
+      paymentMetadata,
+    });
+  } catch (error) {
+    logger.error(
+      { err: error, paymentId: item.id, telegramId: subscription.telegramId },
+      'Failed to activate subscription after payment approval',
+    );
+    if (subscription.telegramId) {
+      try {
+        await telegram.sendMessage(
+          subscription.telegramId,
+          'Оплата подтверждена, но не удалось активировать подписку. Свяжитесь с поддержкой, пожалуйста.',
+        );
+      } catch (notifyError) {
+        logger.error(
+          { err: notifyError, paymentId: item.id, telegramId: subscription.telegramId },
+          'Failed to notify user about activation failure',
+        );
+      }
+    }
+    return;
+  }
+
+  let inviteLink: string | undefined;
+  try {
+    const invite = await telegram.createChatInviteLink(binding.chatId, {
+      creates_join_request: true,
+      name: `Subscription ${subscription.telegramId} ${subscription.period.days}d`,
+    });
+    inviteLink = invite.invite_link;
+  } catch (error) {
+    logger.error(
+      { err: error, paymentId: item.id, chatId: binding.chatId },
+      'Failed to create invite link after subscription activation',
+    );
+  }
+
+  if (!subscription.telegramId) {
+    return;
+  }
+
+  const roleCopy = getExecutorRoleCopy(subscription.role);
+  const expiresLabel = activation.nextBillingAt
+    ? formatDateTime(activation.nextBillingAt)
+    : undefined;
+
+  const parts = [
+    '✅ Оплата подписки подтверждена.',
+    expiresLabel ? `Подписка активна до ${expiresLabel}.` : undefined,
+    inviteLink
+      ? `Чтобы вступить в ${roleCopy.pluralGenitive}, отправьте заявку: ${inviteLink}`
+      : 'Ссылка на канал будет отправлена дополнительно. Свяжитесь с поддержкой, если не получили её в ближайшее время.',
+    'Если ссылка перестанет работать, запросите новую через меню «Получить ссылку на канал».',
+  ].filter((value): value is string => Boolean(value && value.trim().length > 0));
+
+  try {
+    await telegram.sendMessage(subscription.telegramId, parts.join('\n'));
+  } catch (error) {
+    logger.error(
+      { err: error, paymentId: item.id, telegramId: subscription.telegramId },
+      'Failed to notify user about approved subscription payment',
+    );
+  }
+};
+
+const handleSubscriptionRejection = async (
+  context: ModerationRejectionContext<PaymentReviewItem>,
+): Promise<void> => {
+  const { item, telegram, reason } = context;
+  const subscription = item.subscription;
+  if (!subscription?.telegramId) {
+    return;
+  }
+
+  const message = [
+    '❌ Оплата подписки не подтверждена.',
+    `Причина: ${reason}.`,
+    'Проверьте данные и отправьте новый чек через меню «Получить ссылку на канал».',
+  ].join('\n');
+
+  try {
+    await telegram.sendMessage(subscription.telegramId, message);
+  } catch (error) {
+    logger.error(
+      { err: error, paymentId: item.id, telegramId: subscription.telegramId },
+      'Failed to notify user about rejected subscription payment',
+    );
+  }
+};
+
 const queue: ModerationQueue<PaymentReviewItem> = createModerationQueue<PaymentReviewItem>({
   type: 'payment',
   channelType: 'verify',
@@ -192,6 +459,36 @@ export const publishPaymentReview = async (
   telegram: Telegram,
   payment: PaymentReviewItem,
 ): Promise<PublishModerationResult> => queue.publish(telegram, payment);
+
+export const submitSubscriptionPaymentReview = async (
+  telegram: Telegram,
+  request: SubscriptionPaymentRequest,
+): Promise<PublishModerationResult> => {
+  const payment = createSubscriptionPaymentReviewItem(request);
+  payment.onApprove = handleSubscriptionApproval;
+  payment.onReject = handleSubscriptionRejection;
+
+  const result = await queue.publish(telegram, payment);
+
+  if (result.status === 'published' && payment.subscription) {
+    payment.subscription.moderation = {
+      chatId: result.chatId,
+      messageId: result.messageId,
+      token: result.token,
+    };
+
+    if (result.chatId !== undefined) {
+      await copyReceiptToModerationChannel(
+        telegram,
+        payment.subscription.receipt,
+        result.chatId,
+        request.paymentId,
+      );
+    }
+  }
+
+  return result;
+};
 
 export const registerPaymentModerationQueue = (bot: Telegraf<BotContext>): void => {
   queue.register(bot);

--- a/src/bot/moderation/queue.ts
+++ b/src/bot/moderation/queue.ts
@@ -171,6 +171,7 @@ export interface ModerationDecisionContext<T> {
   item: T;
   moderator: ModeratorInfo;
   decidedAt: number;
+  telegram: Telegram;
 }
 
 export interface ModerationRejectionContext<T> extends ModerationDecisionContext<T> {
@@ -350,14 +351,16 @@ export const createModerationQueue = <T extends ModerationQueueItemBase<T>>(
           item: entry.item,
           moderator,
           decidedAt,
-        } as ModerationDecisionContext<T>);
+          telegram: ctx.telegram,
+        });
       } else {
         await entry.item.onReject?.({
           item: entry.item,
           moderator,
           decidedAt,
+          telegram: ctx.telegram,
           reason: normaliseReason(reason),
-        } as ModerationRejectionContext<T>);
+        });
       }
     } catch (callbackError) {
       logger.error(

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -30,7 +30,18 @@ export interface ExecutorVerificationRoleState {
   moderationThreadMessageId?: number;
 }
 
+export type ExecutorSubscriptionStatus =
+  | 'idle'
+  | 'selectingPeriod'
+  | 'awaitingReceipt'
+  | 'pendingModeration';
+
 export interface ExecutorSubscriptionState {
+  status: ExecutorSubscriptionStatus;
+  selectedPeriodId?: string;
+  pendingPaymentId?: string;
+  moderationChatId?: number;
+  moderationMessageId?: number;
   lastInviteLink?: string;
   lastIssuedAt?: number;
 }

--- a/src/db/subscriptions.ts
+++ b/src/db/subscriptions.ts
@@ -43,6 +43,37 @@ const ACTIVE_SUBSCRIPTION_STATUSES: SubscriptionStatus[] = [
   'past_due',
 ];
 
+interface ExistingSubscriptionRow {
+  id: string;
+  next_billing_at: Date | string | null;
+  grace_until: Date | string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface ActivateSubscriptionParams {
+  telegramId: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  chatId: number;
+  periodDays: number;
+  periodLabel?: string;
+  amount: number;
+  currency: string;
+  paymentId: string;
+  submittedAt?: Date;
+  paymentMetadata?: Record<string, unknown>;
+}
+
+export interface ActivateSubscriptionResult {
+  subscriptionId: string;
+  userId: string;
+  periodStart: Date;
+  periodEnd: Date;
+  nextBillingAt: Date;
+}
+
 const parseNumeric = (
   value: string | number | null | undefined,
 ): number | undefined => {
@@ -95,6 +126,275 @@ const mapSubscriptionRow = (row: SubscriptionRow): SubscriptionWithUser => {
     firstName: row.first_name ?? undefined,
     lastName: row.last_name ?? undefined,
   } satisfies SubscriptionWithUser;
+};
+
+const upsertTelegramUser = async (
+  client: PoolClient,
+  params: ActivateSubscriptionParams,
+): Promise<string> => {
+  const { rows } = await client.query<{ id: string }>(
+    `
+      INSERT INTO users (
+        telegram_id,
+        username,
+        first_name,
+        last_name,
+        phone,
+        is_courier,
+        updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, true, now())
+      ON CONFLICT (telegram_id) DO UPDATE
+      SET
+        username = COALESCE(EXCLUDED.username, users.username),
+        first_name = COALESCE(EXCLUDED.first_name, users.first_name),
+        last_name = COALESCE(EXCLUDED.last_name, users.last_name),
+        phone = COALESCE(EXCLUDED.phone, users.phone),
+        is_courier = true,
+        updated_at = now()
+      RETURNING id
+    `,
+    [
+      params.telegramId,
+      params.username ?? null,
+      params.firstName ?? null,
+      params.lastName ?? null,
+      params.phone ?? null,
+    ],
+  );
+
+  const [row] = rows;
+  if (!row) {
+    throw new Error('Failed to upsert telegram user for subscription activation');
+  }
+
+  return row.id;
+};
+
+const fetchSubscriptionForUpdate = async (
+  client: PoolClient,
+  userId: string,
+  chatId: number,
+): Promise<ExistingSubscriptionRow | null> => {
+  const { rows } = await client.query<ExistingSubscriptionRow>(
+    `
+      SELECT id, next_billing_at, grace_until, metadata
+      FROM subscriptions
+      WHERE user_id = $1 AND chat_id = $2
+      LIMIT 1
+      FOR UPDATE
+    `,
+    [userId, chatId],
+  );
+
+  const [row] = rows;
+  return row ?? null;
+};
+
+const determinePeriodStart = (
+  existing: ExistingSubscriptionRow | null,
+  submittedAt: Date,
+): Date => {
+  if (!existing) {
+    return submittedAt;
+  }
+
+  const expiration =
+    parseTimestamp(existing.grace_until) ?? parseTimestamp(existing.next_billing_at);
+  if (expiration && expiration.getTime() > submittedAt.getTime()) {
+    return expiration;
+  }
+
+  return submittedAt;
+};
+
+const buildMetadataPatch = (
+  params: ActivateSubscriptionParams,
+  periodEnd: Date,
+  submittedAt: Date,
+): Record<string, unknown> => {
+  const patch: Record<string, unknown> = {
+    lastPaymentId: params.paymentId,
+    lastPaymentAt: submittedAt.toISOString(),
+    lastPeriodDays: params.periodDays,
+    lastPeriodEnd: periodEnd.toISOString(),
+  };
+
+  if (params.periodLabel) {
+    patch.lastPeriodLabel = params.periodLabel;
+  }
+
+  return patch;
+};
+
+export const activateSubscription = async (
+  params: ActivateSubscriptionParams,
+): Promise<ActivateSubscriptionResult> => {
+  const submittedAt = params.submittedAt ?? new Date();
+  const periodDays = Math.max(1, params.periodDays);
+
+  return withTx(async (client) => {
+    const userId = await upsertTelegramUser(client, params);
+    const existing = await fetchSubscriptionForUpdate(client, userId, params.chatId);
+
+    const periodStart = determinePeriodStart(existing, submittedAt);
+    const periodEnd = new Date(periodStart.getTime() + periodDays * 24 * 60 * 60 * 1000);
+    const metadataPatch = buildMetadataPatch(params, periodEnd, submittedAt);
+
+    let subscriptionId: string;
+    if (existing) {
+      const { rows } = await client.query<{ id: string }>(
+        `
+          UPDATE subscriptions
+          SET plan = $2,
+              status = 'active',
+              amount = $3,
+              currency = $4,
+              interval = 'day',
+              interval_count = $5,
+              next_billing_at = $6,
+              grace_until = NULL,
+              cancel_at_period_end = false,
+              cancelled_at = NULL,
+              ended_at = NULL,
+              metadata = COALESCE(metadata, '{}'::jsonb) || $7::jsonb,
+              updated_at = $8
+          WHERE id = $1
+          RETURNING id
+        `,
+        [
+          existing.id,
+          'manual',
+          params.amount,
+          params.currency,
+          periodDays,
+          periodEnd,
+          JSON.stringify(metadataPatch),
+          submittedAt,
+        ],
+      );
+
+      const [row] = rows;
+      subscriptionId = row?.id ?? existing.id;
+    } else {
+      const { rows } = await client.query<{ id: string }>(
+        `
+          INSERT INTO subscriptions (
+            user_id,
+            chat_id,
+            plan,
+            tier,
+            status,
+            currency,
+            amount,
+            interval,
+            interval_count,
+            next_billing_at,
+            grace_until,
+            cancel_at_period_end,
+            cancelled_at,
+            ended_at,
+            metadata
+          )
+          VALUES (
+            $1,
+            $2,
+            $3,
+            NULL,
+            'active',
+            $4,
+            $5,
+            'day',
+            $6,
+            $7,
+            NULL,
+            false,
+            NULL,
+            NULL,
+            $8::jsonb
+          )
+          RETURNING id
+        `,
+        [
+          userId,
+          params.chatId,
+          'manual',
+          params.currency,
+          params.amount,
+          periodDays,
+          periodEnd,
+          JSON.stringify(metadataPatch),
+        ],
+      );
+
+      const [row] = rows;
+      if (!row) {
+        throw new Error('Failed to create subscription during activation');
+      }
+      subscriptionId = row.id;
+    }
+
+    await client.query(
+      `
+        INSERT INTO subscription_payments (
+          subscription_id,
+          amount,
+          currency,
+          status,
+          payment_provider,
+          provider_payment_id,
+          provider_customer_id,
+          invoice_url,
+          receipt_url,
+          period_start,
+          period_end,
+          paid_at,
+          metadata
+        )
+        VALUES (
+          $1,
+          $2,
+          $3,
+          'succeeded',
+          'manual',
+          $4,
+          NULL,
+          NULL,
+          NULL,
+          $5,
+          $6,
+          $7,
+          $8::jsonb
+        )
+      `,
+      [
+        subscriptionId,
+        params.amount,
+        params.currency,
+        params.paymentId,
+        periodStart,
+        periodEnd,
+        submittedAt,
+        JSON.stringify(params.paymentMetadata ?? {}),
+      ],
+    );
+
+    await insertSubscriptionEvent(client, subscriptionId, 'payment_applied', {
+      paymentId: params.paymentId,
+      amount: params.amount,
+      currency: params.currency,
+      periodStart: periodStart.toISOString(),
+      periodEnd: periodEnd.toISOString(),
+    });
+
+    return {
+      subscriptionId,
+      userId,
+      periodStart,
+      periodEnd,
+      nextBillingAt: periodEnd,
+    } satisfies ActivateSubscriptionResult;
+  });
 };
 
 export const findSubscriptionsExpiringSoon = async (
@@ -182,6 +482,30 @@ export const recordSubscriptionWarning = async (
       JSON.stringify({ expiresAt: expiresAt.toISOString() }),
     ],
   );
+};
+
+export const hasActiveSubscription = async (
+  chatId: number,
+  telegramId: number,
+): Promise<boolean> => {
+  const { rows } = await pool.query<{ exists: number }>(
+    `
+      SELECT 1 AS exists
+      FROM subscriptions s
+      JOIN users u ON u.id = s.user_id
+      WHERE s.chat_id = $1
+        AND u.telegram_id = $2
+        AND s.status = ANY($3::text[])
+        AND (
+          COALESCE(s.grace_until, s.next_billing_at) IS NULL
+          OR COALESCE(s.grace_until, s.next_billing_at) > now()
+        )
+      LIMIT 1
+    `,
+    [chatId, telegramId, ACTIVE_SUBSCRIPTION_STATUSES],
+  );
+
+  return rows.length > 0;
 };
 
 const insertSubscriptionEvent = async (


### PR DESCRIPTION
## Summary
- add executor subscription flow with period selection, Kaspi payment instructions, and receipt submission for moderation
- extend payment moderation queue to activate subscriptions and deliver invite links upon approval while handling rejections
- introduce subscription period config, persistence helpers, and join-request checks based on active subscriptions

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9568842bc832d99daa488b477b4ac