### PR TITLE
Persist Telegraf session state in Postgres

### DIFF
--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -200,6 +200,16 @@ CREATE TABLE IF NOT EXISTS callback_map (
     created_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Persistent session storage for the bot finite state machine.
+CREATE TABLE IF NOT EXISTS sessions (
+    scope text NOT NULL,
+    scope_id bigint NOT NULL,
+    state jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (scope, scope_id)
+);
+
 -- Support conversations between users and moderators.
 CREATE TABLE IF NOT EXISTS support_threads (
     id text PRIMARY KEY,

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -1,5 +1,12 @@
 import type { MiddlewareFn } from 'telegraf';
 
+import { pool } from '../../db';
+import {
+  deleteSessionState,
+  loadSessionState,
+  saveSessionState,
+  type SessionKey,
+} from '../../db/sessions';
 import {
   EXECUTOR_ROLES,
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
@@ -58,25 +65,85 @@ const createDefaultState = (): SessionState => ({
   ui: createUiState(),
 });
 
-const resolveSessionKey = (ctx: BotContext): string | undefined => {
-  if (ctx.chat?.id !== undefined) {
-    return `chat:${ctx.chat.id}`;
+const SESSION_META = Symbol('session-meta');
+
+interface SessionMeta {
+  key: SessionKey;
+  cleared: boolean;
+}
+
+type SessionMetaContainer = {
+  [SESSION_META]?: SessionMeta;
+};
+
+const setSessionMeta = (ctx: BotContext, meta?: SessionMeta): void => {
+  const container = ctx as BotContext & SessionMetaContainer;
+  if (meta) {
+    container[SESSION_META] = meta;
+  } else {
+    delete container[SESSION_META];
+  }
+};
+
+const getSessionMeta = (ctx: BotContext): SessionMeta | undefined => {
+  const container = ctx as BotContext & SessionMetaContainer;
+  return container[SESSION_META];
+};
+
+const parseScopeId = (value: unknown): string | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value).toString();
   }
 
-  if (ctx.from?.id !== undefined) {
-    return `user:${ctx.from.id}`;
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+
+    if (/^[+-]?\d+$/.test(trimmed)) {
+      try {
+        return BigInt(trimmed).toString();
+      } catch {
+        return undefined;
+      }
+    }
   }
 
   return undefined;
 };
 
-const store = new Map<string, SessionState>();
-
-export const clearSession = (ctx: BotContext): void => {
-  const key = resolveSessionKey(ctx);
-  if (key) {
-    store.delete(key);
+const resolveSessionKey = (ctx: BotContext): SessionKey | undefined => {
+  const chatId = parseScopeId(ctx.chat?.id);
+  if (chatId !== undefined) {
+    return { scope: 'chat', scopeId: chatId } satisfies SessionKey;
   }
+
+  const userId = parseScopeId(ctx.from?.id);
+  if (userId !== undefined) {
+    return { scope: 'user', scopeId: userId } satisfies SessionKey;
+  }
+
+  return undefined;
+};
+
+export const clearSession = async (ctx: BotContext): Promise<void> => {
+  const key = resolveSessionKey(ctx);
+  if (!key) {
+    return;
+  }
+
+  const meta = getSessionMeta(ctx);
+  if (meta && meta.key.scope === key.scope && meta.key.scopeId === key.scopeId) {
+    meta.cleared = true;
+    return;
+  }
+
+  await deleteSessionState(pool, key);
 };
 
 export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
@@ -86,19 +153,52 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     return;
   }
 
-  const existing = store.get(key);
-  const state = existing ?? createDefaultState();
+  const client = await pool.connect();
+  const meta: SessionMeta = { key, cleared: false };
+  setSessionMeta(ctx, meta);
 
-  if (!state.ui) {
-    state.ui = createUiState();
-  }
-
-  ctx.session = state;
+  let nextError: unknown;
 
   try {
-    await next();
+    await client.query('BEGIN');
+
+    const existing = await loadSessionState(client, key, { forUpdate: true });
+    const state = existing ?? createDefaultState();
+
+    if (!state.ui) {
+      state.ui = createUiState();
+    }
+
+    ctx.session = state;
+
+    try {
+      await next();
+    } catch (error) {
+      nextError = error;
+    }
+
+    if (meta.cleared) {
+      await deleteSessionState(client, key);
+    } else {
+      await saveSessionState(client, key, ctx.session);
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to rollback session transaction', rollbackError);
+    }
+    throw error;
   } finally {
-    store.set(key, ctx.session);
+    setSessionMeta(ctx, undefined);
+    client.release();
+  }
+
+  if (nextError) {
+    throw nextError;
   }
 };
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,1 +1,2 @@
 export * from './client';
+export * from './sessions';

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -1,0 +1,100 @@
+import type { PoolClient } from './client';
+
+import type { SessionState } from '../bot/types';
+
+export type SessionScope = 'chat' | 'user';
+
+export interface SessionKey {
+  scope: SessionScope;
+  scopeId: string;
+}
+
+interface SessionRow {
+  state: SessionState | string | null;
+}
+
+type Queryable = Pick<PoolClient, 'query'>;
+
+const parseSessionState = (value: SessionRow['state']): SessionState => {
+  if (value === null || value === undefined) {
+    throw new Error('Session payload is empty');
+  }
+
+  if (typeof value === 'string') {
+    return JSON.parse(value) as SessionState;
+  }
+
+  if (typeof value === 'object') {
+    return value as SessionState;
+  }
+
+  throw new Error('Unsupported session payload type');
+};
+
+export const loadSessionState = async (
+  client: PoolClient,
+  key: SessionKey,
+  options: { forUpdate?: boolean } = {},
+): Promise<SessionState | null> => {
+  const lockClause = options.forUpdate ? ' FOR UPDATE' : '';
+  const { rows } = await client.query<SessionRow>(
+    `
+      SELECT state
+      FROM sessions
+      WHERE scope = $1 AND scope_id = $2${lockClause}
+    `,
+    [key.scope, key.scopeId],
+  );
+
+  const [row] = rows;
+  if (!row) {
+    return null;
+  }
+
+  try {
+    return parseSessionState(row.state);
+  } catch (error) {
+    const reason =
+      error instanceof Error ? error.message : typeof error === 'string' ? error : 'unknown error';
+    throw new Error(
+      `Failed to parse session state for ${key.scope}:${key.scopeId}: ${reason}`,
+    );
+  }
+};
+
+export const saveSessionState = async (
+  queryable: Queryable,
+  key: SessionKey,
+  state: SessionState,
+): Promise<void> => {
+  let payload: string;
+  try {
+    payload = JSON.stringify(state);
+  } catch (error) {
+    const reason =
+      error instanceof Error ? error.message : typeof error === 'string' ? error : 'unknown error';
+    throw new Error(`Failed to serialise session state: ${reason}`);
+  }
+
+  await queryable.query(
+    `
+      INSERT INTO sessions (scope, scope_id, state)
+      VALUES ($1, $2, $3::jsonb)
+      ON CONFLICT (scope, scope_id) DO UPDATE
+      SET state = EXCLUDED.state,
+          updated_at = now()
+    `,
+    [key.scope, key.scopeId, payload],
+  );
+};
+
+export const deleteSessionState = async (
+  queryable: Queryable,
+  key: SessionKey,
+): Promise<void> => {
+  await queryable.query(`DELETE FROM sessions WHERE scope = $1 AND scope_id = $2`, [
+    key.scope,
+    key.scopeId,
+  ]);
+};
+

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,8 +1,79 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { clearSession, session } from '../src/bot/middlewares/session';
 import type { BotContext } from '../src/bot/types';
+import { pool } from '../src/db';
+
+type QueryHandler = (
+  text: string,
+  params?: ReadonlyArray<unknown>,
+) => Promise<{ rows: unknown[] }>;
+
+const originalConnect = pool.connect.bind(pool);
+const originalQuery = pool.query.bind(pool);
+
+const normaliseSql = (text: string): string => text.replace(/\s+/g, ' ').trim().toLowerCase();
+
+const createSessionQueryHandler = (store: Map<string, string>): QueryHandler => {
+  return async (text, params = []) => {
+    const normalised = normaliseSql(text);
+
+    if (normalised.startsWith('begin') || normalised.startsWith('commit')) {
+      return { rows: [] };
+    }
+
+    if (normalised.startsWith('rollback')) {
+      return { rows: [] };
+    }
+
+    if (normalised.startsWith('select') && normalised.includes('from sessions')) {
+      const [scope, scopeId] = params as [string, string];
+      const key = `${scope}:${scopeId}`;
+      const payload = store.get(key);
+      if (!payload) {
+        return { rows: [] };
+      }
+      return { rows: [{ state: JSON.parse(payload) }] };
+    }
+
+    if (normalised.startsWith('insert into sessions')) {
+      const [scope, scopeId, payload] = params as [string, string, unknown];
+      const key = `${scope}:${scopeId}`;
+      const serialised =
+        typeof payload === 'string' ? payload : JSON.stringify(payload ?? {});
+      store.set(key, serialised);
+      return { rows: [] };
+    }
+
+    if (normalised.startsWith('delete from sessions')) {
+      const [scope, scopeId] = params as [string, string];
+      const key = `${scope}:${scopeId}`;
+      store.delete(key);
+      return { rows: [] };
+    }
+
+    throw new Error(`Unexpected SQL in session middleware test: ${text}`);
+  };
+};
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  const handler = createSessionQueryHandler(store);
+
+  (pool as unknown as { connect: () => Promise<{ query: QueryHandler; release: () => void }> }).connect =
+    async () => ({
+      query: handler,
+      release: () => {},
+    });
+
+  (pool as unknown as { query: QueryHandler }).query = handler;
+});
+
+afterEach(() => {
+  (pool as unknown as { connect: typeof originalConnect }).connect = originalConnect;
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
 
 describe('session middleware', () => {
   it('resets session state to initial values after clearing', async () => {
@@ -24,7 +95,7 @@ describe('session middleware', () => {
     assert.ok(ctx.session.ui.steps['demo']);
     assert.deepEqual(ctx.session.ui.homeActions, ['home:demo']);
 
-    clearSession(ctx);
+    await clearSession(ctx);
 
     const ctx2 = { chat: { id: 999, type: 'private' }, from: { id: 555 } } as unknown as BotContext;
     await middleware(ctx2, async () => {});
@@ -36,6 +107,6 @@ describe('session middleware', () => {
     assert.deepEqual(ctx2.session.ui.homeActions, []);
     assert.notStrictEqual(ctx2.session, ctx.session);
 
-    clearSession(ctx2);
+    await clearSession(ctx2);
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated `sessions` table to the SQL migrations for storing FSM state keyed by scope and identifier
- add Postgres data-access helpers and update the session middleware to read/write session rows transactionally
- adjust the session middleware test suite to exercise the new persistence layer with a mocked pg client

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e9393adc832d99d2a17ae2688e71