### PR TITLE
Add shared pricing service using tariff configuration

### DIFF
--- a/src/bot/services/pricing.ts
+++ b/src/bot/services/pricing.ts
@@ -1,79 +1,9 @@
-import { config } from '../../config';
-import type { PricingConfig, TariffConfig } from '../../config';
-import type { OrderLocation, OrderPriceDetails } from '../../types';
-
-const EARTH_RADIUS_KM = 6371;
-
-const toRadians = (value: number): number => (value * Math.PI) / 180;
-
-export const calculateDistanceKm = (
-  from: OrderLocation,
-  to: OrderLocation,
-): number => {
-  const dLat = toRadians(to.latitude - from.latitude);
-  const dLon = toRadians(to.longitude - from.longitude);
-
-  const lat1 = toRadians(from.latitude);
-  const lat2 = toRadians(to.latitude);
-
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
-
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-  return Math.max(0, EARTH_RADIUS_KM * c);
-};
-
-const roundPrice = (amount: number): number => Math.round(amount / 10) * 10;
-
-const buildQuote = (
-  from: OrderLocation,
-  to: OrderLocation,
-  tariff: TariffConfig,
-): OrderPriceDetails => {
-  const distanceKm = calculateDistanceKm(from, to);
-  const raw = tariff.baseFare + distanceKm * tariff.perKm;
-  const amount = Math.max(tariff.minimumFare, roundPrice(raw));
-
-  return {
-    amount,
-    currency: 'KZT',
-    distanceKm,
-  } satisfies OrderPriceDetails;
-};
-
-const createEstimator =
-  (tariff: TariffConfig) =>
-  (from: OrderLocation, to: OrderLocation): OrderPriceDetails =>
-    buildQuote(from, to, tariff);
-
-export const createPricingService = (pricing: PricingConfig) => ({
-  estimateTaxiPrice: createEstimator(pricing.taxi),
-  estimateDeliveryPrice: createEstimator(pricing.delivery),
-});
-
-const defaultPricingService = createPricingService(config.pricing);
-
-export const estimateTaxiPrice = defaultPricingService.estimateTaxiPrice;
-export const estimateDeliveryPrice = defaultPricingService.estimateDeliveryPrice;
-
-const priceFormatter = new Intl.NumberFormat('ru-RU');
-
-export const formatPriceAmount = (amount: number, currency: string): string =>
-  `${priceFormatter.format(amount)} ${currency}`;
-
-export const formatPriceDetails = (price: OrderPriceDetails): string =>
-  formatPriceAmount(price.amount, price.currency);
-
-export const formatDistance = (distanceKm: number): string => {
-  if (!Number.isFinite(distanceKm)) {
-    return 'н/д';
-  }
-
-  if (distanceKm < 0.1) {
-    return '<0.1';
-  }
-
-  return distanceKm.toFixed(1);
-};
+export {
+  calculateDistanceKm,
+  createPricingService,
+  estimateTaxiPrice,
+  estimateDeliveryPrice,
+  formatPriceAmount,
+  formatPriceDetails,
+  formatDistance,
+} from '../../services/pricing';

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -1,0 +1,79 @@
+import { config } from '../config';
+import type { PricingConfig, TariffConfig } from '../config';
+import type { OrderLocation, OrderPriceDetails } from '../types';
+
+const EARTH_RADIUS_KM = 6371;
+
+const toRadians = (value: number): number => (value * Math.PI) / 180;
+
+export const calculateDistanceKm = (
+  from: OrderLocation,
+  to: OrderLocation,
+): number => {
+  const dLat = toRadians(to.latitude - from.latitude);
+  const dLon = toRadians(to.longitude - from.longitude);
+
+  const lat1 = toRadians(from.latitude);
+  const lat2 = toRadians(to.latitude);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return Math.max(0, EARTH_RADIUS_KM * c);
+};
+
+const roundPrice = (amount: number): number => Math.round(amount / 10) * 10;
+
+const buildQuote = (
+  from: OrderLocation,
+  to: OrderLocation,
+  tariff: TariffConfig,
+): OrderPriceDetails => {
+  const distanceKm = calculateDistanceKm(from, to);
+  const raw = tariff.baseFare + distanceKm * tariff.perKm;
+  const amount = Math.max(tariff.minimumFare, roundPrice(raw));
+
+  return {
+    amount,
+    currency: 'KZT',
+    distanceKm,
+  } satisfies OrderPriceDetails;
+};
+
+const createEstimator =
+  (tariff: TariffConfig) =>
+  (from: OrderLocation, to: OrderLocation): OrderPriceDetails =>
+    buildQuote(from, to, tariff);
+
+export const createPricingService = (pricing: PricingConfig) => ({
+  estimateTaxiPrice: createEstimator(pricing.taxi),
+  estimateDeliveryPrice: createEstimator(pricing.delivery),
+});
+
+const defaultPricingService = createPricingService(config.pricing);
+
+export const estimateTaxiPrice = defaultPricingService.estimateTaxiPrice;
+export const estimateDeliveryPrice = defaultPricingService.estimateDeliveryPrice;
+
+const priceFormatter = new Intl.NumberFormat('ru-RU');
+
+export const formatPriceAmount = (amount: number, currency: string): string =>
+  `${priceFormatter.format(amount)} ${currency}`;
+
+export const formatPriceDetails = (price: OrderPriceDetails): string =>
+  formatPriceAmount(price.amount, price.currency);
+
+export const formatDistance = (distanceKm: number): string => {
+  if (!Number.isFinite(distanceKm)) {
+    return 'н/д';
+  }
+
+  if (distanceKm < 0.1) {
+    return '<0.1';
+  }
+
+  return distanceKm.toFixed(1);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "src/index.ts",
     "src/bot/**/*.ts",
     "src/config/**/*.ts",
+    "src/services/**/*.ts",
     "src/db/**/*.ts",
     "src/jobs/**/*.ts",
     "src/types/**/*.ts",


### PR DESCRIPTION
## Summary
- move the pricing calculations to a shared service that reads tariff configuration values
- re-export the shared helpers from the bot pricing module for existing callers
- update the TypeScript project includes so the new service is compiled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c980f4cd28832d8b5ed44f30dfaf34