### PR TITLE
Align schema and data access with updated spec

### DIFF
--- a/db/sql/001_patch.sql
+++ b/db/sql/001_patch.sql
@@ -1,345 +1,386 @@
--- Follow-up adjustments migrating the legacy schema to the current layout.
+-- Idempotent patch ensuring the runtime schema matches the expected structure.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Ensure enum types exist and contain required values.
 DO $$
-DECLARE
-    needs_migration boolean;
 BEGIN
-    SELECT EXISTS (
-        SELECT 1
-        FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'users'
-          AND column_name = 'is_courier'
-    )
-    INTO needs_migration;
-
-    IF NOT needs_migration THEN
-        RAISE NOTICE 'Skipping legacy schema migration; users.is_courier column not found.';
-        RETURN;
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_role') THEN
+        CREATE TYPE user_role AS ENUM ('client', 'courier', 'driver');
     END IF;
-
-    -- Prepare enum types and column conversions.
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_type WHERE typname = 'user_role'
-    ) THEN
-        EXECUTE $$CREATE TYPE user_role AS ENUM ('client', 'executor', 'moderator')$$;
-    END IF;
-
-    EXECUTE 'ALTER TYPE order_status RENAME TO order_status_old';
-    EXECUTE $$CREATE TYPE order_status AS ENUM ('open', 'claimed', 'cancelled', 'done')$$;
-
-    EXECUTE $$
-        ALTER TABLE orders
-            ALTER COLUMN status DROP DEFAULT
-    $$;
-
-    EXECUTE $$
-        ALTER TABLE orders
-            ALTER COLUMN status TYPE order_status
-            USING CASE
-                WHEN status::text = 'new' THEN 'open'::order_status
-                WHEN status::text = 'claimed' THEN 'claimed'::order_status
-                WHEN status::text = 'cancelled' THEN 'cancelled'::order_status
-                ELSE 'open'::order_status
-            END
-    $$;
-
-    EXECUTE $$ALTER TABLE orders ALTER COLUMN status SET DEFAULT 'open'::order_status$$;
-    EXECUTE 'DROP TYPE order_status_old';
-
-    -- Rename verification enum to the new name used by the runtime.
-    EXECUTE 'ALTER TYPE verification_type RENAME TO verification_role';
-
-    -- Extend orders with the new bookkeeping columns.
-    EXECUTE $$
-        ALTER TABLE orders
-            ADD COLUMN IF NOT EXISTS customer_name text,
-            ADD COLUMN IF NOT EXISTS customer_username text,
-            ADD COLUMN IF NOT EXISTS client_comment text,
-            ADD COLUMN IF NOT EXISTS claimed_by bigint,
-            ADD COLUMN IF NOT EXISTS claimed_at timestamptz,
-            ADD COLUMN IF NOT EXISTS completed_at timestamptz
-    $$;
-
-    EXECUTE $$
-        UPDATE orders
-        SET
-            customer_name = COALESCE(customer_name, metadata->>'customerName'),
-            customer_username = COALESCE(customer_username, metadata->>'customerUsername'),
-            client_comment = COALESCE(client_comment, metadata->>'notes')
-    $$;
-
-    EXECUTE $$
-        ALTER TABLE orders
-            DROP COLUMN IF EXISTS metadata
-    $$;
-
-    -- Ensure helper indexes exist for the extended order state.
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_orders_claimed_by ON orders(claimed_by)$$;
-
-    -- Create new user records with numeric identifiers and role/is_verified flags.
-    EXECUTE $$
-        CREATE TABLE users_new (
-            id bigserial PRIMARY KEY,
-            telegram_id bigint NOT NULL UNIQUE,
-            username text,
-            first_name text,
-            last_name text,
-            phone text,
-            role user_role NOT NULL DEFAULT 'client',
-            is_verified boolean NOT NULL DEFAULT false,
-            marketing_opt_in boolean NOT NULL DEFAULT false,
-            is_blocked boolean NOT NULL DEFAULT false,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            updated_at timestamptz NOT NULL DEFAULT now(),
-            old_id uuid
-        )
-    $$;
-
-    EXECUTE $$
-        INSERT INTO users_new (
-            telegram_id,
-            username,
-            first_name,
-            last_name,
-            phone,
-            role,
-            marketing_opt_in,
-            is_blocked,
-            created_at,
-            updated_at,
-            old_id
-        )
-        SELECT
-            telegram_id,
-            username,
-            first_name,
-            last_name,
-            phone,
-            CASE WHEN is_courier THEN 'executor' ELSE 'client' END,
-            marketing_opt_in,
-            is_blocked,
-            created_at,
-            updated_at,
-            id
-        FROM users
-    $$;
-
-    EXECUTE $$
-        CREATE TEMP TABLE user_id_map ON COMMIT DROP AS
-        SELECT old_id, id AS new_id
-        FROM users_new
-    $$;
-
-    -- Rebuild verifications with explicit photo counters and numeric user references.
-    EXECUTE $$
-        CREATE TABLE verifications_new (
-            id bigserial PRIMARY KEY,
-            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
-            role verification_role NOT NULL,
-            status verification_status NOT NULL DEFAULT 'pending',
-            photos_required integer NOT NULL DEFAULT 0,
-            photos_uploaded integer NOT NULL DEFAULT 0,
-            expires_at timestamptz,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            updated_at timestamptz NOT NULL DEFAULT now()
-        )
-    $$;
-
-    EXECUTE $$
-        INSERT INTO verifications_new (
-            user_id,
-            role,
-            status,
-            photos_required,
-            photos_uploaded,
-            expires_at,
-            created_at,
-            updated_at
-        )
-        SELECT
-            map.new_id,
-            v.type::text::verification_role,
-            v.status,
-            0,
-            0,
-            v.expires_at,
-            v.created_at,
-            v.updated_at
-        FROM verifications v
-        JOIN user_id_map map ON map.old_id = v.user_id
-    $$;
-
-    -- Build the subscriptions table with numeric identifiers and the new warning bookkeeping.
-    EXECUTE $$
-        CREATE TABLE subscriptions_new (
-            id bigserial PRIMARY KEY,
-            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
-            chat_id bigint NOT NULL,
-            plan text NOT NULL,
-            tier text,
-            status subscription_status NOT NULL DEFAULT 'active',
-            currency text NOT NULL,
-            amount integer NOT NULL,
-            interval text NOT NULL,
-            interval_count integer NOT NULL DEFAULT 1,
-            next_billing_at timestamptz,
-            grace_until timestamptz,
-            cancel_at_period_end boolean NOT NULL DEFAULT false,
-            cancelled_at timestamptz,
-            ended_at timestamptz,
-            metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
-            last_warning_at timestamptz,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            updated_at timestamptz NOT NULL DEFAULT now(),
-            old_id uuid,
-            UNIQUE (user_id, chat_id)
-        )
-    $$;
-
-    EXECUTE $$
-        INSERT INTO subscriptions_new (
-            user_id,
-            chat_id,
-            plan,
-            tier,
-            status,
-            currency,
-            amount,
-            interval,
-            interval_count,
-            next_billing_at,
-            grace_until,
-            cancel_at_period_end,
-            cancelled_at,
-            ended_at,
-            metadata,
-            created_at,
-            updated_at,
-            old_id
-        )
-        SELECT
-            map.new_id,
-            chat_id,
-            plan,
-            tier,
-            status,
-            currency,
-            amount,
-            interval,
-            interval_count,
-            next_billing_at,
-            grace_until,
-            cancel_at_period_end,
-            cancelled_at,
-            ended_at,
-            COALESCE(metadata, '{}'::jsonb),
-            created_at,
-            updated_at,
-            id
-        FROM subscriptions s
-        JOIN user_id_map map ON map.old_id = s.user_id
-    $$;
-
-    EXECUTE $$
-        CREATE TEMP TABLE subscription_id_map ON COMMIT DROP AS
-        SELECT old_id, id AS new_id, user_id
-        FROM subscriptions_new
-    $$;
-
-    -- Create the consolidated payments table and backfill existing subscription payments.
-    EXECUTE $$
-        CREATE TABLE payments (
-            id bigserial PRIMARY KEY,
-            subscription_id bigint NOT NULL REFERENCES subscriptions_new(id) ON DELETE CASCADE,
-            user_id bigint NOT NULL REFERENCES users_new(id) ON DELETE CASCADE,
-            amount integer NOT NULL,
-            currency text NOT NULL,
-            status text NOT NULL,
-            payment_provider text NOT NULL,
-            provider_payment_id text,
-            provider_customer_id text,
-            invoice_url text,
-            receipt_url text,
-            period_start timestamptz,
-            period_end timestamptz,
-            paid_at timestamptz,
-            metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
-            created_at timestamptz NOT NULL DEFAULT now(),
-            UNIQUE (provider_payment_id)
-        )
-    $$;
-
-    EXECUTE $$
-        INSERT INTO payments (
-            subscription_id,
-            user_id,
-            amount,
-            currency,
-            status,
-            payment_provider,
-            provider_payment_id,
-            provider_customer_id,
-            invoice_url,
-            receipt_url,
-            period_start,
-            period_end,
-            paid_at,
-            metadata,
-            created_at
-        )
-        SELECT
-            sub_map.new_id,
-            sub_map.user_id,
-            sp.amount,
-            sp.currency,
-            sp.status,
-            sp.payment_provider,
-            sp.provider_payment_id,
-            sp.provider_customer_id,
-            sp.invoice_url,
-            sp.receipt_url,
-            sp.period_start,
-            sp.period_end,
-            sp.paid_at,
-            COALESCE(sp.metadata, '{}'::jsonb),
-            sp.created_at
-        FROM subscription_payments sp
-        JOIN subscription_id_map sub_map ON sub_map.old_id = sp.subscription_id
-    $$;
-
-    -- Sync is_verified flags with active verifications.
-    EXECUTE $$
-        UPDATE users_new u
-        SET is_verified = true
-        WHERE EXISTS (
-            SELECT 1
-            FROM verifications_new v
-            WHERE v.user_id = u.id
-              AND v.status = 'approved'
-              AND (v.expires_at IS NULL OR v.expires_at > now())
-        )
-    $$;
-
-    -- Retire legacy tables now that data has been migrated.
-    EXECUTE 'DROP TABLE IF EXISTS subscription_payments';
-    EXECUTE 'DROP TABLE IF EXISTS subscription_events';
-    EXECUTE 'DROP TABLE verifications';
-    EXECUTE 'DROP TABLE subscriptions';
-    EXECUTE 'DROP TABLE users';
-
-    EXECUTE 'ALTER TABLE users_new DROP COLUMN old_id';
-    EXECUTE 'ALTER TABLE subscriptions_new DROP COLUMN old_id';
-
-    EXECUTE 'ALTER TABLE verifications_new RENAME TO verifications';
-    EXECUTE 'ALTER TABLE subscriptions_new RENAME TO subscriptions';
-    EXECUTE 'ALTER TABLE users_new RENAME TO users';
-
-    -- Final index and constraint tidy-up.
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_users_telegram_id ON users(telegram_id)$$;
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_verifications_user_role_status ON verifications(user_id, role, status)$$;
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id)$$;
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id ON subscriptions(chat_id)$$;
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_payments_subscription_id ON payments(subscription_id)$$;
-    EXECUTE $$CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id)$$;
 END
 $$;
+
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'courier';
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'driver';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'order_kind') THEN
+        CREATE TYPE order_kind AS ENUM ('taxi', 'delivery');
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'order_status') THEN
+        CREATE TYPE order_status AS ENUM ('open', 'claimed', 'cancelled', 'done');
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'verification_role') THEN
+        CREATE TYPE verification_role AS ENUM ('courier', 'driver');
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'verification_status') THEN
+        CREATE TYPE verification_status AS ENUM ('pending', 'approved', 'rejected', 'cancelled');
+    END IF;
+END
+$$;
+
+ALTER TYPE verification_status ADD VALUE IF NOT EXISTS 'cancelled';
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'subscription_status') THEN
+        CREATE TYPE subscription_status AS ENUM (
+            'active',
+            'trialing',
+            'past_due',
+            'canceled',
+            'expired',
+            'paused'
+        );
+    END IF;
+END
+$$;
+
+-- Create tables when missing so later alterations succeed.
+CREATE TABLE IF NOT EXISTS users (
+    id bigserial PRIMARY KEY,
+    tg_id bigint NOT NULL,
+    username text,
+    first_name text,
+    last_name text,
+    phone text,
+    role user_role NOT NULL DEFAULT 'client',
+    is_verified boolean NOT NULL DEFAULT false,
+    marketing_opt_in boolean NOT NULL DEFAULT false,
+    is_blocked boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (tg_id)
+);
+
+CREATE TABLE IF NOT EXISTS channels (
+    id boolean PRIMARY KEY DEFAULT true,
+    verify_channel_id bigint,
+    drivers_channel_id bigint
+);
+
+CREATE TABLE IF NOT EXISTS verifications (
+    id bigserial PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role verification_role NOT NULL,
+    status verification_status NOT NULL DEFAULT 'pending',
+    photos_required integer NOT NULL DEFAULT 0,
+    photos_uploaded integer NOT NULL DEFAULT 0,
+    expires_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS verification_photos (
+    id bigserial PRIMARY KEY,
+    verification_id bigint NOT NULL REFERENCES verifications(id) ON DELETE CASCADE,
+    file_id text NOT NULL,
+    file_unique_id text,
+    file_size integer,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id bigserial PRIMARY KEY,
+    kind order_kind NOT NULL,
+    status order_status NOT NULL DEFAULT 'open',
+    client_id bigint REFERENCES users(id) ON DELETE SET NULL,
+    client_phone text,
+    customer_name text,
+    customer_username text,
+    client_comment text,
+    claimed_by bigint REFERENCES users(id) ON DELETE SET NULL,
+    claimed_at timestamptz,
+    completed_at timestamptz,
+    pickup_query text NOT NULL,
+    pickup_address text NOT NULL,
+    pickup_lat double precision NOT NULL,
+    pickup_lon double precision NOT NULL,
+    dropoff_query text NOT NULL,
+    dropoff_address text NOT NULL,
+    dropoff_lat double precision NOT NULL,
+    dropoff_lon double precision NOT NULL,
+    price_amount integer NOT NULL,
+    price_currency text NOT NULL,
+    distance_km double precision NOT NULL,
+    channel_message_id bigint,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS order_channel_posts (
+    id bigserial PRIMARY KEY,
+    order_id bigint NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    channel_id bigint NOT NULL,
+    message_id bigint NOT NULL,
+    thread_id bigint,
+    published_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (order_id, channel_id)
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id bigserial PRIMARY KEY,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    chat_id bigint NOT NULL,
+    plan text NOT NULL,
+    tier text,
+    status subscription_status NOT NULL DEFAULT 'active',
+    currency text NOT NULL,
+    amount integer NOT NULL,
+    interval text NOT NULL,
+    interval_count integer NOT NULL DEFAULT 1,
+    next_billing_at timestamptz,
+    grace_until timestamptz,
+    cancel_at_period_end boolean NOT NULL DEFAULT false,
+    cancelled_at timestamptz,
+    ended_at timestamptz,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    last_warning_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, chat_id)
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id bigserial PRIMARY KEY,
+    subscription_id bigint NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    user_id bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount integer NOT NULL,
+    currency text NOT NULL,
+    status text NOT NULL,
+    payment_provider text NOT NULL,
+    provider_payment_id text,
+    provider_customer_id text,
+    invoice_url text,
+    receipt_url text,
+    period_start timestamptz,
+    period_end timestamptz,
+    paid_at timestamptz,
+    metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (provider_payment_id)
+);
+
+CREATE TABLE IF NOT EXISTS callback_map (
+    token text PRIMARY KEY,
+    action text NOT NULL,
+    chat_id bigint,
+    message_id bigint,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    expires_at timestamptz NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS support_threads (
+    id text PRIMARY KEY,
+    user_chat_id bigint NOT NULL,
+    user_tg_id bigint,
+    user_message_id bigint NOT NULL,
+    moderator_chat_id bigint NOT NULL,
+    moderator_message_id bigint NOT NULL,
+    status text NOT NULL DEFAULT 'open',
+    closed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT support_threads_status_check CHECK (status IN ('open', 'closed'))
+);
+
+-- Column adjustments for legacy databases.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'users'
+          AND column_name = 'telegram_id'
+    )
+    THEN
+        EXECUTE 'ALTER TABLE users RENAME COLUMN telegram_id TO tg_id';
+    END IF;
+END
+$$;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS username text,
+    ADD COLUMN IF NOT EXISTS first_name text,
+    ADD COLUMN IF NOT EXISTS last_name text,
+    ADD COLUMN IF NOT EXISTS phone text,
+    ADD COLUMN IF NOT EXISTS role user_role;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS is_verified boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS marketing_opt_in boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS is_blocked boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE users
+    ALTER COLUMN role SET DEFAULT 'client';
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'users'
+          AND column_name = 'role'
+    )
+    THEN
+        BEGIN
+            ALTER TABLE users ALTER COLUMN role SET NOT NULL;
+        EXCEPTION
+            WHEN not_null_violation THEN
+                RAISE NOTICE 'Skipping NOT NULL on users.role due to existing null values.';
+        END;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'users'
+          AND column_name = 'tg_id'
+    )
+    THEN
+        BEGIN
+            ALTER TABLE users ALTER COLUMN tg_id TYPE bigint USING tg_id::bigint;
+        EXCEPTION
+            WHEN invalid_text_representation THEN
+                RAISE NOTICE 'Skipping tg_id type coercion due to incompatible data.';
+        END;
+
+        BEGIN
+            ALTER TABLE users ALTER COLUMN tg_id SET NOT NULL;
+        EXCEPTION
+            WHEN not_null_violation THEN
+                RAISE NOTICE 'Skipping NOT NULL on users.tg_id due to existing null values.';
+        END;
+    END IF;
+END
+$$;
+
+-- Bring legacy verification counters up to date.
+ALTER TABLE verifications
+    ADD COLUMN IF NOT EXISTS photos_required integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS photos_uploaded integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS expires_at timestamptz,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+-- Extend orders with the required bookkeeping columns.
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS client_phone text,
+    ADD COLUMN IF NOT EXISTS customer_name text,
+    ADD COLUMN IF NOT EXISTS customer_username text,
+    ADD COLUMN IF NOT EXISTS client_comment text,
+    ADD COLUMN IF NOT EXISTS claimed_by bigint,
+    ADD COLUMN IF NOT EXISTS claimed_at timestamptz,
+    ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+    ADD COLUMN IF NOT EXISTS channel_message_id bigint,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+
+-- Subscription table safety checks.
+ALTER TABLE subscriptions
+    ADD COLUMN IF NOT EXISTS tier text,
+    ADD COLUMN IF NOT EXISTS next_billing_at timestamptz,
+    ADD COLUMN IF NOT EXISTS grace_until timestamptz,
+    ADD COLUMN IF NOT EXISTS cancel_at_period_end boolean NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS cancelled_at timestamptz,
+    ADD COLUMN IF NOT EXISTS ended_at timestamptz,
+    ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS last_warning_at timestamptz,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'subscriptions_user_chat_unique'
+    )
+    THEN
+        ALTER TABLE subscriptions
+            ADD CONSTRAINT subscriptions_user_chat_unique UNIQUE (user_id, chat_id);
+    END IF;
+END
+$$;
+
+-- Payment table safety checks.
+ALTER TABLE payments
+    ADD COLUMN IF NOT EXISTS provider_payment_id text,
+    ADD COLUMN IF NOT EXISTS provider_customer_id text,
+    ADD COLUMN IF NOT EXISTS invoice_url text,
+    ADD COLUMN IF NOT EXISTS receipt_url text,
+    ADD COLUMN IF NOT EXISTS period_start timestamptz,
+    ADD COLUMN IF NOT EXISTS period_end timestamptz,
+    ADD COLUMN IF NOT EXISTS paid_at timestamptz,
+    ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+
+-- Support thread constraint enforcement.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.constraint_column_usage
+        WHERE table_name = 'support_threads'
+          AND constraint_name = 'support_threads_status_check'
+    )
+    THEN
+        ALTER TABLE support_threads
+            ADD CONSTRAINT support_threads_status_check CHECK (status IN ('open', 'closed'));
+    END IF;
+END
+$$;
+
+-- Seed the singleton channels row.
+INSERT INTO channels (id)
+VALUES (true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create helper indexes required by the application.
+CREATE INDEX IF NOT EXISTS idx_users_tg_id ON users(tg_id);
+CREATE INDEX IF NOT EXISTS idx_verifications_user_role_status ON verifications(user_id, role, status);
+CREATE INDEX IF NOT EXISTS idx_verification_photos_verification_id ON verification_photos(verification_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status);
+CREATE INDEX IF NOT EXISTS idx_orders_claimed_by ON orders(claimed_by);
+CREATE INDEX IF NOT EXISTS idx_orders_created_at ON orders(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_order_channel_posts_order_id ON order_channel_posts(order_id);
+CREATE INDEX IF NOT EXISTS idx_order_channel_posts_channel_message ON order_channel_posts(channel_id, message_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id ON subscriptions(chat_id);
+CREATE INDEX IF NOT EXISTS idx_payments_subscription_id ON payments(subscription_id);
+CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);
+CREATE INDEX IF NOT EXISTS idx_callback_map_expires_at ON callback_map(expires_at);
+CREATE INDEX IF NOT EXISTS idx_support_threads_status ON support_threads(status);
+CREATE INDEX IF NOT EXISTS idx_support_threads_moderator_message ON support_threads(moderator_chat_id, moderator_message_id);

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -371,6 +371,7 @@ const handleSubscriptionApproval = async (
       firstName: subscription.firstName,
       lastName: subscription.lastName,
       phone: subscription.phone,
+      role: subscription.role,
       chatId: binding.chatId,
       periodDays: subscription.period.days,
       periodLabel: subscription.period.label,

--- a/src/bot/services/support.ts
+++ b/src/bot/services/support.ts
@@ -120,7 +120,7 @@ interface SupportThreadState {
 interface SupportThreadRow {
   id: string;
   user_chat_id: number | string;
-  user_telegram_id: number | string | null;
+  user_tg_id: number | string | null;
   user_message_id: number;
   moderator_chat_id: number | string;
   moderator_message_id: number;
@@ -235,7 +235,7 @@ const insertSupportThreadRecord = async (
         INSERT INTO support_threads (
           id,
           user_chat_id,
-          user_telegram_id,
+          user_tg_id,
           user_message_id,
           moderator_chat_id,
           moderator_message_id,


### PR DESCRIPTION
## Summary
- rebuild the base schema to use the new executor role literals, rename users.telegram_id to tg_id, and add verification_photos, order_channel_posts, callback_map, and support_threads tables with their indexes
- replace the legacy migration with an idempotent patch that creates the same tables, columns, and indexes while safely renaming telegram_id when present
- update subscription, verification, and support data access layers to target tg_id and propagate executor roles through moderation flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e5311898832d9aadc5c02c03ef81