### PR TITLE
Enforce executor verification and subscription gating

### DIFF
--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -123,7 +123,9 @@ const submitForModeration = async (
   return true;
 };
 
-const handleVerificationAction = async (ctx: BotContext): Promise<void> => {
+export const startExecutorVerification = async (
+  ctx: BotContext,
+): Promise<void> => {
   ensureExecutorState(ctx);
   const state = ctx.session.executor;
   const role = state.role;
@@ -142,7 +144,7 @@ const handleVerificationAction = async (ctx: BotContext): Promise<void> => {
   const prompt = await ctx.reply(promptText);
   ctx.session.ephemeralMessages.push(prompt.message_id);
 
-  await showExecutorMenu(ctx);
+  await showExecutorMenu(ctx, { skipAccessCheck: true });
 };
 
 const handleIncomingPhoto = async (ctx: BotContext): Promise<void> => {
@@ -189,11 +191,11 @@ const handleIncomingPhoto = async (ctx: BotContext): Promise<void> => {
 
   if (uploaded >= required) {
     await submitForModeration(ctx, state);
-    await showExecutorMenu(ctx);
+    await showExecutorMenu(ctx, { skipAccessCheck: true });
     return;
   }
 
-  await showExecutorMenu(ctx);
+  await showExecutorMenu(ctx, { skipAccessCheck: true });
 };
 
 const handleTextDuringCollection = async (ctx: BotContext, next: () => Promise<void>): Promise<void> => {
@@ -233,7 +235,7 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
     }
 
     await ctx.answerCbQuery();
-    await handleVerificationAction(ctx);
+    await startExecutorVerification(ctx);
   });
 
   bot.on('photo', async (ctx) => {

--- a/src/db/verifications.ts
+++ b/src/db/verifications.ts
@@ -1,0 +1,30 @@
+import { pool } from './client';
+
+type VerificationRole = 'courier' | 'driver';
+
+interface VerificationExistsRow {
+  is_verified: boolean;
+}
+
+export const isExecutorVerified = async (
+  telegramId: number,
+  role: VerificationRole,
+): Promise<boolean> => {
+  const { rows } = await pool.query<VerificationExistsRow>(
+    `
+      SELECT EXISTS(
+        SELECT 1
+        FROM verifications v
+        JOIN users u ON u.id = v.user_id
+        WHERE u.telegram_id = $1
+          AND v.type = $2
+          AND v.status = 'approved'
+          AND (v.expires_at IS NULL OR v.expires_at > now())
+      ) AS is_verified
+    `,
+    [telegramId, role],
+  );
+
+  const [row] = rows;
+  return row?.is_verified ?? false;
+};


### PR DESCRIPTION
## Summary
- add database-backed verification/subscription checks before showing the executor menu and update the menu copy accordingly
- expose reusable verification and subscription entrypoints so redirects from the menu do not loop while preserving existing flows

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c984127588832da275f02a240cb841