### PR TITLE
Refactor executor verification moderation flow

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -37,12 +37,22 @@ const cloneUploadedPhotos = (
   return photos.map((photo) => ({ ...photo }));
 };
 
+const cloneModerationState = (
+  moderation?: ExecutorVerificationRoleState['moderation'],
+): ExecutorVerificationRoleState['moderation'] => {
+  if (!moderation) {
+    return undefined;
+  }
+
+  return { ...moderation };
+};
+
 const createRoleVerificationState = (): ExecutorVerificationRoleState => ({
   status: 'idle',
   requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
   uploadedPhotos: [],
   submittedAt: undefined,
-  moderationThreadMessageId: undefined,
+  moderation: undefined,
 });
 
 const createSubscriptionState = (): ExecutorSubscriptionState => ({
@@ -62,7 +72,7 @@ const normaliseRoleVerificationState = (
   requiredPhotos: ensurePositiveRequirement(value?.requiredPhotos),
   uploadedPhotos: cloneUploadedPhotos(value?.uploadedPhotos),
   submittedAt: value?.submittedAt,
-  moderationThreadMessageId: value?.moderationThreadMessageId,
+  moderation: cloneModerationState(value?.moderation),
 });
 
 const createDefaultVerificationState = () => {
@@ -151,6 +161,7 @@ export const resetVerificationState = (state: ExecutorFlowState): void => {
   state.verification[role] = {
     ...createRoleVerificationState(),
     requiredPhotos: ensurePositiveRequirement(current?.requiredPhotos),
+    moderation: undefined,
   };
 };
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -22,12 +22,19 @@ export interface ExecutorUploadedPhoto {
 
 export type ExecutorVerificationStatus = 'idle' | 'collecting' | 'submitted';
 
+export interface ExecutorVerificationModerationState {
+  applicationId?: string;
+  chatId?: number;
+  messageId?: number;
+  token?: string;
+}
+
 export interface ExecutorVerificationRoleState {
   status: ExecutorVerificationStatus;
   requiredPhotos: number;
   uploadedPhotos: ExecutorUploadedPhoto[];
   submittedAt?: number;
-  moderationThreadMessageId?: number;
+  moderation?: ExecutorVerificationModerationState;
 }
 
 export type ExecutorSubscriptionStatus =


### PR DESCRIPTION
## Summary
- extend executor verification session state with moderation metadata fields
- normalise and reset verification state to preserve moderation info correctly
- submit verification applications through the moderation queue, tracking publish metadata and handling approval/rejection callbacks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9b58a3140832d9ff9435f306c6b7d