### PR TITLE
Move phone collect flow into common flows directory

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -1,7 +1,7 @@
 import { Markup, Telegraf } from 'telegraf';
 
 import type { BotContext } from '../types';
-import { phoneCollect } from '../utils/phone-collect';
+import { phoneCollect } from '../flows/common/phoneCollect';
 
 type RoleKey = 'client' | 'courier' | 'driver';
 

--- a/src/bot/flows/common/phoneCollect.ts
+++ b/src/bot/flows/common/phoneCollect.ts
@@ -1,6 +1,6 @@
 import { Markup } from 'telegraf';
 
-import type { BotContext } from '../types';
+import type { BotContext } from '../../types';
 
 export interface PhoneCollectOptions {
   /** Custom prompt shown when requesting the phone number. */


### PR DESCRIPTION
## Summary
- move the phone collection helper into the flows/common folder to align with the directory structure
- adjust the start command to import the helper from its new location

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9ece7160c832db29396dc09baa0bb