### PR TITLE
Implement auth context and executor access control

### DIFF
--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -341,10 +341,10 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
   try {
     const order = await createOrder({
       kind: 'delivery',
-      clientId: ctx.session.user?.id,
+      clientId: ctx.auth.user.telegramId,
       clientPhone: ctx.session.phoneNumber,
       customerName: buildCustomerName(ctx),
-      customerUsername: ctx.session.user?.username,
+      customerUsername: ctx.auth.user.username,
       clientComment: draft.notes,
       pickup: draft.pickup,
       dropoff: draft.dropoff,

--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -268,10 +268,10 @@ const confirmOrder = async (ctx: BotContext, draft: ClientOrderDraftState): Prom
   try {
     const order = await createOrder({
       kind: 'taxi',
-      clientId: ctx.session.user?.id,
+      clientId: ctx.auth.user.telegramId,
       clientPhone: ctx.session.phoneNumber,
       customerName: buildCustomerName(ctx),
-      customerUsername: ctx.session.user?.username,
+      customerUsername: ctx.auth.user.username,
       clientComment: draft.notes,
       pickup: draft.pickup,
       dropoff: draft.dropoff,

--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -1,7 +1,197 @@
 import type { MiddlewareFn } from 'telegraf';
 
 import { logger } from '../../config';
-import type { BotContext } from '../types';
+import { pool } from '../../db';
+import {
+  EXECUTOR_ROLES,
+  type AuthExecutorState,
+  type AuthState,
+  type BotContext,
+  type ExecutorRole,
+  type UserRole,
+} from '../types';
+
+type Nullable<T> = T | null | undefined;
+
+interface AuthQueryRow {
+  tg_id: string | number;
+  username: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  phone: string | null;
+  role: string | null;
+  is_verified: boolean | null;
+  is_blocked: boolean | null;
+  courier_verified: boolean | null;
+  driver_verified: boolean | null;
+  has_active_subscription: boolean | null;
+}
+
+const parseNumericId = (value: string | number): number => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Failed to parse numeric identifier: ${value}`);
+  }
+
+  return parsed;
+};
+
+const normaliseString = (value: Nullable<string>): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const normaliseRole = (value: Nullable<string>): UserRole => {
+  switch (value) {
+    case 'courier':
+    case 'driver':
+    case 'moderator':
+      return value;
+    case 'client':
+    default:
+      return 'client';
+  }
+};
+
+const buildVerifiedMap = (row: AuthQueryRow): Record<ExecutorRole, boolean> => ({
+  courier: Boolean(row.courier_verified),
+  driver: Boolean(row.driver_verified),
+});
+
+const buildExecutorState = (row: AuthQueryRow): AuthExecutorState => {
+  const verifiedRoles = buildVerifiedMap(row);
+  const isVerified = Boolean(row.is_verified) || EXECUTOR_ROLES.some((role) => verifiedRoles[role]);
+
+  return {
+    verifiedRoles,
+    hasActiveSubscription: Boolean(row.has_active_subscription),
+    isVerified,
+  } satisfies AuthExecutorState;
+};
+
+const mapAuthRow = (row: AuthQueryRow): AuthState => {
+  const telegramId = parseNumericId(row.tg_id);
+  const executor = buildExecutorState(row);
+  const role = normaliseRole(row.role);
+
+  return {
+    user: {
+      telegramId,
+      username: normaliseString(row.username),
+      firstName: normaliseString(row.first_name),
+      lastName: normaliseString(row.last_name),
+      phone: normaliseString(row.phone),
+      role,
+      isVerified: Boolean(row.is_verified),
+      isBlocked: Boolean(row.is_blocked),
+    },
+    executor,
+    isModerator: role === 'moderator',
+  } satisfies AuthState;
+};
+
+const loadAuthState = async (
+  from: NonNullable<BotContext['from']>,
+): Promise<AuthState> => {
+  const { rows } = await pool.query<AuthQueryRow>(
+    `
+      WITH upsert AS (
+        INSERT INTO users (tg_id, username, first_name, last_name, updated_at)
+        VALUES ($1, $2, $3, $4, now())
+        ON CONFLICT (tg_id) DO UPDATE
+        SET
+          username = COALESCE(EXCLUDED.username, users.username),
+          first_name = COALESCE(EXCLUDED.first_name, users.first_name),
+          last_name = COALESCE(EXCLUDED.last_name, users.last_name),
+          updated_at = now()
+        RETURNING tg_id, username, first_name, last_name, phone, role, is_verified, is_blocked
+      )
+      SELECT
+        u.tg_id,
+        u.username,
+        u.first_name,
+        u.last_name,
+        u.phone,
+        u.role,
+        u.is_verified,
+        u.is_blocked,
+        COALESCE(cv.is_verified, false) AS courier_verified,
+        COALESCE(dv.is_verified, false) AS driver_verified,
+        COALESCE(sub.has_active_subscription, false) AS has_active_subscription
+      FROM upsert u
+      LEFT JOIN LATERAL (
+        SELECT EXISTS (
+          SELECT 1
+          FROM verifications v
+          WHERE v.user_id = u.tg_id
+            AND v.role = 'courier'
+            AND v.status = 'active'
+            AND (v.expires_at IS NULL OR v.expires_at > now())
+        ) AS is_verified
+      ) cv ON true
+      LEFT JOIN LATERAL (
+        SELECT EXISTS (
+          SELECT 1
+          FROM verifications v
+          WHERE v.user_id = u.tg_id
+            AND v.role = 'driver'
+            AND v.status = 'active'
+            AND (v.expires_at IS NULL OR v.expires_at > now())
+        ) AS is_verified
+      ) dv ON true
+      LEFT JOIN LATERAL (
+        SELECT EXISTS (
+          SELECT 1
+          FROM channels c
+          JOIN subscriptions s ON s.chat_id = c.drivers_channel_id
+          WHERE c.id = 1
+            AND c.drivers_channel_id IS NOT NULL
+            AND s.user_id = u.tg_id
+            AND s.status = 'active'
+            AND (
+              COALESCE(s.grace_until, s.next_billing_at) IS NULL
+              OR COALESCE(s.grace_until, s.next_billing_at) > now()
+            )
+        ) AS has_active_subscription
+      ) sub ON true
+    `,
+    [
+      from.id,
+      from.username ?? null,
+      from.first_name ?? null,
+      from.last_name ?? null,
+    ],
+  );
+
+  const [row] = rows;
+  if (!row) {
+    throw new Error('Failed to load authentication context');
+  }
+
+  return mapAuthRow(row);
+};
+
+const applyAuthState = (ctx: BotContext, authState: AuthState): void => {
+  ctx.auth = authState;
+  ctx.session.isAuthenticated = true;
+  ctx.session.user = {
+    id: authState.user.telegramId,
+    username: authState.user.username,
+    firstName: authState.user.firstName,
+    lastName: authState.user.lastName,
+  };
+  if (authState.user.phone && !ctx.session.phoneNumber) {
+    ctx.session.phoneNumber = authState.user.phone;
+  }
+};
 
 export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   if (!ctx.from) {
@@ -9,13 +199,20 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     return;
   }
 
-  ctx.session.user = {
-    id: ctx.from.id,
-    username: ctx.from.username ?? undefined,
-    firstName: ctx.from.first_name ?? undefined,
-    lastName: ctx.from.last_name ?? undefined,
-  };
-  ctx.session.isAuthenticated = true;
+  try {
+    const authState = await loadAuthState(ctx.from);
+    applyAuthState(ctx, authState);
+  } catch (error) {
+    logger.error({ err: error, update: ctx.update }, 'Failed to authenticate update');
+    return;
+  }
 
   await next();
+};
+
+export const __testing__ = {
+  loadAuthState,
+  mapAuthRow,
+  buildExecutorState,
+  normaliseRole,
 };

--- a/src/bot/services/orders.ts
+++ b/src/bot/services/orders.ts
@@ -74,8 +74,8 @@ export const buildOrderSummary = (
 };
 
 export const buildCustomerName = (ctx: BotContext): string | undefined => {
-  const first = ctx.session.user?.firstName?.trim();
-  const last = ctx.session.user?.lastName?.trim();
+  const first = ctx.auth.user.firstName?.trim();
+  const last = ctx.auth.user.lastName?.trim();
   const full = [first, last].filter(Boolean).join(' ').trim();
   return full || undefined;
 };

--- a/src/bot/services/verify.ts
+++ b/src/bot/services/verify.ts
@@ -38,7 +38,7 @@ export const buildVerificationSummary = (
   state: ExecutorFlowState,
   options: VerificationSummaryOptions = {},
 ): string => {
-  const applicant = ctx.session.user;
+  const applicant = ctx.auth.user;
   const copy = getExecutorRoleCopy(state.role);
   const verification = state.verification[state.role];
   const lines = [
@@ -60,8 +60,9 @@ export const buildVerificationSummary = (
     lines.push(`Имя: ${fullName}`);
   }
 
-  if (ctx.session.phoneNumber) {
-    lines.push(`Телефон: ${ctx.session.phoneNumber}`);
+  const phone = ctx.auth.user.phone ?? ctx.session.phoneNumber;
+  if (phone) {
+    lines.push(`Телефон: ${phone}`);
   }
 
   const uploaded = options.photoCount ?? verification.uploadedPhotos.length;

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -8,11 +8,36 @@ export type ExecutorRole = 'courier' | 'driver';
 
 export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
 
+export type UserRole = 'client' | 'courier' | 'driver' | 'moderator';
+
 export interface SessionUser {
   id: number;
   username?: string;
   firstName?: string;
   lastName?: string;
+}
+
+export interface AuthUser {
+  telegramId: number;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  role: UserRole;
+  isVerified: boolean;
+  isBlocked: boolean;
+}
+
+export interface AuthExecutorState {
+  verifiedRoles: Record<ExecutorRole, boolean>;
+  hasActiveSubscription: boolean;
+  isVerified: boolean;
+}
+
+export interface AuthState {
+  user: AuthUser;
+  executor: AuthExecutorState;
+  isModerator: boolean;
 }
 
 export interface ExecutorUploadedPhoto {
@@ -107,4 +132,5 @@ export interface SessionState {
 
 export type BotContext = Context & {
   session: SessionState;
+  auth: AuthState;
 };

--- a/tests/client-menu.test.ts
+++ b/tests/client-menu.test.ts
@@ -64,6 +64,25 @@ const createSessionState = (): SessionState => ({
   ui: { steps: {}, homeActions: [] },
 });
 
+const createAuthState = (): BotContext['auth'] => ({
+  user: {
+    telegramId: 42,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    role: 'client',
+    isVerified: false,
+    isBlocked: false,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: false,
+});
+
 const createMockBot = () => {
   const actions = new Map<string, (ctx: BotContext) => Promise<void>>();
   const commands = new Map<string, (ctx: BotContext) => Promise<void>>();
@@ -93,7 +112,9 @@ const createMockContext = () => {
 
   const ctx = {
     chat: { id: 99, type: 'private' as const },
+    from: { id: 42 },
     session,
+    auth: createAuthState(),
     reply: async (text: string, extra?: unknown) => {
       const messageId = nextMessageId++;
       replyCalls.push({ text, extra, messageId });

--- a/tests/executor-access.test.ts
+++ b/tests/executor-access.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, beforeEach, describe, it } from 'node:test';
+
+import { EXECUTOR_VERIFICATION_PHOTO_COUNT, type BotContext, type SessionState } from '../src/bot/types';
+import type { UiStepOptions } from '../src/bot/ui';
+
+let ensureExecutorState: typeof import('../src/bot/flows/executor/menu')['ensureExecutorState'];
+let showExecutorMenu: typeof import('../src/bot/flows/executor/menu')['showExecutorMenu'];
+let startExecutorSubscription: typeof import('../src/bot/flows/executor/subscription')['startExecutorSubscription'];
+let uiHelper: typeof import('../src/bot/ui')['ui'];
+
+before(async () => {
+  process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+  process.env.CITY_DEFAULT = process.env.CITY_DEFAULT ?? 'Алматы';
+  process.env.KASPI_CARD = process.env.KASPI_CARD ?? '4400 0000 0000 0000';
+  process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Freedom Bot';
+  process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+7 (700) 000-00-00';
+  process.env.DRIVERS_CHANNEL_INVITE =
+    process.env.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers';
+  process.env.SUB_PRICE_7 = process.env.SUB_PRICE_7 ?? '5000';
+  process.env.SUB_PRICE_15 = process.env.SUB_PRICE_15 ?? '9000';
+  process.env.SUB_PRICE_30 = process.env.SUB_PRICE_30 ?? '16000';
+
+  ({ ensureExecutorState, showExecutorMenu } = await import('../src/bot/flows/executor/menu'));
+  ({ startExecutorSubscription } = await import('../src/bot/flows/executor/subscription'));
+  ({ ui: uiHelper } = await import('../src/bot/ui'));
+});
+
+const createSessionState = (): SessionState => ({
+  ephemeralMessages: [],
+  isAuthenticated: false,
+  awaitingPhone: false,
+  executor: {
+    role: 'courier',
+    verification: {
+      courier: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+      driver: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+    },
+    subscription: { status: 'idle' },
+  },
+  client: {
+    taxi: { stage: 'idle' },
+    delivery: { stage: 'idle' },
+  },
+  ui: { steps: {}, homeActions: [] },
+});
+
+const createAuthState = (telegramId = 700): BotContext['auth'] => ({
+  user: {
+    telegramId,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    role: 'courier',
+    isVerified: false,
+    isBlocked: false,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: false,
+});
+
+const createContext = () => {
+  const session = createSessionState();
+  const auth = createAuthState();
+
+  const ctx = {
+    chat: { id: 700, type: 'private' as const },
+    from: { id: auth.user.telegramId },
+    session,
+    auth,
+    answerCbQuery: async () => {},
+    reply: async () => ({ message_id: 1, chat: { id: 700 }, text: '' }),
+    telegram: {
+      editMessageText: async () => true,
+      deleteMessage: async () => true,
+      copyMessage: async () => true,
+    },
+  } as unknown as BotContext;
+
+  return { ctx, session, auth };
+};
+
+let originalStep: typeof uiHelper.step;
+let recordedSteps: UiStepOptions[];
+
+beforeEach(() => {
+  recordedSteps = [];
+  originalStep = uiHelper.step;
+  (uiHelper as { step: typeof uiHelper.step }).step = async (_ctx, options) => {
+    recordedSteps.push(options);
+    return { messageId: recordedSteps.length, sent: true };
+  };
+});
+
+afterEach(() => {
+  (uiHelper as { step: typeof uiHelper.step }).step = originalStep;
+});
+
+describe('executor access control', () => {
+  it('blocks subscription start when verification is missing', async () => {
+    const { ctx } = createContext();
+    ensureExecutorState(ctx);
+
+    await startExecutorSubscription(ctx);
+
+    const state = ctx.session.executor.subscription;
+    assert.equal(state.status, 'idle');
+    assert.equal(state.selectedPeriodId, undefined);
+    const rejection = recordedSteps.find(
+      (step) => step.id === 'executor:subscription:verification-required',
+    );
+    assert.ok(rejection, 'verification reminder should be shown');
+  });
+
+  it('renders the executor menu when verification and subscription are active', async () => {
+    const { ctx } = createContext();
+    ensureExecutorState(ctx);
+
+    ctx.auth.executor.verifiedRoles.courier = true;
+    ctx.auth.executor.isVerified = true;
+    ctx.auth.executor.hasActiveSubscription = true;
+    ctx.auth.user.isVerified = true;
+
+    await showExecutorMenu(ctx);
+
+    const menuStep = recordedSteps.find((step) => step.id === 'executor:menu:main');
+    assert.ok(menuStep, 'executor menu should be displayed');
+  });
+});

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -46,6 +46,25 @@ const setPoolQuery = (fn: typeof pool.query) => {
   (pool as unknown as { query: typeof pool.query }).query = fn;
 };
 
+const createAuthState = (telegramId: number): BotContext['auth'] => ({
+  user: {
+    telegramId,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    role: 'client',
+    isVerified: false,
+    isBlocked: false,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: false,
+});
+
 type SupportModule = typeof import('../src/bot/services/support');
 
 let __testing__: SupportModule['__testing__'];
@@ -102,6 +121,7 @@ describe('support service', () => {
       },
       message: { message_id: 123, text: 'Нужна помощь' },
       telegram: telegram.api,
+      auth: createAuthState(222),
     } as unknown as BotContext;
 
     const result = (await forwardSupportMessage(ctx)) as SupportForwardResult;
@@ -153,6 +173,7 @@ describe('support service', () => {
       }),
       answerCbQuery: async () => {},
       telegram: telegram.api,
+      auth: createAuthState(555),
     } as unknown as BotContext;
 
     await __testing__.handleReplyAction(ctx, threadId);
@@ -170,6 +191,7 @@ describe('support service', () => {
       },
       reply: async () => {},
       telegram: telegram.api,
+      auth: createAuthState(555),
     } as unknown as BotContext;
 
     const handled = await __testing__.handleModeratorReplyMessage(replyCtx);
@@ -206,6 +228,7 @@ describe('support service', () => {
       from: { id: 777 },
       answerCbQuery: async () => {},
       telegram: telegram.api,
+      auth: createAuthState(777),
     } as unknown as BotContext;
 
     await __testing__.handleCloseAction(ctx, threadId);

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -52,6 +52,25 @@ const createSessionState = (): SessionState => ({
   ui: { steps: {}, homeActions: [] },
 });
 
+const createAuthState = (): BotContext['auth'] => ({
+  user: {
+    telegramId: 42,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    role: 'client',
+    isVerified: false,
+    isBlocked: false,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: false,
+});
+
 type EditHandler = (
   chatId: number,
   messageId: number,
@@ -70,8 +89,10 @@ const createMockContext = () => {
   let editOverride: EditHandler | undefined;
 
   const ctx = {
-    chat: { id: 42, type: 'private' },
+    chat: { id: 42, type: 'private' as const },
+    from: { id: 42 },
     session,
+    auth: createAuthState(),
     reply: async (text: string, extra?: unknown) => {
       const messageId = nextMessageId++;
       replyCalls.push({ text, extra, messageId });


### PR DESCRIPTION
## Summary
- add an authentication middleware that loads Telegram users from Postgres and exposes verification/subscription metadata
- update executor flows and client order creation to rely on the new auth context, redirecting unverified or unsubscribed users
- exercise the new access control in executor tests and adjust existing suites for the required auth state

## Testing
- npm run check
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ca648674ec832da258720520dc0d89