### PR TITLE
Add configurable subscription env variables

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,42 @@
+# Environment configuration
+
+Freedom Bot relies on a handful of environment variables. The sections below outline
+which values are required and how optional settings can be used to fine‑tune the bot.
+
+## Required variables
+
+These variables must be present; the application will refuse to start if any of them
+are missing or blank.
+
+- `BOT_TOKEN` – Telegram bot token obtained via [@BotFather](https://t.me/BotFather).
+- `DATABASE_URL` – PostgreSQL connection string used by the application layer.
+- `KASPI_CARD` – Kaspi Gold card number shown in the subscription instructions.
+- `KASPI_NAME` – Account holder name displayed alongside the Kaspi details.
+- `KASPI_PHONE` – Contact phone number provided with the Kaspi payment details.
+
+## Subscription settings
+
+- `SUB_PRICE_7`, `SUB_PRICE_15`, `SUB_PRICE_30` – Override subscription prices (in
+  KZT) for 7, 15 and 30 day plans. Defaults are 5000, 9000 and 16000 respectively
+  when the variables are omitted.
+- `SUB_WARN_HOURS_BEFORE` – Number of hours before expiry when reminder messages are
+  sent. Defaults to 24 hours. The value must be a positive number.
+- `DRIVERS_CHANNEL_INVITE` – Optional fallback invite link delivered to executors when
+  an automatic invite cannot be created.
+
+## Location and geocoding
+
+- `CITY_DEFAULT` – Optional default city appended to short address queries.
+- `TWOGIS_API_KEY` – Enables the optional 2ГИС geocoding integration when present.
+- `NOMINATIM_BASE` – Optional base URL for self‑hosted Nominatim instances. When
+  provided, the bot derives `/search` and `/reverse` endpoints from this value.
+
+## Tariff hints
+
+The following values describe default tariff parameters used in external automations.
+They are optional but must be defined together when used.
+
+- `TARIFF_BASE` – Base fare applied to a new order.
+- `TARIFF_PER_KM` – Distance component calculated per kilometre.
+- `TARIFF_PER_MIN` – Time component calculated per minute.
+

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -6,7 +6,7 @@ import type {
   PhotoSize,
 } from 'telegraf/typings/core/types/typegram';
 
-import { logger } from '../../../config';
+import { config, logger } from '../../../config';
 import type { BotContext } from '../../types';
 import {
   EXECUTOR_MENU_ACTION,
@@ -35,16 +35,12 @@ const SUBSCRIPTION_SELECT_PERIOD_REMINDER_STEP_ID = 'executor:subscription:selec
 const SUBSCRIPTION_RECEIPT_REMINDER_STEP_ID = 'executor:subscription:receipt-reminder';
 const SUBSCRIPTION_SENDER_UNKNOWN_STEP_ID = 'executor:subscription:sender-unknown';
 
-const KASPI_DETAILS = [
-  'Получатель: Freedom Bot',
-  'Kaspi Gold: 4400 4301 2345 6789',
-  'Телефон: +7 (700) 000-00-00',
-  'Комментарий: Подписка Freedom Bot',
-];
-
 const formatKaspiDetails = (): string[] => [
   'Оплатите через Kaspi по реквизитам:',
-  ...KASPI_DETAILS,
+  `Получатель: ${config.subscriptions.payment.kaspi.name}`,
+  `Kaspi Gold: ${config.subscriptions.payment.kaspi.card}`,
+  `Телефон: ${config.subscriptions.payment.kaspi.phone}`,
+  'Комментарий: Подписка Freedom Bot',
 ];
 
 const buildPeriodKeyboard = (): InlineKeyboardMarkup =>

--- a/src/bot/flows/executor/subscriptionPlans.ts
+++ b/src/bot/flows/executor/subscriptionPlans.ts
@@ -1,3 +1,5 @@
+import { config } from '../../../config';
+
 export interface SubscriptionPeriodOption {
   id: string;
   /** Human-readable label describing the duration. */
@@ -15,22 +17,22 @@ export const SUBSCRIPTION_PERIOD_OPTIONS: readonly SubscriptionPeriodOption[] = 
     id: '7',
     label: '7 дней',
     days: 7,
-    amount: 5000,
-    currency: 'KZT',
+    amount: config.subscriptions.prices.sevenDays,
+    currency: config.subscriptions.prices.currency,
   },
   {
     id: '15',
     label: '15 дней',
     days: 15,
-    amount: 9000,
-    currency: 'KZT',
+    amount: config.subscriptions.prices.fifteenDays,
+    currency: config.subscriptions.prices.currency,
   },
   {
     id: '30',
     label: '30 дней',
     days: 30,
-    amount: 16000,
-    currency: 'KZT',
+    amount: config.subscriptions.prices.thirtyDays,
+    currency: config.subscriptions.prices.currency,
   },
 ] as const;
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
 export { config, loadConfig } from './env';
-export type { AppConfig, PricingConfig, RequiredEnvVar, TariffConfig } from './env';
+export type { AppConfig, PricingConfig, RequiredEnvVar, TariffConfig, TariffRates } from './env';
 export { logger } from './logger';
 export type { Logger } from './logger';

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -29,6 +29,15 @@ describe('pricing service', () => {
     const baseEnv = {
       BOT_TOKEN: originalEnv.BOT_TOKEN ?? 'test-token',
       DATABASE_URL: originalEnv.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db',
+      CITY_DEFAULT: originalEnv.CITY_DEFAULT ?? 'Алматы',
+      KASPI_CARD: originalEnv.KASPI_CARD ?? '4400 0000 0000 0000',
+      KASPI_NAME: originalEnv.KASPI_NAME ?? 'Freedom Bot',
+      KASPI_PHONE: originalEnv.KASPI_PHONE ?? '+7 (700) 000-00-00',
+      DRIVERS_CHANNEL_INVITE:
+        originalEnv.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers',
+      SUB_PRICE_7: originalEnv.SUB_PRICE_7 ?? '5000',
+      SUB_PRICE_15: originalEnv.SUB_PRICE_15 ?? '9000',
+      SUB_PRICE_30: originalEnv.SUB_PRICE_30 ?? '16000',
     } satisfies Record<string, string>;
 
     const setTariffEnv = (tariffs: PricingConfig) => {

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -56,6 +56,15 @@ async function importSupportModule() {
   process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
   process.env.DATABASE_URL =
     process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+  process.env.CITY_DEFAULT = process.env.CITY_DEFAULT ?? 'Алматы';
+  process.env.KASPI_CARD = process.env.KASPI_CARD ?? '4400 0000 0000 0000';
+  process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Freedom Bot';
+  process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+7 (700) 000-00-00';
+  process.env.DRIVERS_CHANNEL_INVITE =
+    process.env.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers';
+  process.env.SUB_PRICE_7 = process.env.SUB_PRICE_7 ?? '5000';
+  process.env.SUB_PRICE_15 = process.env.SUB_PRICE_15 ?? '9000';
+  process.env.SUB_PRICE_30 = process.env.SUB_PRICE_30 ?? '16000';
 
   return import('../src/bot/services/support');
 }

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -12,6 +12,15 @@ before(async () => {
   process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
   process.env.DATABASE_URL =
     process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+  process.env.CITY_DEFAULT = process.env.CITY_DEFAULT ?? 'Алматы';
+  process.env.KASPI_CARD = process.env.KASPI_CARD ?? '4400 0000 0000 0000';
+  process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Freedom Bot';
+  process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+7 (700) 000-00-00';
+  process.env.DRIVERS_CHANNEL_INVITE =
+    process.env.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers';
+  process.env.SUB_PRICE_7 = process.env.SUB_PRICE_7 ?? '5000';
+  process.env.SUB_PRICE_15 = process.env.SUB_PRICE_15 ?? '9000';
+  process.env.SUB_PRICE_30 = process.env.SUB_PRICE_30 ?? '16000';
 
   ({ ui: uiHelper } = await import('../src/bot/ui'));
 });


### PR DESCRIPTION
## Summary
- add configuration support for new subscription pricing, Kaspi payment and optional tariff settings
- hook geocoding into the central config, including optional NOMINATIM_BASE support, and document env variables
- update executor flows and moderation fallbacks to rely on the new config and adjust tests accordingly

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a63cbc68832d86aff0f258690fcf