### PR TITLE
Refine flow messaging with UI helper

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -10,6 +10,7 @@ import { ui } from '../../ui';
 const ROLE_CLIENT_ACTION = 'role:client';
 export const CLIENT_MENU_ACTION = 'client:menu:show';
 const CLIENT_MENU_STEP_ID = 'client:menu:main';
+const CLIENT_MENU_PRIVATE_WARNING_STEP_ID = 'client:menu:private-only';
 
 const buildMenuKeyboard = (): InlineKeyboardMarkup =>
   Markup.inlineKeyboard([
@@ -86,7 +87,11 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
 
   bot.command('order', async (ctx) => {
     if (ctx.chat?.type !== 'private') {
-      await ctx.reply('Меню доступно только в личном чате с ботом.');
+      await ui.step(ctx, {
+        id: CLIENT_MENU_PRIVATE_WARNING_STEP_ID,
+        text: 'Меню доступно только в личном чате с ботом.',
+        cleanup: true,
+      });
       return;
     }
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { clearSession, session } from '../src/bot/middlewares/session';
+import type { BotContext } from '../src/bot/types';
+
+describe('session middleware', () => {
+  it('resets session state to initial values after clearing', async () => {
+    const middleware = session();
+    const ctx = { chat: { id: 999, type: 'private' }, from: { id: 555 } } as unknown as BotContext;
+
+    await middleware(ctx, async () => {
+      ctx.session.isAuthenticated = true;
+      ctx.session.phoneNumber = '+7 700 000 00 00';
+      ctx.session.client.taxi.stage = 'collectingPickup';
+      ctx.session.executor.subscription.status = 'awaitingReceipt';
+      ctx.session.ui.steps['demo'] = { chatId: ctx.chat!.id!, messageId: 1, cleanup: true };
+      ctx.session.ui.homeActions.push('home:demo');
+    });
+
+    assert.equal(ctx.session.isAuthenticated, true);
+    assert.equal(ctx.session.client.taxi.stage, 'collectingPickup');
+    assert.equal(ctx.session.executor.subscription.status, 'awaitingReceipt');
+    assert.ok(ctx.session.ui.steps['demo']);
+    assert.deepEqual(ctx.session.ui.homeActions, ['home:demo']);
+
+    clearSession(ctx);
+
+    const ctx2 = { chat: { id: 999, type: 'private' }, from: { id: 555 } } as unknown as BotContext;
+    await middleware(ctx2, async () => {});
+
+    assert.equal(ctx2.session.isAuthenticated, false);
+    assert.equal(ctx2.session.client.taxi.stage, 'idle');
+    assert.equal(ctx2.session.executor.subscription.status, 'idle');
+    assert.deepEqual(ctx2.session.ui.steps, {});
+    assert.deepEqual(ctx2.session.ui.homeActions, []);
+    assert.notStrictEqual(ctx2.session, ctx.session);
+
+    clearSession(ctx2);
+  });
+});

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import {
+  EXECUTOR_VERIFICATION_PHOTO_COUNT,
+  type BotContext,
+  type SessionState,
+} from '../src/bot/types';
+
+let uiHelper!: typeof import('../src/bot/ui')['ui'];
+
+before(async () => {
+  process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+
+  ({ ui: uiHelper } = await import('../src/bot/ui'));
+});
+
+const createSessionState = (): SessionState => ({
+  ephemeralMessages: [],
+  isAuthenticated: false,
+  awaitingPhone: false,
+  executor: {
+    role: 'courier',
+    verification: {
+      courier: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+      driver: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+    },
+    subscription: { status: 'idle' },
+  },
+  client: {
+    taxi: { stage: 'idle' },
+    delivery: { stage: 'idle' },
+  },
+  ui: { steps: {}, homeActions: [] },
+});
+
+type EditHandler = (
+  chatId: number,
+  messageId: number,
+  inlineMessageId: undefined,
+  text: string,
+  extra?: unknown,
+) => Promise<unknown>;
+
+const createMockContext = () => {
+  const session = createSessionState();
+  let nextMessageId = 1;
+  const replyCalls: Array<{ text: string; extra?: unknown; messageId: number }> = [];
+  const editCalls: Array<{ chatId: number; messageId: number; text: string; extra?: unknown }> = [];
+  const deleteCalls: Array<{ chatId: number; messageId: number }> = [];
+
+  let editOverride: EditHandler | undefined;
+
+  const ctx = {
+    chat: { id: 42, type: 'private' },
+    session,
+    reply: async (text: string, extra?: unknown) => {
+      const messageId = nextMessageId++;
+      replyCalls.push({ text, extra, messageId });
+      return { message_id: messageId, chat: { id: 42 }, text };
+    },
+    telegram: {
+      editMessageText: async (
+        chatId: number,
+        messageId: number,
+        inlineMessageId: undefined,
+        text: string,
+        extra?: unknown,
+      ) => {
+        editCalls.push({ chatId, messageId, text, extra });
+        if (editOverride) {
+          return editOverride(chatId, messageId, inlineMessageId, text, extra);
+        }
+        return true;
+      },
+      deleteMessage: async (chatId: number, messageId: number) => {
+        deleteCalls.push({ chatId, messageId });
+        return true;
+      },
+    },
+  } as unknown as BotContext;
+
+  const setEditHandler = (handler: EditHandler | undefined) => {
+    editOverride = handler;
+  };
+
+  return { ctx, session, replyCalls, editCalls, deleteCalls, setEditHandler };
+};
+
+describe('ui helper', () => {
+  it('sends and tracks steps, editing existing messages when possible', async () => {
+    const { ctx, replyCalls, editCalls } = createMockContext();
+
+    const initial = await uiHelper.step(ctx, {
+      id: 'test:step',
+      text: 'Initial step',
+      cleanup: true,
+    });
+    assert.ok(initial?.sent);
+    assert.equal(replyCalls.length, 1);
+    assert.equal(ctx.session.ui.steps['test:step']?.cleanup, true);
+
+    const updated = await uiHelper.step(ctx, {
+      id: 'test:step',
+      text: 'Updated step',
+      cleanup: false,
+    });
+    assert.ok(updated);
+    assert.equal(updated?.sent, false);
+    assert.equal(replyCalls.length, 1);
+    assert.equal(editCalls.length, 1);
+    assert.equal(ctx.session.ui.steps['test:step']?.cleanup, false);
+  });
+
+  it('registers home actions when provided', async () => {
+    const { ctx } = createMockContext();
+
+    await uiHelper.step(ctx, { id: 'with-home', text: 'Menu', homeAction: 'home:test' });
+
+    assert.deepEqual(ctx.session.ui.homeActions, ['home:test']);
+  });
+
+  it('handles "message is not modified" errors without duplicating messages', async () => {
+    const { ctx, replyCalls, editCalls, setEditHandler } = createMockContext();
+
+    await uiHelper.step(ctx, { id: 'unchanged', text: 'Same text', cleanup: true });
+
+    setEditHandler(async () => {
+      const error = new Error('Bad Request: message is not modified');
+      (error as { description?: string }).description = 'Bad Request: message is not modified';
+      throw error;
+    });
+
+    const result = await uiHelper.step(ctx, {
+      id: 'unchanged',
+      text: 'Same text',
+      cleanup: true,
+    });
+    assert.ok(result);
+    assert.equal(result?.sent, false);
+    assert.equal(replyCalls.length, 1);
+    assert.equal(editCalls.length, 1);
+  });
+
+  it('clears cleanup steps when navigating home', async () => {
+    const { ctx, deleteCalls } = createMockContext();
+
+    await uiHelper.step(ctx, { id: 'cleanup', text: 'Remove me', cleanup: true });
+    await uiHelper.step(ctx, { id: 'keep', text: 'Keep me', cleanup: false });
+
+    await uiHelper.clear(ctx);
+
+    assert.equal(deleteCalls.length, 1);
+    assert.ok(!ctx.session.ui.steps['cleanup']);
+    assert.ok(ctx.session.ui.steps['keep']);
+  });
+
+  it('supports explicit clearing rules', async () => {
+    const { ctx, deleteCalls } = createMockContext();
+
+    await uiHelper.step(ctx, { id: 'first', text: 'First message', cleanup: false });
+    await uiHelper.step(ctx, { id: 'second', text: 'Second message', cleanup: false });
+
+    await uiHelper.clear(ctx, { cleanupOnly: false, ids: 'second' });
+
+    assert.equal(deleteCalls.length, 1);
+    assert.ok(ctx.session.ui.steps['first']);
+    assert.ok(!ctx.session.ui.steps['second']);
+  });
+});


### PR DESCRIPTION
## Summary
- replace direct replies in client and executor flows with `ui.step` so prompts, errors, and confirmations are tracked and cleaned up when returning home
- extend the UI helper with `ui.clear` and a guard for unchanged edits, and wire it into the auto-delete middleware
- add automated coverage for the UI helper behaviors and session reset lifecycle

## Testing
- npm test
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c99d500184832d869d0cbdf3d05978