### PR TITLE
Respect database SSL configuration

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -14,6 +14,12 @@ are missing or blank.
 - `KASPI_NAME` – Account holder name displayed alongside the Kaspi details.
 - `KASPI_PHONE` – Contact phone number provided with the Kaspi payment details.
 
+## Database options
+
+- `DATABASE_SSL` – Enables TLS for the PostgreSQL connection when set to `true`,
+  `1` or `yes`. The connection negotiates SSL with certificate validation. Leave
+  the variable unset (or explicitly set it to `false`) to connect without TLS.
+
 ## Subscription settings
 
 - `SUB_PRICE_7`, `SUB_PRICE_15`, `SUB_PRICE_30` – Override subscription prices (in

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,13 +1,19 @@
 import { Pool, PoolClient } from 'pg';
-import dotenv from 'dotenv';
+import type { PoolConfig } from 'pg';
 
-dotenv.config();
+import { config } from '../config';
+
+const createSslOptions = (): PoolConfig['ssl'] => {
+  if (!config.database.ssl) {
+    return false;
+  }
+
+  return { rejectUnauthorized: true } satisfies NonNullable<PoolConfig['ssl']>;
+};
 
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production'
-    ? { rejectUnauthorized: false }
-    : false,
+  connectionString: config.database.url,
+  ssl: createSslOptions(),
 });
 
 export { pool };           // Named export (import { pool } from ...)

--- a/tests/db-client.test.ts
+++ b/tests/db-client.test.ts
@@ -1,0 +1,68 @@
+import './helpers/setup-env';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+const MODULE_PATHS = [
+  '../src/db',
+  '../src/db/client',
+  '../src/config',
+  '../src/config/env',
+] as const;
+
+const RESOLVED_MODULE_PATHS = MODULE_PATHS.map((modulePath) =>
+  require.resolve(modulePath),
+);
+
+const clearModuleCache = (): void => {
+  for (const path of RESOLVED_MODULE_PATHS) {
+    delete require.cache[path];
+  }
+};
+
+const importPool = async () => {
+  clearModuleCache();
+  const mod = await import('../src/db/client');
+  return mod.pool;
+};
+
+describe('database client TLS configuration', () => {
+  let databaseSslBackup: string | undefined;
+
+  beforeEach(() => {
+    databaseSslBackup = process.env.DATABASE_SSL;
+  });
+
+  afterEach(() => {
+    if (databaseSslBackup === undefined) {
+      delete process.env.DATABASE_SSL;
+    } else {
+      process.env.DATABASE_SSL = databaseSslBackup;
+    }
+    clearModuleCache();
+  });
+
+  it('disables TLS when DATABASE_SSL is not enabled', async () => {
+    delete process.env.DATABASE_SSL;
+
+    const pool = await importPool();
+    try {
+      assert.equal(pool.options.connectionString, process.env.DATABASE_URL);
+      assert.equal(pool.options.ssl, false);
+    } finally {
+      await pool.end();
+    }
+  });
+
+  it('enables TLS with certificate verification when DATABASE_SSL is true', async () => {
+    process.env.DATABASE_SSL = 'true';
+
+    const pool = await importPool();
+    try {
+      assert.equal(pool.options.connectionString, process.env.DATABASE_URL);
+      assert.deepEqual(pool.options.ssl, { rejectUnauthorized: true });
+    } finally {
+      await pool.end();
+    }
+  });
+});

--- a/tests/helpers/setup-env.ts
+++ b/tests/helpers/setup-env.ts
@@ -1,0 +1,13 @@
+const REQUIRED_ENV_DEFAULTS: Record<string, string> = {
+  BOT_TOKEN: 'test-token',
+  DATABASE_URL: 'postgres://user:pass@localhost:5432/db',
+  KASPI_CARD: '4400 0000 0000 0000',
+  KASPI_NAME: 'Freedom Bot',
+  KASPI_PHONE: '+7 (700) 000-00-00',
+};
+
+for (const [key, value] of Object.entries(REQUIRED_ENV_DEFAULTS)) {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+}

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,3 +1,5 @@
+import './helpers/setup-env';
+
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -1,3 +1,5 @@
+import './helpers/setup-env';
+
 import assert from 'node:assert/strict';
 import { before, beforeEach, describe, it } from 'node:test';
 


### PR DESCRIPTION
## Summary
- use the central config in the database client so the pool honours the `DATABASE_SSL` switch and enforces certificate validation when enabled
- add a helper to provide default required env vars in tests plus a regression test proving the pool toggles TLS
- document the new `DATABASE_SSL` behaviour in the environment reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caba9af610832dbf0f63a5e92ec1e4