### PR TITLE
Add ETA-aware tariff pricing

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -50,7 +50,12 @@ Omitting any of them keeps the built-in defaults.
 ## Tariff hints
 
 The following values describe default tariff parameters used in external automations.
-They are optional but must be defined together when used.
+They are optional but must be defined together when used. When present, Freedom Bot
+also applies them to price quotes shown to customers and executors using the
+`base + per_km * distance + per_min * eta` formula. The ETA is approximated with a
+5-minute pickup buffer and an average city speed of roughly 27 km/h, then rounded
+to the nearest minute before calculating the time component. The final quote is
+rounded to the nearest tenge for consistency with legacy pricing.
 
 - `TARIFF_BASE` – Base fare applied to a new order.
 - `TARIFF_PER_KM` – Distance component calculated per kilometre.

--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -4,6 +4,7 @@ import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram'
 import { getChannelBinding } from './bindings';
 import { logger } from '../../config';
 import { withTx } from '../../db/client';
+import { formatEtaMinutes } from '../services/pricing';
 import {
   lockOrderById,
   setOrderChannelMessageId,
@@ -55,6 +56,7 @@ export const buildOrderMessage = (order: OrderRecord): string => {
     `📍 Подача: ${order.pickup.address}`,
     `🎯 Назначение: ${order.dropoff.address}`,
     `📏 Расстояние: ${formatDistance(order.price.distanceKm)} км`,
+    `⏱️ В пути: ≈${formatEtaMinutes(order.price.etaMinutes)} мин`,
     `💰 Стоимость: ${formatPrice(order.price.amount, order.price.currency)}`,
   ];
 

--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -10,7 +10,7 @@ import { handleClientOrderCancellation } from '../../channels/ordersChannel';
 import { buildInlineKeyboard, mergeInlineKeyboards } from '../../keyboards/common';
 import { buildOrderLocationsKeyboard } from '../../keyboards/orders';
 import { ensurePrivateCallback, isPrivateChat } from '../../services/access';
-import { formatDistance, formatPriceAmount } from '../../services/pricing';
+import { formatDistance, formatEtaMinutes, formatPriceAmount } from '../../services/pricing';
 import type { BotContext } from '../../types';
 import type { OrderStatus, OrderWithExecutor } from '../../../types';
 import { ui } from '../../ui';
@@ -170,6 +170,7 @@ const buildOrderDetailText = (
   lines.push(`📍 Подача: ${order.pickup.address}`);
   lines.push(`🎯 Назначение: ${order.dropoff.address}`);
   lines.push(`📏 Расстояние: ${formatDistance(order.price.distanceKm)} км`);
+  lines.push(`⏱️ В пути: ≈${formatEtaMinutes(order.price.etaMinutes)} мин`);
   lines.push(`💰 Стоимость: ${formatPriceAmount(order.price.amount, order.price.currency)}`);
 
   if (order.clientComment?.trim()) {

--- a/src/bot/services/orders.ts
+++ b/src/bot/services/orders.ts
@@ -1,6 +1,6 @@
 import type { BotContext, ClientOrderDraftState } from '../types';
 import type { OrderLocation, OrderPriceDetails } from '../../types';
-import { formatDistance, formatPriceAmount } from './pricing';
+import { formatDistance, formatEtaMinutes, formatPriceAmount } from './pricing';
 
 export type CompletedOrderDraft = ClientOrderDraftState & {
   pickup: OrderLocation;
@@ -27,8 +27,10 @@ export interface OrderSummaryOptions {
   pickupLabel?: string;
   dropoffLabel?: string;
   distanceLabel?: string;
+  etaLabel?: string;
   priceLabel?: string;
   includeDistance?: boolean;
+  includeEta?: boolean;
   includePrice?: boolean;
   instructions?: string[];
 }
@@ -47,6 +49,11 @@ export const buildOrderSummary = (
   if (options.includeDistance ?? true) {
     const distanceLabel = options.distanceLabel ?? '📏 Расстояние';
     lines.push(`${distanceLabel}: ${formatDistance(draft.price.distanceKm)} км`);
+  }
+
+  if (options.includeEta ?? true) {
+    const etaLabel = options.etaLabel ?? '⏱️ В пути';
+    lines.push(`${etaLabel}: ≈${formatEtaMinutes(draft.price.etaMinutes)} мин`);
   }
 
   if (options.includePrice ?? true) {

--- a/src/bot/services/pricing.ts
+++ b/src/bot/services/pricing.ts
@@ -3,7 +3,9 @@ export {
   createPricingService,
   estimateTaxiPrice,
   estimateDeliveryPrice,
+  estimateEtaMinutes,
   formatPriceAmount,
   formatPriceDetails,
   formatDistance,
+  formatEtaMinutes,
 } from '../../services/pricing';

--- a/src/db/orders.ts
+++ b/src/db/orders.ts
@@ -10,6 +10,7 @@ import type {
   OrderStatus,
   OrderWithExecutor,
 } from '../types';
+import { estimateEtaMinutes } from '../services/pricing';
 
 interface OrderRow {
   id: number;
@@ -70,11 +71,13 @@ const mapLocation = (query: string, address: string, lat: number, lon: number): 
 const mapPrice = (amount: number, currency: string, distance: number | string): OrderPriceDetails => {
   const parsed =
     typeof distance === 'string' ? Number.parseFloat(distance) : distance;
+  const distanceKm = Number.isNaN(parsed) ? 0 : parsed;
 
   return {
     amount,
     currency,
-    distanceKm: Number.isNaN(parsed) ? 0 : parsed,
+    distanceKm,
+    etaMinutes: estimateEtaMinutes(distanceKm),
   } satisfies OrderPriceDetails;
 };
 

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -1,8 +1,11 @@
 import { config } from '../config';
-import type { PricingConfig, TariffConfig } from '../config';
+import type { PricingConfig, TariffConfig, TariffRates } from '../config';
 import type { OrderLocation, OrderPriceDetails } from '../types';
 
 const EARTH_RADIUS_KM = 6371;
+const AVERAGE_SPEED_KMH = 27;
+const PICKUP_BUFFER_MINUTES = 5;
+const MINIMUM_TRIP_MINUTES = 5;
 
 const toRadians = (value: number): number => (value * Math.PI) / 180;
 
@@ -27,38 +30,76 @@ export const calculateDistanceKm = (
 
 const roundPrice = (amount: number): number => Math.round(amount / 10) * 10;
 
+export const estimateEtaMinutes = (distanceKm: number): number => {
+  if (!Number.isFinite(distanceKm) || distanceKm <= 0) {
+    return MINIMUM_TRIP_MINUTES;
+  }
+
+  const travelMinutes = (distanceKm / AVERAGE_SPEED_KMH) * 60;
+  const total = Math.ceil(travelMinutes + PICKUP_BUFFER_MINUTES);
+
+  return Math.max(MINIMUM_TRIP_MINUTES, total);
+};
+
+const computeAmount = (
+  distanceKm: number,
+  etaMinutes: number,
+  serviceTariff: TariffConfig,
+  generalTariff: TariffRates | null,
+): number => {
+  if (generalTariff) {
+    const raw =
+      generalTariff.base +
+      generalTariff.perKm * distanceKm +
+      generalTariff.perMin * etaMinutes;
+
+    return roundPrice(raw);
+  }
+
+  const raw = serviceTariff.baseFare + distanceKm * serviceTariff.perKm;
+  const rounded = roundPrice(raw);
+
+  return Math.max(serviceTariff.minimumFare, rounded);
+};
+
 const buildQuote = (
   from: OrderLocation,
   to: OrderLocation,
   tariff: TariffConfig,
+  generalTariff: TariffRates | null,
 ): OrderPriceDetails => {
   const distanceKm = calculateDistanceKm(from, to);
-  const raw = tariff.baseFare + distanceKm * tariff.perKm;
-  const amount = Math.max(tariff.minimumFare, roundPrice(raw));
+  const etaMinutes = estimateEtaMinutes(distanceKm);
+  const amount = computeAmount(distanceKm, etaMinutes, tariff, generalTariff);
 
   return {
     amount,
     currency: 'KZT',
     distanceKm,
+    etaMinutes,
   } satisfies OrderPriceDetails;
 };
 
 const createEstimator =
-  (tariff: TariffConfig) =>
+  (tariff: TariffConfig, generalTariff: TariffRates | null) =>
   (from: OrderLocation, to: OrderLocation): OrderPriceDetails =>
-    buildQuote(from, to, tariff);
+    buildQuote(from, to, tariff, generalTariff);
 
-export const createPricingService = (pricing: PricingConfig) => ({
-  estimateTaxiPrice: createEstimator(pricing.taxi),
-  estimateDeliveryPrice: createEstimator(pricing.delivery),
+export const createPricingService = (
+  pricing: PricingConfig,
+  generalTariff: TariffRates | null = null,
+) => ({
+  estimateTaxiPrice: createEstimator(pricing.taxi, generalTariff),
+  estimateDeliveryPrice: createEstimator(pricing.delivery, generalTariff),
 });
 
-const defaultPricingService = createPricingService(config.pricing);
+const defaultPricingService = createPricingService(config.pricing, config.tariff);
 
 export const estimateTaxiPrice = defaultPricingService.estimateTaxiPrice;
 export const estimateDeliveryPrice = defaultPricingService.estimateDeliveryPrice;
 
 const priceFormatter = new Intl.NumberFormat('ru-RU');
+const durationFormatter = new Intl.NumberFormat('ru-RU');
 
 export const formatPriceAmount = (amount: number, currency: string): string =>
   `${priceFormatter.format(amount)} ${currency}`;
@@ -76,4 +117,16 @@ export const formatDistance = (distanceKm: number): string => {
   }
 
   return distanceKm.toFixed(1);
+};
+
+export const formatEtaMinutes = (etaMinutes: number): string => {
+  if (!Number.isFinite(etaMinutes) || etaMinutes <= 0) {
+    return 'н/д';
+  }
+
+  if (etaMinutes < 1) {
+    return '<1';
+  }
+
+  return durationFormatter.format(Math.round(etaMinutes));
 };

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -13,6 +13,7 @@ export interface OrderPriceDetails {
   amount: number;
   currency: string;
   distanceKm: number;
+  etaMinutes: number;
 }
 
 export interface OrderExecutorInfo {

--- a/tests/orders-channel.test.ts
+++ b/tests/orders-channel.test.ts
@@ -6,6 +6,7 @@ import type { Telegram } from 'telegraf';
 
 import * as bindings from '../src/bot/channels/bindings';
 import { handleClientOrderCancellation } from '../src/bot/channels/ordersChannel';
+import { estimateEtaMinutes } from '../src/services/pricing';
 import type { OrderWithExecutor } from '../src/types';
 
 describe('handleClientOrderCancellation', () => {
@@ -50,7 +51,12 @@ describe('handleClientOrderCancellation', () => {
       latitude: 43.3,
       longitude: 76.95,
     },
-    price: { amount: 1500, currency: 'KZT', distanceKm: 5.2 },
+    price: {
+      amount: 1500,
+      currency: 'KZT',
+      distanceKm: 5.2,
+      etaMinutes: estimateEtaMinutes(5.2),
+    },
     createdAt: new Date('2024-01-01T00:00:00Z'),
     ...overrides,
   });

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,13 +1,24 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import type { PricingConfig, TariffConfig } from '../src/config';
+import type { PricingConfig, TariffConfig, TariffRates } from '../src/config';
 import type { OrderLocation } from '../src/types';
 
-const computeExpectedAmount = (distanceKm: number, tariff: TariffConfig): number => {
+const roundToNearestTen = (value: number): number => Math.round(value / 10) * 10;
+
+const computeServiceAmount = (distanceKm: number, tariff: TariffConfig): number => {
   const raw = tariff.baseFare + distanceKm * tariff.perKm;
-  const rounded = Math.round(raw / 10) * 10;
+  const rounded = roundToNearestTen(raw);
   return Math.max(tariff.minimumFare, rounded);
+};
+
+const computeGeneralAmount = (
+  distanceKm: number,
+  etaMinutes: number,
+  tariff: TariffRates,
+): number => {
+  const raw = tariff.base + distanceKm * tariff.perKm + etaMinutes * tariff.perMin;
+  return roundToNearestTen(raw);
 };
 
 const from: OrderLocation = {
@@ -40,7 +51,7 @@ describe('pricing service', () => {
       SUB_PRICE_30: originalEnv.SUB_PRICE_30 ?? '16000',
     } satisfies Record<string, string>;
 
-    const setTariffEnv = (tariffs: PricingConfig) => {
+    const setServiceTariffEnv = (tariffs: PricingConfig) => {
       process.env = {
         ...process.env,
         TAXI_BASE_FARE: tariffs.taxi.baseFare.toString(),
@@ -50,6 +61,9 @@ describe('pricing service', () => {
         DELIVERY_PER_KM: tariffs.delivery.perKm.toString(),
         DELIVERY_MINIMUM_FARE: tariffs.delivery.minimumFare.toString(),
       };
+      delete process.env.TARIFF_BASE;
+      delete process.env.TARIFF_PER_KM;
+      delete process.env.TARIFF_PER_MIN;
     };
 
     try {
@@ -59,31 +73,42 @@ describe('pricing service', () => {
         taxi: { baseFare: 1200, perKm: 85, minimumFare: 1500 },
         delivery: { baseFare: 1600, perKm: 95, minimumFare: 1900 },
       };
-      setTariffEnv(tariffSetA);
+      setServiceTariffEnv(tariffSetA);
 
       const { loadConfig } = await import('../src/config/env');
-      const { createPricingService, calculateDistanceKm } = await import('../src/bot/services/pricing');
+      const {
+        createPricingService,
+        calculateDistanceKm,
+        estimateEtaMinutes,
+      } = await import('../src/bot/services/pricing');
 
       const configA = loadConfig();
       assert.equal(configA.pricing.taxi.baseFare, tariffSetA.taxi.baseFare);
       assert.equal(configA.pricing.delivery.baseFare, tariffSetA.delivery.baseFare);
+      assert.equal(configA.tariff, null);
 
       const serviceA = createPricingService(configA.pricing);
       const distance = calculateDistanceKm(from, to);
+      const eta = estimateEtaMinutes(distance);
 
       const taxiQuoteA = serviceA.estimateTaxiPrice(from, to);
       assert.equal(taxiQuoteA.distanceKm, distance);
-      assert.equal(taxiQuoteA.amount, computeExpectedAmount(distance, configA.pricing.taxi));
+      assert.equal(taxiQuoteA.etaMinutes, eta);
+      assert.equal(taxiQuoteA.amount, computeServiceAmount(distance, configA.pricing.taxi));
 
       const deliveryQuoteA = serviceA.estimateDeliveryPrice(from, to);
       assert.equal(deliveryQuoteA.distanceKm, distance);
-      assert.equal(deliveryQuoteA.amount, computeExpectedAmount(distance, configA.pricing.delivery));
+      assert.equal(deliveryQuoteA.etaMinutes, eta);
+      assert.equal(
+        deliveryQuoteA.amount,
+        computeServiceAmount(distance, configA.pricing.delivery),
+      );
 
       const tariffSetB: PricingConfig = {
         taxi: { baseFare: 700, perKm: 25, minimumFare: 800 },
         delivery: { baseFare: 950, perKm: 30, minimumFare: 1000 },
       };
-      setTariffEnv(tariffSetB);
+      setServiceTariffEnv(tariffSetB);
 
       const configB = loadConfig();
       assert.equal(configB.pricing.taxi.baseFare, tariffSetB.taxi.baseFare);
@@ -93,13 +118,87 @@ describe('pricing service', () => {
 
       const taxiQuoteB = serviceB.estimateTaxiPrice(from, to);
       assert.equal(taxiQuoteB.distanceKm, distance);
-      assert.equal(taxiQuoteB.amount, computeExpectedAmount(distance, configB.pricing.taxi));
+      assert.equal(taxiQuoteB.etaMinutes, eta);
+      assert.equal(taxiQuoteB.amount, computeServiceAmount(distance, configB.pricing.taxi));
       assert.notStrictEqual(taxiQuoteB.amount, taxiQuoteA.amount);
 
       const deliveryQuoteB = serviceB.estimateDeliveryPrice(from, to);
       assert.equal(deliveryQuoteB.distanceKm, distance);
-      assert.equal(deliveryQuoteB.amount, computeExpectedAmount(distance, configB.pricing.delivery));
+      assert.equal(deliveryQuoteB.etaMinutes, eta);
+      assert.equal(
+        deliveryQuoteB.amount,
+        computeServiceAmount(distance, configB.pricing.delivery),
+      );
       assert.notStrictEqual(deliveryQuoteB.amount, deliveryQuoteA.amount);
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
+  it('prefers general tariff when provided', async () => {
+    const originalEnv = { ...process.env };
+    const baseEnv = {
+      BOT_TOKEN: originalEnv.BOT_TOKEN ?? 'test-token',
+      DATABASE_URL: originalEnv.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db',
+      CITY_DEFAULT: originalEnv.CITY_DEFAULT ?? 'Алматы',
+      KASPI_CARD: originalEnv.KASPI_CARD ?? '4400 0000 0000 0000',
+      KASPI_NAME: originalEnv.KASPI_NAME ?? 'Freedom Bot',
+      KASPI_PHONE: originalEnv.KASPI_PHONE ?? '+7 (700) 000-00-00',
+      DRIVERS_CHANNEL_INVITE:
+        originalEnv.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers',
+      SUB_PRICE_7: originalEnv.SUB_PRICE_7 ?? '5000',
+      SUB_PRICE_15: originalEnv.SUB_PRICE_15 ?? '9000',
+      SUB_PRICE_30: originalEnv.SUB_PRICE_30 ?? '16000',
+      TAXI_BASE_FARE: '500',
+      TAXI_PER_KM: '100',
+      TAXI_MINIMUM_FARE: '800',
+      DELIVERY_BASE_FARE: '600',
+      DELIVERY_PER_KM: '110',
+      DELIVERY_MINIMUM_FARE: '900',
+    } satisfies Record<string, string>;
+
+    const generalTariff: TariffRates = { base: 350, perKm: 95, perMin: 15 };
+
+    try {
+      process.env = {
+        ...process.env,
+        ...baseEnv,
+        TARIFF_BASE: generalTariff.base.toString(),
+        TARIFF_PER_KM: generalTariff.perKm.toString(),
+        TARIFF_PER_MIN: generalTariff.perMin.toString(),
+      };
+
+      const { loadConfig } = await import('../src/config/env');
+      const {
+        createPricingService,
+        calculateDistanceKm,
+        estimateEtaMinutes,
+      } = await import('../src/bot/services/pricing');
+
+      const configWithTariff = loadConfig();
+      assert.deepEqual(configWithTariff.tariff, generalTariff);
+
+      const service = createPricingService(configWithTariff.pricing, configWithTariff.tariff);
+      const distance = calculateDistanceKm(from, to);
+      const eta = estimateEtaMinutes(distance);
+
+      const taxiQuote = service.estimateTaxiPrice(from, to);
+      assert.equal(taxiQuote.distanceKm, distance);
+      assert.equal(taxiQuote.etaMinutes, eta);
+      assert.equal(taxiQuote.amount, computeGeneralAmount(distance, eta, generalTariff));
+      assert.notStrictEqual(
+        taxiQuote.amount,
+        computeServiceAmount(distance, configWithTariff.pricing.taxi),
+      );
+
+      const deliveryQuote = service.estimateDeliveryPrice(from, to);
+      assert.equal(deliveryQuote.distanceKm, distance);
+      assert.equal(deliveryQuote.etaMinutes, eta);
+      assert.equal(deliveryQuote.amount, computeGeneralAmount(distance, eta, generalTariff));
+      assert.notStrictEqual(
+        deliveryQuote.amount,
+        computeServiceAmount(distance, configWithTariff.pricing.delivery),
+      );
     } finally {
       process.env = originalEnv;
     }


### PR DESCRIPTION
## Summary
- add ETA-aware pricing that prefers the unified tariff override when provided
- expose ETA data across price details and order summaries for customers and executors
- refresh documentation and regression tests to cover the new calculation rules

## Testing
- npm test
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbb43bd350832da9c07c9d6115ca29