### PR TITLE
Implement support ticket forwarding with moderator actions

### DIFF
--- a/src/bot/services/support.ts
+++ b/src/bot/services/support.ts
@@ -1,5 +1,18 @@
-import { Markup } from 'telegraf';
-import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+import crypto from 'crypto';
+
+import { Markup, Telegraf } from 'telegraf';
+import type {
+  ForceReply,
+  InlineKeyboardMarkup,
+  Message,
+} from 'telegraf/typings/core/types/typegram';
+import type { ExtraCopyMessage } from 'telegraf/typings/telegram-types';
+
+import { logger } from '../../config';
+import { pool } from '../../db';
+import { getChannelBinding } from '../channels/bindings';
+import type { BotContext } from '../types';
+import { safeEditReplyMarkup } from '../../utils/tg';
 
 export interface SupportContact {
   type: 'phone' | 'email' | 'telegram' | 'link';
@@ -90,4 +103,579 @@ export const buildSupportKeyboard = (
   }
 
   return Markup.inlineKeyboard(buttons).reply_markup;
+};
+
+type SupportThreadStatus = 'open' | 'closed';
+
+interface SupportThreadState {
+  id: string;
+  userChatId: number;
+  userTelegramId?: number;
+  userMessageId: number;
+  moderatorChatId: number;
+  moderatorMessageId: number;
+  status: SupportThreadStatus;
+}
+
+interface SupportThreadRow {
+  id: string;
+  user_chat_id: number | string;
+  user_telegram_id: number | string | null;
+  user_message_id: number;
+  moderator_chat_id: number | string;
+  moderator_message_id: number;
+  status: SupportThreadStatus;
+  closed_at: Date | string | null;
+}
+
+interface SupportThreadPrompt {
+  threadId: string;
+  moderatorId?: number;
+}
+
+const REPLY_ACTION_PREFIX = 'support:reply';
+const CLOSE_ACTION_PREFIX = 'support:close';
+const REPLY_ACTION_PATTERN = /^support:reply:([\da-f-]+)$/;
+const CLOSE_ACTION_PATTERN = /^support:close:([\da-f-]+)$/;
+
+const threadsById = new Map<string, SupportThreadState>();
+const threadsByModeratorMessage = new Map<string, string>();
+const pendingReplyPrompts = new Map<string, SupportThreadPrompt>();
+const promptsByThread = new Map<string, Set<string>>();
+
+type ModerationChannelResolver = () => Promise<number | null>;
+
+const defaultResolveModerationChannel: ModerationChannelResolver = async () => {
+  const binding = await getChannelBinding('verify');
+  return binding?.chatId ?? null;
+};
+
+let resolveModerationChannel: ModerationChannelResolver =
+  defaultResolveModerationChannel;
+
+const createThreadId = (): string => crypto.randomBytes(8).toString('hex');
+
+const buildMessageKey = (chatId: number, messageId: number): string =>
+  `${chatId.toString(10)}:${messageId.toString(10)}`;
+
+const registerPrompt = (
+  threadId: string,
+  chatId: number,
+  messageId: number,
+  moderatorId?: number,
+): void => {
+  const key = buildMessageKey(chatId, messageId);
+  pendingReplyPrompts.set(key, { threadId, moderatorId });
+
+  let entries = promptsByThread.get(threadId);
+  if (!entries) {
+    entries = new Set<string>();
+    promptsByThread.set(threadId, entries);
+  }
+
+  entries.add(key);
+};
+
+const clearPrompt = (key: string): void => {
+  const prompt = pendingReplyPrompts.get(key);
+  if (!prompt) {
+    return;
+  }
+
+  pendingReplyPrompts.delete(key);
+
+  const entries = promptsByThread.get(prompt.threadId);
+  if (!entries) {
+    return;
+  }
+
+  entries.delete(key);
+  if (entries.size === 0) {
+    promptsByThread.delete(prompt.threadId);
+  }
+};
+
+const clearPromptsForThread = (threadId: string): void => {
+  const entries = promptsByThread.get(threadId);
+  if (!entries) {
+    return;
+  }
+
+  for (const key of entries) {
+    pendingReplyPrompts.delete(key);
+  }
+
+  promptsByThread.delete(threadId);
+};
+
+const trackThreadState = (state: SupportThreadState): void => {
+  threadsById.set(state.id, state);
+  const key = buildMessageKey(state.moderatorChatId, state.moderatorMessageId);
+  threadsByModeratorMessage.set(key, state.id);
+};
+
+const deleteThreadState = (threadId: string): void => {
+  const state = threadsById.get(threadId);
+  if (!state) {
+    return;
+  }
+
+  threadsById.delete(threadId);
+  const key = buildMessageKey(state.moderatorChatId, state.moderatorMessageId);
+  threadsByModeratorMessage.delete(key);
+  clearPromptsForThread(threadId);
+};
+
+const insertSupportThreadRecord = async (
+  state: SupportThreadState,
+): Promise<void> => {
+  try {
+    await pool.query<SupportThreadRow>(
+      `
+        INSERT INTO support_threads (
+          id,
+          user_chat_id,
+          user_telegram_id,
+          user_message_id,
+          moderator_chat_id,
+          moderator_message_id,
+          status
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+      `,
+      [
+        state.id,
+        state.userChatId,
+        state.userTelegramId ?? null,
+        state.userMessageId,
+        state.moderatorChatId,
+        state.moderatorMessageId,
+        state.status,
+      ],
+    );
+  } catch (error) {
+    logger.error(
+      { err: error, threadId: state.id },
+      'Failed to persist support thread record',
+    );
+  }
+};
+
+const markSupportThreadClosed = async (threadId: string): Promise<void> => {
+  try {
+    await pool.query<SupportThreadRow>(
+      `
+        UPDATE support_threads
+        SET status = 'closed', closed_at = NOW()
+        WHERE id = $1
+      `,
+      [threadId],
+    );
+  } catch (error) {
+    logger.error(
+      { err: error, threadId },
+      'Failed to mark support thread as closed',
+    );
+  }
+};
+
+const buildSupportThreadKeyboard = (threadId: string) =>
+  Markup.inlineKeyboard([
+    [Markup.button.callback('💬 Reply', `${REPLY_ACTION_PREFIX}:${threadId}`)],
+    [Markup.button.callback('✅ Close', `${CLOSE_ACTION_PREFIX}:${threadId}`)],
+  ]);
+
+const formatSupportHeader = (ctx: BotContext, threadId: string): string => {
+  const parts: string[] = [
+    '🆘 Новое обращение в поддержку',
+    `ID обращения: ${threadId}`,
+  ];
+
+  const userId = ctx.from?.id ?? ctx.chat?.id;
+  if (userId) {
+    parts.push(`Telegram ID: ${userId}`);
+  }
+
+  if (ctx.from?.username) {
+    parts.push(`Username: @${ctx.from.username}`);
+  }
+
+  const fullName = [ctx.from?.first_name, ctx.from?.last_name]
+    .filter((value) => Boolean(value && value.trim().length > 0))
+    .join(' ')
+    .trim();
+
+  if (fullName) {
+    parts.push(`Имя: ${fullName}`);
+  }
+
+  return parts.join('\n');
+};
+
+const sendSupportHeader = async (
+  ctx: BotContext,
+  moderationChatId: number,
+  threadId: string,
+): Promise<number | undefined> => {
+  const text = formatSupportHeader(ctx, threadId);
+
+  try {
+    const header = await ctx.telegram.sendMessage(moderationChatId, text);
+    return header.message_id;
+  } catch (error) {
+    logger.error(
+      { err: error, threadId, moderationChatId },
+      'Failed to send support header message',
+    );
+    return undefined;
+  }
+};
+
+const buildCopyOptions = (
+  threadId: string,
+  replyToMessageId?: number,
+): ExtraCopyMessage => {
+  const keyboard = buildSupportThreadKeyboard(threadId);
+
+  const options: ExtraCopyMessage = {
+    reply_markup: keyboard.reply_markup,
+  } satisfies ExtraCopyMessage;
+
+  if (replyToMessageId) {
+    const mutable = options as Record<string, unknown>;
+    mutable.reply_to_message_id = replyToMessageId;
+    mutable.allow_sending_without_reply = true;
+  }
+
+  return options;
+};
+
+export interface SupportForwardResult {
+  status: 'forwarded' | 'missing_channel' | 'skipped';
+  threadId?: string;
+  moderatorMessageId?: number;
+}
+
+const ensureSupportMessage = (ctx: BotContext): Message | undefined => {
+  const message = ctx.message as Message | undefined;
+  if (!message) {
+    return undefined;
+  }
+
+  if (message.message_id === undefined || message.message_id === null) {
+    return undefined;
+  }
+
+  return message;
+};
+
+export const forwardSupportMessage = async (
+  ctx: BotContext,
+): Promise<SupportForwardResult> => {
+  const chatId = ctx.chat?.id;
+  if (chatId === undefined) {
+    return { status: 'skipped' };
+  }
+
+  const message = ensureSupportMessage(ctx);
+  if (!message) {
+    return { status: 'skipped' };
+  }
+
+  const moderationChatId = await resolveModerationChannel();
+  if (moderationChatId === null) {
+    logger.warn(
+      { chatId, messageId: message.message_id },
+      'Support moderation channel is not configured',
+    );
+    return { status: 'missing_channel' };
+  }
+
+  const threadId = createThreadId();
+  const headerMessageId = await sendSupportHeader(ctx, moderationChatId, threadId);
+
+  let forwardedMessageId: number;
+  try {
+    const options = buildCopyOptions(threadId, headerMessageId);
+    const forwarded = await ctx.telegram.copyMessage(
+      moderationChatId,
+      chatId,
+      message.message_id,
+      options,
+    );
+    forwardedMessageId = forwarded.message_id;
+  } catch (error) {
+    logger.error(
+      { err: error, chatId, moderationChatId, messageId: message.message_id },
+      'Failed to forward support message to moderation channel',
+    );
+    return { status: 'skipped' };
+  }
+
+  const state: SupportThreadState = {
+    id: threadId,
+    userChatId: chatId,
+    userTelegramId: ctx.from?.id ?? ctx.chat?.id,
+    userMessageId: message.message_id,
+    moderatorChatId: moderationChatId,
+    moderatorMessageId: forwardedMessageId,
+    status: 'open',
+  } satisfies SupportThreadState;
+
+  trackThreadState(state);
+  await insertSupportThreadRecord(state);
+
+  return {
+    status: 'forwarded',
+    threadId,
+    moderatorMessageId: forwardedMessageId,
+  } satisfies SupportForwardResult;
+};
+
+const handleReplyAction = async (
+  ctx: BotContext,
+  threadId: string,
+): Promise<void> => {
+  const state = threadsById.get(threadId);
+  if (!state || state.status !== 'open') {
+    await ctx.answerCbQuery('Обращение недоступно. Возможно, оно уже закрыто.');
+    return;
+  }
+
+  const chatId = ctx.chat?.id;
+  if (chatId === undefined) {
+    await ctx.answerCbQuery('Не удалось запросить ответ. Попробуйте ещё раз.');
+    return;
+  }
+
+  try {
+    const promptText =
+      'Отправьте ответ пользователю сообщением. Это сообщение будет доставлено в личные сообщения.';
+    const forceReply: ForceReply = { force_reply: true, selective: true };
+    const prompt = await ctx.reply(promptText, { reply_markup: forceReply });
+    registerPrompt(threadId, prompt.chat.id, prompt.message_id, ctx.from?.id);
+    await ctx.answerCbQuery('Отправьте ответ пользователю сообщением.');
+  } catch (error) {
+    logger.error(
+      { err: error, threadId },
+      'Failed to prompt moderator for support reply',
+    );
+    await ctx.answerCbQuery('Не удалось запросить ответ. Попробуйте ещё раз.');
+  }
+};
+
+const notifyUserClosed = async (ctx: BotContext, state: SupportThreadState) => {
+  try {
+    await ctx.telegram.sendMessage(
+      state.userChatId,
+      '✅ Ваше обращение в поддержку было закрыто. Если у вас остались вопросы, отправьте новое сообщение.',
+    );
+  } catch (error) {
+    logger.error(
+      { err: error, threadId: state.id, userChatId: state.userChatId },
+      'Failed to notify user about closed support thread',
+    );
+  }
+};
+
+const handleCloseAction = async (
+  ctx: BotContext,
+  threadId: string,
+): Promise<void> => {
+  const state = threadsById.get(threadId);
+  if (!state) {
+    await ctx.answerCbQuery('Обращение уже закрыто.');
+    return;
+  }
+
+  if (state.status === 'closed') {
+    await ctx.answerCbQuery('Обращение уже закрыто.');
+    return;
+  }
+
+  state.status = 'closed';
+
+  const keyboardCleared = await safeEditReplyMarkup(
+    ctx.telegram,
+    state.moderatorChatId,
+    state.moderatorMessageId,
+    undefined,
+  );
+  if (!keyboardCleared) {
+    logger.debug(
+      {
+        threadId: state.id,
+        chatId: state.moderatorChatId,
+        messageId: state.moderatorMessageId,
+      },
+      'Failed to clear support thread inline keyboard on close',
+    );
+  }
+
+  await markSupportThreadClosed(threadId);
+  await notifyUserClosed(ctx, state);
+
+  deleteThreadState(threadId);
+  await ctx.answerCbQuery('Обращение закрыто.');
+};
+
+const copyModeratorReplyToUser = async (
+  ctx: BotContext,
+  state: SupportThreadState,
+): Promise<boolean> => {
+  const message = ctx.message as Message | undefined;
+  if (!message) {
+    return false;
+  }
+
+  try {
+    await ctx.telegram.copyMessage(
+      state.userChatId,
+      ctx.chat?.id ?? state.moderatorChatId,
+      message.message_id,
+    );
+    return true;
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        threadId: state.id,
+        userChatId: state.userChatId,
+        moderatorChatId: state.moderatorChatId,
+        messageId: message.message_id,
+      },
+      'Failed to deliver moderator reply to support user',
+    );
+    return false;
+  }
+};
+
+const acknowledgeModeratorReply = async (
+  ctx: BotContext,
+  messageId: number,
+  text: string,
+): Promise<void> => {
+  try {
+    await ctx.reply(text, {
+      reply_parameters: {
+        message_id: messageId,
+        allow_sending_without_reply: true,
+      },
+    });
+  } catch (error) {
+    logger.debug(
+      { err: error, chatId: ctx.chat?.id, messageId },
+      'Failed to acknowledge moderator reply',
+    );
+  }
+};
+
+const handleModeratorReplyMessage = async (
+  ctx: BotContext,
+): Promise<boolean> => {
+  const message = ctx.message as Message | undefined;
+  const replyTo = (message as Partial<{ reply_to_message: Message }>)
+    ?.reply_to_message;
+  const chatId = ctx.chat?.id;
+
+  if (!message || !replyTo || chatId === undefined) {
+    return false;
+  }
+
+  const promptKey = buildMessageKey(chatId, replyTo.message_id);
+  const prompt = pendingReplyPrompts.get(promptKey);
+  if (!prompt) {
+    return false;
+  }
+
+  if (prompt.moderatorId !== undefined && ctx.from?.id !== prompt.moderatorId) {
+    return false;
+  }
+
+  const state = threadsById.get(prompt.threadId);
+  if (!state) {
+    clearPrompt(promptKey);
+    await acknowledgeModeratorReply(
+      ctx,
+      message.message_id,
+      'Обращение уже закрыто.',
+    );
+    return true;
+  }
+
+  if (state.status !== 'open') {
+    clearPrompt(promptKey);
+    await acknowledgeModeratorReply(
+      ctx,
+      message.message_id,
+      'Обращение уже закрыто.',
+    );
+    return true;
+  }
+
+  const delivered = await copyModeratorReplyToUser(ctx, state);
+  clearPrompt(promptKey);
+
+  const response = delivered
+    ? 'Ответ доставлен пользователю.'
+    : 'Не удалось доставить ответ пользователю.';
+
+  await acknowledgeModeratorReply(ctx, message.message_id, response);
+  return true;
+};
+
+export const registerSupportModerationBridge = (
+  bot: Telegraf<BotContext>,
+): void => {
+  bot.action(REPLY_ACTION_PATTERN, async (ctx: BotContext) => {
+    const match = (ctx as BotContext & { match?: RegExpMatchArray }).match;
+    const threadId = match?.[1];
+    if (!threadId) {
+      await ctx.answerCbQuery('Некорректное действие.');
+      return;
+    }
+
+    await handleReplyAction(ctx, threadId);
+  });
+
+  bot.action(CLOSE_ACTION_PATTERN, async (ctx: BotContext) => {
+    const match = (ctx as BotContext & { match?: RegExpMatchArray }).match;
+    const threadId = match?.[1];
+    if (!threadId) {
+      await ctx.answerCbQuery('Некорректное действие.');
+      return;
+    }
+
+    await handleCloseAction(ctx, threadId);
+  });
+
+  bot.on('message', async (ctx: BotContext, next?: () => Promise<void>) => {
+    const handled = await handleModeratorReplyMessage(ctx);
+    if (!handled && next) {
+      await next();
+    }
+  });
+};
+
+const resetSupportState = (): void => {
+  threadsById.clear();
+  threadsByModeratorMessage.clear();
+  pendingReplyPrompts.clear();
+  promptsByThread.clear();
+  resolveModerationChannel = defaultResolveModerationChannel;
+};
+
+export const __testing__ = {
+  threadsById,
+  pendingReplyPrompts,
+  promptsByThread,
+  handleReplyAction,
+  handleCloseAction,
+  handleModeratorReplyMessage,
+  registerPrompt,
+  deleteThreadState,
+  resetSupportState,
+  setModerationChannelResolver: (resolver: ModerationChannelResolver | null) => {
+    resolveModerationChannel = resolver ?? defaultResolveModerationChannel;
+  },
 };

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import { before, beforeEach, describe, it } from 'node:test';
+
+import type { Telegraf } from 'telegraf';
+
+import type { BotContext } from '../src/bot/types';
+import { pool } from '../src/db';
+
+import type { SupportForwardResult } from '../src/bot/services/support';
+
+interface TelegramCall {
+  method: string;
+  args: any[];
+}
+
+const createMockTelegram = () => {
+  const calls: TelegramCall[] = [];
+
+  return {
+    calls,
+    api: {
+      async sendMessage(chatId: number, text: string) {
+        calls.push({ method: 'sendMessage', args: [chatId, text] });
+        return { message_id: 401, chat: { id: chatId }, text };
+      },
+      async copyMessage(
+        chatId: number,
+        fromChatId: number,
+        messageId: number,
+        extra?: unknown,
+      ) {
+        calls.push({ method: 'copyMessage', args: [chatId, fromChatId, messageId, extra] });
+        return { message_id: 402, chat: { id: chatId } };
+      },
+      async editMessageReplyMarkup(...args: any[]) {
+        calls.push({ method: 'editMessageReplyMarkup', args });
+        return true;
+      },
+    } as any,
+  };
+};
+
+const originalQuery = pool.query.bind(pool);
+
+const setPoolQuery = (fn: typeof pool.query) => {
+  (pool as unknown as { query: typeof pool.query }).query = fn;
+};
+
+type SupportModule = typeof import('../src/bot/services/support');
+
+let __testing__: SupportModule['__testing__'];
+let forwardSupportMessage: SupportModule['forwardSupportMessage'];
+let registerSupportModerationBridge: SupportModule['registerSupportModerationBridge'];
+
+async function importSupportModule() {
+  process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+
+  return import('../src/bot/services/support');
+}
+
+describe('support service', () => {
+  before(async () => {
+    const mod = await importSupportModule();
+    __testing__ = mod.__testing__;
+    forwardSupportMessage = mod.forwardSupportMessage;
+    registerSupportModerationBridge = mod.registerSupportModerationBridge;
+  });
+  beforeEach(() => {
+    __testing__.resetSupportState();
+    setPoolQuery(originalQuery);
+  });
+
+  it('forwards support messages and records threads', async () => {
+    const telegram = createMockTelegram();
+
+    const capturedQueries: any[] = [];
+    setPoolQuery(async (...args: any[]) => {
+      capturedQueries.push(args);
+      return { rows: [] } as any;
+    });
+
+    __testing__.setModerationChannelResolver(async () => 987654321);
+
+    const ctx = {
+      chat: { id: 111 },
+      from: {
+        id: 222,
+        username: 'support_user',
+        first_name: 'Support',
+        last_name: 'User',
+      },
+      message: { message_id: 123, text: 'Нужна помощь' },
+      telegram: telegram.api,
+    } as unknown as BotContext;
+
+    const result = (await forwardSupportMessage(ctx)) as SupportForwardResult;
+    assert.equal(result.status, 'forwarded');
+    assert.ok(result.threadId);
+
+    const copyCall = telegram.calls.find((call) => call.method === 'copyMessage');
+    assert.ok(copyCall, 'copyMessage should be invoked');
+    assert.equal(copyCall?.args[0], 987654321);
+    assert.equal(copyCall?.args[1], 111);
+    assert.equal(copyCall?.args[2], 123);
+
+    const options = copyCall?.args[3];
+    assert.ok(options?.reply_markup, 'inline keyboard is attached');
+    assert.equal(options?.reply_to_message_id, 401);
+
+    assert.ok(
+      capturedQueries.some((entry) =>
+        typeof entry?.[0] === 'string' && entry[0].includes('INSERT INTO support_threads'),
+      ),
+      'support thread insert query should be executed',
+    );
+
+    const state = __testing__.threadsById.get(result.threadId!);
+    assert.ok(state, 'thread state is tracked');
+    assert.equal(state?.moderatorMessageId, 402);
+  });
+
+  it('prompts moderators for replies and delivers responses', async () => {
+    const threadId = 'thread-reply';
+    const telegram = createMockTelegram();
+
+    __testing__.threadsById.set(threadId, {
+      id: threadId,
+      userChatId: 321,
+      userMessageId: 5,
+      userTelegramId: 654,
+      moderatorChatId: 99,
+      moderatorMessageId: 77,
+      status: 'open',
+    });
+
+    const ctx = {
+      chat: { id: 99 },
+      from: { id: 555 },
+      reply: async () => ({
+        chat: { id: 99 },
+        message_id: 500,
+      }),
+      answerCbQuery: async () => {},
+      telegram: telegram.api,
+    } as unknown as BotContext;
+
+    await __testing__.handleReplyAction(ctx, threadId);
+
+    const promptKey = `${ctx.chat!.id}:${500}`;
+    assert.ok(__testing__.pendingReplyPrompts.has(promptKey));
+
+    const replyCtx = {
+      chat: { id: 99 },
+      from: { id: 555 },
+      message: {
+        message_id: 600,
+        text: 'Ответ пользователю',
+        reply_to_message: { message_id: 500 },
+      },
+      reply: async () => {},
+      telegram: telegram.api,
+    } as unknown as BotContext;
+
+    const handled = await __testing__.handleModeratorReplyMessage(replyCtx);
+    assert.equal(handled, true);
+
+    const delivered = telegram.calls.find((call) => call.method === 'copyMessage');
+    assert.ok(delivered, 'reply should be copied to the user');
+    assert.equal(delivered?.args[0], 321);
+    assert.equal(__testing__.pendingReplyPrompts.size, 0);
+  });
+
+  it('closes support threads and cleans up state', async () => {
+    const threadId = 'thread-close';
+    const telegram = createMockTelegram();
+
+    const updateQueries: any[] = [];
+    setPoolQuery(async (...args: any[]) => {
+      updateQueries.push(args);
+      return { rows: [] } as any;
+    });
+
+    __testing__.threadsById.set(threadId, {
+      id: threadId,
+      userChatId: 654,
+      userMessageId: 10,
+      userTelegramId: 654,
+      moderatorChatId: 4321,
+      moderatorMessageId: 765,
+      status: 'open',
+    });
+
+    const ctx = {
+      chat: { id: 4321 },
+      from: { id: 777 },
+      answerCbQuery: async () => {},
+      telegram: telegram.api,
+    } as unknown as BotContext;
+
+    await __testing__.handleCloseAction(ctx, threadId);
+
+    assert.ok(
+      updateQueries.some((entry) =>
+        typeof entry?.[0] === 'string' && entry[0].includes('UPDATE support_threads'),
+      ),
+      'update query should be executed when closing a thread',
+    );
+
+    assert.equal(__testing__.threadsById.has(threadId), false, 'thread state should be cleared');
+
+    const notifyCall = telegram.calls.find((call) => call.method === 'sendMessage');
+    assert.ok(notifyCall, 'user should be notified about closure');
+    assert.equal(notifyCall?.args[0], 654);
+  });
+
+  it('registers handlers on a Telegraf instance', async () => {
+    const actions: { pattern: RegExp; handler: (ctx: BotContext) => Promise<void> }[] = [];
+    let messageHandler: ((ctx: BotContext, next?: () => Promise<void>) => Promise<void>) | null =
+      null;
+
+    const bot = {
+      action(pattern: RegExp, handler: (ctx: BotContext) => Promise<void>) {
+        actions.push({ pattern, handler });
+      },
+      on(_: string, handler: typeof messageHandler) {
+        messageHandler = handler;
+      },
+    } as unknown as Telegraf<BotContext>;
+
+    registerSupportModerationBridge(bot);
+
+    assert.equal(actions.length, 2, 'two action handlers are registered');
+    assert.ok(messageHandler, 'message handler should be registered');
+  });
+});


### PR DESCRIPTION
## Summary
- forward user support messages into the moderation channel with per-thread tracking and database persistence
- add inline Reply and Close controls so moderators can answer users and terminate tickets while cleaning local state
- expose testing utilities and cover the new flow with unit tests for forwarding, replying, closing, and handler registration

## Testing
- npm test
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c99675b828832d81b36a1d19103eba