### PR TITLE
Add subscription user/status index migration

### DIFF
--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -247,6 +247,9 @@ CREATE INDEX IF NOT EXISTS idx_orders_created_at ON orders(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_order_channel_posts_order_id ON order_channel_posts(order_id);
 CREATE INDEX IF NOT EXISTS idx_order_channel_posts_channel_message ON order_channel_posts(channel_id, message_id);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id);
+-- NOTE: idx_subscriptions_user_status supports user/status lookups and is introduced in
+-- 002_subscriptions_user_status_index.sql. Keep this declaration in sync to avoid duplicates.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_status ON subscriptions(user_id, status);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id ON subscriptions(chat_id);
 CREATE INDEX IF NOT EXISTS idx_payments_subscription_id ON payments(subscription_id);
 CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);

--- a/db/sql/001_patch.sql
+++ b/db/sql/001_patch.sql
@@ -2365,6 +2365,9 @@ CREATE INDEX IF NOT EXISTS idx_orders_created_at ON orders(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_order_channel_posts_order_id ON order_channel_posts(order_id);
 CREATE INDEX IF NOT EXISTS idx_order_channel_posts_channel_message ON order_channel_posts(channel_id, message_id);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id);
+-- NOTE: idx_subscriptions_user_status is maintained alongside
+-- 002_subscriptions_user_status_index.sql to prevent duplicate migrations.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_status ON subscriptions(user_id, status);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_chat_id ON subscriptions(chat_id);
 CREATE INDEX IF NOT EXISTS idx_payments_subscription_id ON payments(subscription_id);
 CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);

--- a/db/sql/002_subscriptions_user_status_index.sql
+++ b/db/sql/002_subscriptions_user_status_index.sql
@@ -1,0 +1,21 @@
+-- Ensure subscriptions have a composite index for per-user status lookups.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'subscriptions'
+          AND column_name = 'user_id'
+    )
+    AND EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'subscriptions'
+          AND column_name = 'status'
+    ) THEN
+        EXECUTE 'CREATE INDEX IF NOT EXISTS idx_subscriptions_user_status ON subscriptions(user_id, status)';
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- add a forward-compatible SQL migration that ensures the `idx_subscriptions_user_status` composite index exists
- include the index in the base schema files with notes so future migrations stay in sync

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cbcdbb15f8832d9c5e78e802092802