### PR TITLE
Handle shutdown state flag for graceful shutdown logging

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,9 @@ registerJoinRequests(app);
 registerJobs(app);
 
 let gracefulShutdownConfigured = false;
+let cleanupStarted = false;
+
+export const isShutdownInProgress = (): boolean => cleanupStarted;
 
 const botAlreadyStoppedPatterns = [
   /bot is not running/i,
@@ -71,7 +74,6 @@ export const setupGracefulShutdown = (bot: Telegraf<BotContext>): void => {
   gracefulShutdownConfigured = true;
 
   const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
-  let cleanupStarted = false;
   for (const signal of signals) {
     process.once(signal, () => {
       if (cleanupStarted) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { app, setupGracefulShutdown } from './app';
+import { app, isShutdownInProgress, setupGracefulShutdown } from './app';
 import { logger } from './config';
 
 const gracefulShutdownErrorPatterns = [
@@ -52,7 +52,9 @@ const start = async (): Promise<void> => {
     await app.launch();
     logger.info('Bot started using long polling');
   } catch (error) {
-    if (isGracefulShutdownError(error)) {
+    if (isShutdownInProgress()) {
+      logger.info({ err: error }, 'Bot stopped gracefully');
+    } else if (isGracefulShutdownError(error)) {
       logger.info({ err: error }, 'Bot stopped gracefully');
     } else {
       logger.fatal({ err: error }, 'Failed to launch bot');


### PR DESCRIPTION
## Summary
- expose the shutdown-in-progress flag from the app module
- reuse the exported getter in the launcher to treat shutdown errors as graceful stops

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cae0088acc832d9208100d2df738f9