### PR TITLE
Refactor schema to numeric ids and unified payments

### DIFF
--- a/db/sql/001_patch.sql
+++ b/db/sql/001_patch.sql
@@ -1,18 +1,345 @@
--- Follow-up adjustments supporting runtime query patterns.
+-- Follow-up adjustments migrating the legacy schema to the current layout.
+DO $$
+DECLARE
+    needs_migration boolean;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'users'
+          AND column_name = 'is_courier'
+    )
+    INTO needs_migration;
 
--- Ensure metadata columns fall back to empty objects when omitted in inserts.
-ALTER TABLE subscriptions
-    ALTER COLUMN metadata SET DEFAULT '{}'::jsonb;
+    IF NOT needs_migration THEN
+        RAISE NOTICE 'Skipping legacy schema migration; users.is_courier column not found.';
+        RETURN;
+    END IF;
 
-ALTER TABLE subscription_payments
-    ALTER COLUMN metadata SET DEFAULT '{}'::jsonb;
+    -- Prepare enum types and column conversions.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'user_role'
+    ) THEN
+        EXECUTE $$CREATE TYPE user_role AS ENUM ('client', 'executor', 'moderator')$$;
+    END IF;
 
-ALTER TABLE orders
-    ALTER COLUMN metadata SET DEFAULT '{}'::jsonb;
+    EXECUTE 'ALTER TYPE order_status RENAME TO order_status_old';
+    EXECUTE $$CREATE TYPE order_status AS ENUM ('open', 'claimed', 'cancelled', 'done')$$;
 
--- Helpful indexes for frequent lookups.
-CREATE INDEX IF NOT EXISTS idx_verifications_user_type_status
-    ON verifications(user_id, type, status);
+    EXECUTE $$
+        ALTER TABLE orders
+            ALTER COLUMN status DROP DEFAULT
+    $$;
 
-CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id
-    ON subscriptions(chat_id);
+    EXECUTE $$
+        ALTER TABLE orders
+            ALTER COLUMN status TYPE order_status
+            USING CASE
+                WHEN status::text = 'new' THEN 'open'::order_status
+                WHEN status::text = 'claimed' THEN 'claimed'::order_status
+                WHEN status::text = 'cancelled' THEN 'cancelled'::order_status
+                ELSE 'open'::order_status
+            END
+    $$;
+
+    EXECUTE $$ALTER TABLE orders ALTER COLUMN status SET DEFAULT 'open'::order_status$$;
+    EXECUTE 'DROP TYPE order_status_old';
+
+    -- Rename verification enum to the new name used by the runtime.
+    EXECUTE 'ALTER TYPE verification_type RENAME TO verification_role';
+
+    -- Extend orders with the new bookkeeping columns.
+    EXECUTE $$
+        ALTER TABLE orders
+            ADD COLUMN IF NOT EXISTS customer_name text,
+            ADD COLUMN IF NOT EXISTS customer_username text,
+            ADD COLUMN IF NOT EXISTS client_comment text,
+            ADD COLUMN IF NOT EXISTS claimed_by bigint,
+            ADD COLUMN IF NOT EXISTS claimed_at timestamptz,
+            ADD COLUMN IF NOT EXISTS completed_at timestamptz
+    $$;
+
+    EXECUTE $$
+        UPDATE orders
+        SET
+            customer_name = COALESCE(customer_name, metadata->>'customerName'),
+            customer_username = COALESCE(customer_username, metadata->>'customerUsername'),
+            client_comment = COALESCE(client_comment, metadata->>'notes')
+    $$;
+
+    EXECUTE $$
+        ALTER TABLE orders
+            DROP COLUMN IF EXISTS metadata
+    $$;
+
+    -- Ensure helper indexes exist for the extended order state.
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_orders_claimed_by ON orders(claimed_by)$$;
+
+    -- Create new user records with numeric identifiers and role/is_verified flags.
+    EXECUTE $$
+        CREATE TABLE users_new (
+            id bigserial PRIMARY KEY,
+            telegram_id bigint NOT NULL UNIQUE,
+            username text,
+            first_name text,
+            last_name text,
+            phone text,
+            role user_role NOT NULL DEFAULT 'client',
+            is_verified boolean NOT NULL DEFAULT false,
+            marketing_opt_in boolean NOT NULL DEFAULT false,
+            is_blocked boolean NOT NULL DEFAULT false,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            old_id uuid
+        )
+    $$;
+
+    EXECUTE $$
+        INSERT INTO users_new (
+            telegram_id,
+            username,
+            first_name,
+            last_name,
+            phone,
+            role,
+            marketing_opt_in,
+            is_blocked,
+            created_at,
+            updated_at,
+            old_id
+        )
+        SELECT
+            telegram_id,
+            username,
+            first_name,
+            last_name,
+            phone,
+            CASE WHEN is_courier THEN 'executor' ELSE 'client' END,
+            marketing_opt_in,
+            is_blocked,
+            created_at,
+            updated_at,
+            id
+        FROM users
+    $$;
+
+    EXECUTE $$
+        CREATE TEMP TABLE user_id_map ON COMMIT DROP AS
+        SELECT old_id, id AS new_id
+        FROM users_new
+    $$;
+
+    -- Rebuild verifications with explicit photo counters and numeric user references.
+    EXECUTE $$
+        CREATE TABLE verifications_new (
+            id bigserial PRIMARY KEY,
+            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
+            role verification_role NOT NULL,
+            status verification_status NOT NULL DEFAULT 'pending',
+            photos_required integer NOT NULL DEFAULT 0,
+            photos_uploaded integer NOT NULL DEFAULT 0,
+            expires_at timestamptz,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now()
+        )
+    $$;
+
+    EXECUTE $$
+        INSERT INTO verifications_new (
+            user_id,
+            role,
+            status,
+            photos_required,
+            photos_uploaded,
+            expires_at,
+            created_at,
+            updated_at
+        )
+        SELECT
+            map.new_id,
+            v.type::text::verification_role,
+            v.status,
+            0,
+            0,
+            v.expires_at,
+            v.created_at,
+            v.updated_at
+        FROM verifications v
+        JOIN user_id_map map ON map.old_id = v.user_id
+    $$;
+
+    -- Build the subscriptions table with numeric identifiers and the new warning bookkeeping.
+    EXECUTE $$
+        CREATE TABLE subscriptions_new (
+            id bigserial PRIMARY KEY,
+            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
+            chat_id bigint NOT NULL,
+            plan text NOT NULL,
+            tier text,
+            status subscription_status NOT NULL DEFAULT 'active',
+            currency text NOT NULL,
+            amount integer NOT NULL,
+            interval text NOT NULL,
+            interval_count integer NOT NULL DEFAULT 1,
+            next_billing_at timestamptz,
+            grace_until timestamptz,
+            cancel_at_period_end boolean NOT NULL DEFAULT false,
+            cancelled_at timestamptz,
+            ended_at timestamptz,
+            metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+            last_warning_at timestamptz,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            old_id uuid,
+            UNIQUE (user_id, chat_id)
+        )
+    $$;
+
+    EXECUTE $$
+        INSERT INTO subscriptions_new (
+            user_id,
+            chat_id,
+            plan,
+            tier,
+            status,
+            currency,
+            amount,
+            interval,
+            interval_count,
+            next_billing_at,
+            grace_until,
+            cancel_at_period_end,
+            cancelled_at,
+            ended_at,
+            metadata,
+            created_at,
+            updated_at,
+            old_id
+        )
+        SELECT
+            map.new_id,
+            chat_id,
+            plan,
+            tier,
+            status,
+            currency,
+            amount,
+            interval,
+            interval_count,
+            next_billing_at,
+            grace_until,
+            cancel_at_period_end,
+            cancelled_at,
+            ended_at,
+            COALESCE(metadata, '{}'::jsonb),
+            created_at,
+            updated_at,
+            id
+        FROM subscriptions s
+        JOIN user_id_map map ON map.old_id = s.user_id
+    $$;
+
+    EXECUTE $$
+        CREATE TEMP TABLE subscription_id_map ON COMMIT DROP AS
+        SELECT old_id, id AS new_id, user_id
+        FROM subscriptions_new
+    $$;
+
+    -- Create the consolidated payments table and backfill existing subscription payments.
+    EXECUTE $$
+        CREATE TABLE payments (
+            id bigserial PRIMARY KEY,
+            subscription_id bigint NOT NULL REFERENCES subscriptions_new(id) ON DELETE CASCADE,
+            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
+            amount integer NOT NULL,
+            currency text NOT NULL,
+            status text NOT NULL,
+            payment_provider text NOT NULL,
+            provider_payment_id text,
+            provider_customer_id text,
+            invoice_url text,
+            receipt_url text,
+            period_start timestamptz,
+            period_end timestamptz,
+            paid_at timestamptz,
+            metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            UNIQUE (provider_payment_id)
+        )
+    $$;
+
+    EXECUTE $$
+        INSERT INTO payments (
+            subscription_id,
+            user_id,
+            amount,
+            currency,
+            status,
+            payment_provider,
+            provider_payment_id,
+            provider_customer_id,
+            invoice_url,
+            receipt_url,
+            period_start,
+            period_end,
+            paid_at,
+            metadata,
+            created_at
+        )
+        SELECT
+            sub_map.new_id,
+            sub_map.user_id,
+            sp.amount,
+            sp.currency,
+            sp.status,
+            sp.payment_provider,
+            sp.provider_payment_id,
+            sp.provider_customer_id,
+            sp.invoice_url,
+            sp.receipt_url,
+            sp.period_start,
+            sp.period_end,
+            sp.paid_at,
+            COALESCE(sp.metadata, '{}'::jsonb),
+            sp.created_at
+        FROM subscription_payments sp
+        JOIN subscription_id_map sub_map ON sub_map.old_id = sp.subscription_id
+    $$;
+
+    -- Sync is_verified flags with active verifications.
+    EXECUTE $$
+        UPDATE users_new u
+        SET is_verified = true
+        WHERE EXISTS (
+            SELECT 1
+            FROM verifications_new v
+            WHERE v.user_id = u.id
+              AND v.status = 'approved'
+              AND (v.expires_at IS NULL OR v.expires_at > now())
+        )
+    $$;
+
+    -- Retire legacy tables now that data has been migrated.
+    EXECUTE 'DROP TABLE IF EXISTS subscription_payments';
+    EXECUTE 'DROP TABLE IF EXISTS subscription_events';
+    EXECUTE 'DROP TABLE verifications';
+    EXECUTE 'DROP TABLE subscriptions';
+    EXECUTE 'DROP TABLE users';
+
+    EXECUTE 'ALTER TABLE users_new DROP COLUMN old_id';
+    EXECUTE 'ALTER TABLE subscriptions_new DROP COLUMN old_id';
+
+    EXECUTE 'ALTER TABLE verifications_new RENAME TO verifications';
+    EXECUTE 'ALTER TABLE subscriptions_new RENAME TO subscriptions';
+    EXECUTE 'ALTER TABLE users_new RENAME TO users';
+
+    -- Final index and constraint tidy-up.
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_users_telegram_id ON users(telegram_id)$$;
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_verifications_user_role_status ON verifications(user_id, role, status)$$;
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id)$$;
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id ON subscriptions(chat_id)$$;
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_payments_subscription_id ON payments(subscription_id)$$;
+    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id)$$;
+END
+$$;

--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -343,14 +343,12 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
       kind: 'delivery',
       clientId: ctx.session.user?.id,
       clientPhone: ctx.session.phoneNumber,
+      customerName: buildCustomerName(ctx),
+      customerUsername: ctx.session.user?.username,
+      clientComment: draft.notes,
       pickup: draft.pickup,
       dropoff: draft.dropoff,
       price: draft.price,
-      metadata: {
-        customerName: buildCustomerName(ctx),
-        customerUsername: ctx.session.user?.username,
-        notes: comment,
-      },
     });
 
     const publishResult = await publishOrderToDriversChannel(ctx.telegram, order.id);

--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -270,13 +270,12 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
       kind: 'taxi',
       clientId: ctx.session.user?.id,
       clientPhone: ctx.session.phoneNumber,
+      customerName: buildCustomerName(ctx),
+      customerUsername: ctx.session.user?.username,
+      clientComment: draft.notes,
       pickup: draft.pickup,
       dropoff: draft.dropoff,
       price: draft.price,
-      metadata: {
-        customerName: buildCustomerName(ctx),
-        customerUsername: ctx.session.user?.username,
-      },
     });
 
     const publishResult = await publishOrderToDriversChannel(ctx.telegram, order.id);

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -92,7 +92,7 @@ export interface PaymentReviewItem extends ModerationQueueItemBase<PaymentReview
   /** Identifier of the payment under review. */
   id: string | number;
   /** Identifier of the related subscription, if any. */
-  subscriptionId?: string;
+  subscriptionId?: number | string;
   /** Amount of the payment. */
   amount: { value: number; currency: string };
   /** Payer details used for the moderation summary. */

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -35,7 +35,8 @@ const buildUserLabel = (subscription: SubscriptionWithUser): string => {
     parts.push(`ID ${subscription.telegramId}`);
   }
 
-  return parts.join(' ').trim() || subscription.userId;
+  const label = parts.join(' ').trim();
+  return label || String(subscription.userId);
 };
 
 const sendWarningMessage = async (
@@ -154,7 +155,7 @@ const processExpiringSubscriptions = async (
       );
     } finally {
       try {
-        await recordSubscriptionWarning(subscription.id, subscription.expiresAt);
+        await recordSubscriptionWarning(subscription.id, new Date());
       } catch (error) {
         logger.error(
           { err: error, subscriptionId: subscription.id },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,6 @@ export type {
   OrderStatus,
   OrderLocation,
   OrderPriceDetails,
-  OrderMetadata,
   OrderRecord,
   OrderInsertInput,
 } from './orders';

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -1,6 +1,6 @@
 export type OrderKind = 'taxi' | 'delivery';
 
-export type OrderStatus = 'new' | 'claimed' | 'cancelled';
+export type OrderStatus = 'open' | 'claimed' | 'cancelled' | 'done';
 
 export interface OrderLocation {
   query: string;
@@ -15,22 +15,21 @@ export interface OrderPriceDetails {
   distanceKm: number;
 }
 
-export interface OrderMetadata {
-  customerName?: string;
-  customerUsername?: string;
-  notes?: string;
-}
-
 export interface OrderRecord {
   id: number;
   kind: OrderKind;
   status: OrderStatus;
   clientId?: number;
   clientPhone?: string;
+  customerName?: string;
+  customerUsername?: string;
+  clientComment?: string;
+  claimedBy?: number;
+  claimedAt?: Date;
+  completedAt?: Date;
   pickup: OrderLocation;
   dropoff: OrderLocation;
   price: OrderPriceDetails;
-  metadata?: OrderMetadata;
   channelMessageId?: number;
   createdAt: Date;
 }
@@ -39,8 +38,10 @@ export interface OrderInsertInput {
   kind: OrderKind;
   clientId?: number;
   clientPhone?: string;
+  customerName?: string;
+  customerUsername?: string;
+  clientComment?: string;
   pickup: OrderLocation;
   dropoff: OrderLocation;
   price: OrderPriceDetails;
-  metadata?: OrderMetadata;
 }


### PR DESCRIPTION
## Summary
- update the initial schema to use numeric identifiers, enriched order details, last-warning tracking, and a unified payments table
- add a migration that converts existing UUID-based data and legacy tables into the new structure while backfilling derived columns
- adjust database access layers and bot flows to consume the new columns, enums, and subscription warning metadata

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9bfeae14c832d8f332452b03ff146