### PR TITLE
Defer job scheduler start until after launch

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,6 @@ import { session } from './bot/middlewares/session';
 import type { BotContext } from './bot/types';
 import { config, logger } from './config';
 import { pool } from './db';
-import { registerJobs } from './jobs';
 
 export const app = new Telegraf<BotContext>(config.bot.token);
 
@@ -46,7 +45,6 @@ registerVerificationModerationQueue(app);
 registerPaymentModerationQueue(app);
 registerOrdersChannel(app);
 registerJoinRequests(app);
-registerJobs(app);
 
 let gracefulShutdownConfigured = false;
 let cleanupStarted = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { app, isShutdownInProgress, setupGracefulShutdown } from './app';
 import { logger } from './config';
+import { registerJobs } from './jobs';
 
 const gracefulShutdownErrorPatterns = [
   /bot is not running/i,
@@ -50,6 +51,7 @@ const isGracefulShutdownError = (error: unknown): boolean => {
 const start = async (): Promise<void> => {
   try {
     await app.launch();
+    registerJobs(app);
     logger.info('Bot started using long polling');
   } catch (error) {
     if (isShutdownInProgress()) {
@@ -57,7 +59,7 @@ const start = async (): Promise<void> => {
     } else if (isGracefulShutdownError(error)) {
       logger.info({ err: error }, 'Bot stopped gracefully');
     } else {
-      logger.fatal({ err: error }, 'Failed to launch bot');
+      logger.fatal({ err: error }, 'Failed to start bot or jobs');
       process.exitCode = 1;
     }
   }

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -1,7 +1,7 @@
 import type { Telegraf } from 'telegraf';
 
 import type { BotContext } from '../bot/types';
-import { startSubscriptionScheduler } from './scheduler';
+import { startSubscriptionScheduler, stopSubscriptionScheduler } from './scheduler';
 
 let initialized = false;
 
@@ -12,4 +12,13 @@ export const registerJobs = (bot: Telegraf<BotContext>): void => {
 
   startSubscriptionScheduler(bot);
   initialized = true;
+};
+
+export const stopJobs = (): void => {
+  if (!initialized) {
+    return;
+  }
+
+  stopSubscriptionScheduler();
+  initialized = false;
 };

--- a/tests/jobs-lifecycle.test.ts
+++ b/tests/jobs-lifecycle.test.ts
@@ -1,0 +1,123 @@
+import './helpers/setup-env';
+
+import assert from 'node:assert/strict';
+import cron, { type ScheduledTask, type TaskFn } from 'node-cron';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import type { Telegraf } from 'telegraf';
+
+import type { BotContext } from '../src/bot/types';
+import { registerJobs, stopJobs } from '../src/jobs';
+import * as scheduler from '../src/jobs/scheduler';
+
+const createBot = (): Telegraf<BotContext> =>
+  ({ telegram: {} } as unknown as Telegraf<BotContext>);
+
+type Spy<F extends (...args: any[]) => unknown> = ReturnType<typeof mock.fn<F>>;
+
+describe('subscription scheduler lifecycle', () => {
+  let scheduleMock: ReturnType<typeof mock.method>;
+  let stopSpy: Spy<() => void>;
+  let destroySpy: Spy<() => void>;
+
+  beforeEach(() => {
+    stopSpy = mock.fn<() => void>(() => undefined);
+    destroySpy = mock.fn<() => void>(() => undefined);
+    scheduleMock = mock.method(cron, 'schedule', (expression: string, _handler: TaskFn | string) => {
+      const scheduledTask: ScheduledTask = {
+        id: `${expression}:test-task`,
+        stop: stopSpy,
+        destroy: destroySpy,
+        start: () => undefined,
+        getStatus: () => 'running',
+        execute: async () => undefined,
+        getNextRun: () => null,
+        on: () => undefined,
+        off: () => undefined,
+        once: () => undefined,
+      };
+
+      return scheduledTask;
+    });
+  });
+
+  afterEach(() => {
+    scheduler.stopSubscriptionScheduler();
+    scheduleMock.mock.restore();
+    stopSpy.mock.resetCalls();
+    destroySpy.mock.resetCalls();
+  });
+
+  it('starts the subscription scheduler once and allows restarting after stop', () => {
+    const bot = createBot();
+
+    scheduler.startSubscriptionScheduler(bot);
+    scheduler.startSubscriptionScheduler(bot);
+
+    assert.equal(scheduleMock.mock.callCount(), 1);
+    const [firstCall] = scheduleMock.mock.calls;
+    assert.ok(firstCall);
+    assert.equal(firstCall.arguments[0], '*/10 * * * *');
+
+    scheduler.stopSubscriptionScheduler();
+    assert.equal(stopSpy.mock.callCount(), 1);
+    assert.equal(destroySpy.mock.callCount(), 1);
+
+    scheduler.startSubscriptionScheduler(bot);
+    assert.equal(scheduleMock.mock.callCount(), 2);
+  });
+
+  it('ignores stop requests when the scheduler is not running', () => {
+    scheduler.stopSubscriptionScheduler();
+
+    assert.equal(stopSpy.mock.callCount(), 0);
+    assert.equal(destroySpy.mock.callCount(), 0);
+  });
+});
+
+describe('registerJobs', () => {
+  let startSchedulerMock: ReturnType<typeof mock.method>;
+  let stopSchedulerMock: ReturnType<typeof mock.method>;
+
+  beforeEach(() => {
+    startSchedulerMock = mock.method(scheduler, 'startSubscriptionScheduler', mock.fn());
+    stopSchedulerMock = mock.method(scheduler, 'stopSubscriptionScheduler', mock.fn());
+
+    stopJobs();
+    startSchedulerMock.mock.resetCalls();
+    stopSchedulerMock.mock.resetCalls();
+  });
+
+  afterEach(() => {
+    stopJobs();
+    startSchedulerMock.mock.restore();
+    stopSchedulerMock.mock.restore();
+  });
+
+  it('starts background jobs only once while initialized', () => {
+    const bot = createBot();
+
+    registerJobs(bot);
+    registerJobs(bot);
+
+    assert.equal(startSchedulerMock.mock.callCount(), 1);
+  });
+
+  it('does not attempt to stop jobs when they were never started', () => {
+    stopJobs();
+
+    assert.equal(stopSchedulerMock.mock.callCount(), 0);
+  });
+
+  it('stops running jobs and allows them to start again later', () => {
+    const bot = createBot();
+
+    registerJobs(bot);
+    stopJobs();
+
+    assert.equal(stopSchedulerMock.mock.callCount(), 1);
+
+    registerJobs(bot);
+
+    assert.equal(startSchedulerMock.mock.callCount(), 2);
+  });
+});


### PR DESCRIPTION
## Summary
- start the cron jobs only after the bot launches successfully and update fatal logging
- expose helpers to stop jobs, including a safe stopSubscriptionScheduler implementation
- add scheduler lifecycle tests that cover idempotent registration and restart behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae7c5ac5c832d82a507ad6c2dad14