### PR TITLE
Align database schema with expected structure

### DIFF
--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -2,7 +2,7 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- Domain types used throughout the schema.
-CREATE TYPE IF NOT EXISTS user_role AS ENUM ('client', 'courier', 'driver');
+CREATE TYPE IF NOT EXISTS user_role AS ENUM ('client', 'courier', 'driver', 'moderator');
 CREATE TYPE IF NOT EXISTS order_kind AS ENUM ('taxi', 'delivery');
 CREATE TYPE IF NOT EXISTS order_status AS ENUM ('open', 'claimed', 'cancelled', 'done');
 CREATE TYPE IF NOT EXISTS verification_role AS ENUM ('courier', 'driver');


### PR DESCRIPTION
## Summary
- expand enum normalisation to include the moderator role and remap legacy values before recreating each type【F:db/sql/000_init.sql†L1-L11】【F:db/sql/001_patch.sql†L7-L291】
- harden user and verification migrations by adding missing columns, default values, and not-null enforcement aligned with the specification【F:db/sql/001_patch.sql†L708-L884】【F:db/sql/001_patch.sql†L962-L1034】
- extend migration coverage for orders, channel posts, subscriptions, payments, sessions, callback map, and support threads to add required columns, foreign keys, and data cleanup routines【F:db/sql/001_patch.sql†L1121-L1427】【F:db/sql/001_patch.sql†L1479-L1689】【F:db/sql/001_patch.sql†L1755-L1894】【F:db/sql/001_patch.sql†L1910-L2048】

## Testing
- npm test【fbf7c4†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68ca077c3918832d82496adf03bd474d