### PR TITLE
Persist moderation queue state and restore support threads

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,9 +14,18 @@ import { registerExecutorSubscription } from './bot/flows/executor/subscription'
 import { registerExecutorVerification } from './bot/flows/executor/verification';
 import { registerJoinRequests } from './bot/channels/joinRequests';
 import { registerOrdersChannel } from './bot/channels/ordersChannel';
-import { registerPaymentModerationQueue } from './bot/moderation/paymentQueue';
-import { registerVerificationModerationQueue } from './bot/moderation/verifyQueue';
-import { registerSupportModerationBridge } from './bot/services/support';
+import {
+  registerPaymentModerationQueue,
+  restorePaymentModerationQueue,
+} from './bot/moderation/paymentQueue';
+import {
+  registerVerificationModerationQueue,
+  restoreVerificationModerationQueue,
+} from './bot/moderation/verifyQueue';
+import {
+  registerSupportModerationBridge,
+  restoreSupportThreads,
+} from './bot/services/support';
 import { auth } from './bot/middlewares/auth';
 import { autoDelete } from './bot/middlewares/autoDelete';
 import { errorBoundary } from './bot/middlewares/errorBoundary';
@@ -115,3 +124,19 @@ export const setupGracefulShutdown = (bot: Telegraf<BotContext>): void => {
 };
 
 setupGracefulShutdown(app);
+
+export const initialiseAppState = async (): Promise<void> => {
+  const tasks: Promise<void>[] = [
+    restoreVerificationModerationQueue().catch((error) => {
+      logger.error({ err: error }, 'Failed to restore verification moderation queue');
+    }),
+    restorePaymentModerationQueue().catch((error) => {
+      logger.error({ err: error }, 'Failed to restore payment moderation queue');
+    }),
+    restoreSupportThreads().catch((error) => {
+      logger.error({ err: error }, 'Failed to restore support threads');
+    }),
+  ];
+
+  await Promise.all(tasks);
+};

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -104,38 +104,15 @@ const submitForModeration = async (
     },
     photoCount: verification.uploadedPhotos.length,
     submittedAt,
-    onApprove: async ({ telegram, decidedAt }) => {
-      if (verification.moderation?.applicationId === applicationId) {
-        verification.status = 'idle';
-        verification.moderation = undefined;
-        verification.uploadedPhotos = [];
-        verification.submittedAt = decidedAt;
-      }
-
-      const approvalText = buildVerificationApprovedText(copy);
-      const keyboard = buildSubscriptionShortcutKeyboard();
-
-      try {
-        await telegram.sendMessage(applicantId, approvalText, { reply_markup: keyboard });
-      } catch (error) {
-        logger.error(
-          {
-            err: error,
-            chatId: applicantId,
-            applicationId,
-            role,
-          },
-          'Failed to notify applicant about verification approval',
-        );
-      }
+    approvalNotification: {
+      text: buildVerificationApprovedText(copy),
+      keyboard: buildSubscriptionShortcutKeyboard(),
     },
-    onReject: async ({ decidedAt }) => {
-      if (verification.moderation?.applicationId === applicationId) {
-        verification.status = 'idle';
-        verification.moderation = undefined;
-        verification.uploadedPhotos = [];
-        verification.submittedAt = decidedAt;
-      }
+    sessionContext: {
+      scope: 'chat',
+      scopeId: applicantId.toString(10),
+      role,
+      applicationId,
     },
   };
 

--- a/src/db/callbackMap.ts
+++ b/src/db/callbackMap.ts
@@ -1,0 +1,114 @@
+import { pool } from './client';
+
+const parseNumeric = (value: string | number | null | undefined): number | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+export interface CallbackMapRecord<TPayload = unknown> {
+  token: string;
+  action: string;
+  chatId?: number;
+  messageId?: number;
+  payload: TPayload;
+  expiresAt: Date;
+}
+
+interface CallbackMapRow<TPayload> {
+  token: string;
+  action: string;
+  chat_id: string | number | null;
+  message_id: string | number | null;
+  payload: TPayload;
+  expires_at: Date | string;
+}
+
+const mapRow = <TPayload>(row: CallbackMapRow<TPayload>): CallbackMapRecord<TPayload> => ({
+  token: row.token,
+  action: row.action,
+  chatId: parseNumeric(row.chat_id),
+  messageId: parseNumeric(row.message_id),
+  payload: row.payload,
+  expiresAt: new Date(row.expires_at),
+});
+
+export const upsertCallbackMapRecord = async <TPayload>(
+  record: CallbackMapRecord<TPayload>,
+): Promise<void> => {
+  await pool.query(
+    `
+      INSERT INTO callback_map (
+        token,
+        action,
+        chat_id,
+        message_id,
+        payload,
+        expires_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6)
+      ON CONFLICT (token) DO UPDATE
+      SET
+        action = EXCLUDED.action,
+        chat_id = EXCLUDED.chat_id,
+        message_id = EXCLUDED.message_id,
+        payload = EXCLUDED.payload,
+        expires_at = EXCLUDED.expires_at
+    `,
+    [
+      record.token,
+      record.action,
+      record.chatId ?? null,
+      record.messageId ?? null,
+      record.payload,
+      record.expiresAt,
+    ],
+  );
+};
+
+export const loadCallbackMapRecord = async <TPayload>(
+  token: string,
+): Promise<CallbackMapRecord<TPayload> | null> => {
+  const { rows } = await pool.query<CallbackMapRow<TPayload>>(
+    `
+      SELECT token, action, chat_id, message_id, payload, expires_at
+      FROM callback_map
+      WHERE token = $1
+    `,
+    [token],
+  );
+
+  const [row] = rows;
+  if (!row) {
+    return null;
+  }
+
+  return mapRow(row);
+};
+
+export const listCallbackMapRecords = async <TPayload>(
+  action: string,
+): Promise<CallbackMapRecord<TPayload>[]> => {
+  const { rows } = await pool.query<CallbackMapRow<TPayload>>(
+    `
+      SELECT token, action, chat_id, message_id, payload, expires_at
+      FROM callback_map
+      WHERE action = $1 AND expires_at > NOW()
+    `,
+    [action],
+  );
+
+  return rows.map(mapRow);
+};
+
+export const deleteCallbackMapRecord = async (token: string): Promise<void> => {
+  await pool.query(`DELETE FROM callback_map WHERE token = $1`, [token]);
+};
+

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
 export * from './sessions';
+export * from './callbackMap';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { app, isShutdownInProgress, setupGracefulShutdown } from './app';
+import { app, initialiseAppState, isShutdownInProgress, setupGracefulShutdown } from './app';
 import { logger } from './config';
 import { registerJobs } from './jobs';
 
@@ -50,6 +50,7 @@ const isGracefulShutdownError = (error: unknown): boolean => {
 
 const start = async (): Promise<void> => {
   try {
+    await initialiseAppState();
     await app.launch();
     registerJobs(app);
     logger.info('Bot started using long polling');

--- a/tests/moderation-queue.test.ts
+++ b/tests/moderation-queue.test.ts
@@ -1,0 +1,213 @@
+import './helpers/setup-env';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import type { Telegraf } from 'telegraf';
+import type { Telegram } from 'telegraf';
+
+import {
+  createModerationQueue,
+  type ModerationQueueItemBase,
+} from '../src/bot/moderation/queue';
+import type { BotContext } from '../src/bot/types';
+import { pool } from '../src/db';
+
+interface CallbackRecord {
+  token: string;
+  action: string;
+  chatId: number | null;
+  messageId: number | null;
+  payload: any;
+  expiresAt: Date;
+}
+
+const callbackMap = new Map<string, CallbackRecord>();
+
+const channelsRow = {
+  verify_channel_id: '555',
+  drivers_channel_id: null,
+};
+
+const originalQuery = pool.query.bind(pool);
+
+const setPoolQuery = (fn: typeof pool.query) => {
+  (pool as unknown as { query: typeof pool.query }).query = fn;
+};
+
+const fakeQuery = (async (...args: any[]) => {
+  let text: string;
+  let params: any[];
+
+  if (typeof args[0] === 'string') {
+    text = args[0];
+    params = (args[1] ?? []) as any[];
+  } else if (args[0] && typeof args[0] === 'object' && 'text' in args[0]) {
+    text = (args[0] as { text: string }).text;
+    params = (args[1] ?? []) as any[];
+  } else {
+    throw new Error(`Unexpected query invocation: ${JSON.stringify(args[0])}`);
+  }
+
+  if (/SELECT\s+verify_channel_id/i.test(text)) {
+    return { rows: [channelsRow] } as any;
+  }
+
+  if (/INSERT\s+INTO\s+callback_map/i.test(text)) {
+    const [token, action, chatId, messageId, payload, expiresAt] = params;
+    callbackMap.set(token, {
+      token,
+      action,
+      chatId: chatId ?? null,
+      messageId: messageId ?? null,
+      payload,
+      expiresAt,
+    });
+    return { rows: [] } as any;
+  }
+
+  if (/SELECT\s+token,\s+action,\s+chat_id,\s+message_id,\s+payload,\s+expires_at\s+FROM\s+callback_map\s+WHERE\s+token\s*=\s*\$1/i.test(text)) {
+    const [token] = params;
+    const record = callbackMap.get(token);
+    if (!record) {
+      return { rows: [] } as any;
+    }
+
+    return {
+      rows: [
+        {
+          token: record.token,
+          action: record.action,
+          chat_id: record.chatId,
+          message_id: record.messageId,
+          payload: record.payload,
+          expires_at: record.expiresAt,
+        },
+      ],
+    } as any;
+  }
+
+  if (/SELECT\s+token,\s+action,\s+chat_id,\s+message_id,\s+payload,\s+expires_at\s+FROM\s+callback_map\s+WHERE\s+action\s*=\s*\$1/i.test(text)) {
+    const [action] = params;
+    const rows = Array.from(callbackMap.values())
+      .filter((record) => record.action === action && record.expiresAt.getTime() > Date.now())
+      .map((record) => ({
+        token: record.token,
+        action: record.action,
+        chat_id: record.chatId,
+        message_id: record.messageId,
+        payload: record.payload,
+        expires_at: record.expiresAt,
+      }));
+    return { rows } as any;
+  }
+
+  if (/DELETE\s+FROM\s+callback_map/i.test(text)) {
+    const [token] = params;
+    callbackMap.delete(token);
+    return { rows: [] } as any;
+  }
+
+  throw new Error(`Unexpected query: ${text}`);
+}) as typeof pool.query;
+
+interface TestItem extends ModerationQueueItemBase<TestItem> {
+  id: string;
+  label: string;
+}
+
+describe('moderation queue persistence', () => {
+  beforeEach(() => {
+    callbackMap.clear();
+    setPoolQuery(fakeQuery);
+  });
+
+  const restorePool = () => {
+    setPoolQuery(originalQuery);
+  };
+
+  afterEach(() => {
+    restorePool();
+  });
+
+  it('restores pending approvals after restart', async () => {
+    const approvals: string[] = [];
+
+    const deserializeItem = (payload: unknown): TestItem | null => {
+      if (!payload || typeof payload !== 'object') {
+        return null;
+      }
+
+      const item = payload as TestItem;
+      item.onApprove = async (context) => {
+        approvals.push(context.item.id);
+      };
+      return item;
+    };
+
+    const queue = createModerationQueue<TestItem>({
+      type: 'test',
+      channelType: 'verify',
+      defaultRejectionReasons: ['Нет данных'],
+      renderMessage: (item) => item.label,
+      deserializeItem,
+    });
+
+    const telegram = {
+      async sendMessage() {
+        return { message_id: 101, chat: { id: 555 } };
+      },
+      async editMessageText() {
+        return true;
+      },
+    } as unknown as Telegram;
+
+    const publishResult = await queue.publish(telegram, {
+      id: 'item-1',
+      label: 'Test item',
+    });
+
+    assert.equal(publishResult.status, 'published');
+    const token = publishResult.token;
+    assert.ok(token);
+    assert.equal(callbackMap.has(token!), true);
+
+    const queueAfterRestart = createModerationQueue<TestItem>({
+      type: 'test',
+      channelType: 'verify',
+      defaultRejectionReasons: ['Нет данных'],
+      renderMessage: (item) => item.label,
+      deserializeItem,
+    });
+
+    await queueAfterRestart.restore();
+
+    let approveHandler: ((ctx: BotContext) => Promise<void>) | undefined;
+
+    const bot = {
+      action(pattern: RegExp, handler: (ctx: BotContext) => Promise<void>) {
+        if (pattern.test(`mod:test:accept:${token}`)) {
+          approveHandler = handler;
+        }
+      },
+      on() {},
+    } as unknown as Telegraf<BotContext>;
+
+    queueAfterRestart.register(bot);
+    assert.ok(approveHandler, 'Approve handler should be registered');
+
+    const ctx = {
+      match: [`mod:test:accept:${token}`, token],
+      telegram,
+      from: { id: 42 },
+      chat: { id: 555 },
+      answerCbQuery: async () => {},
+    } as unknown as BotContext;
+
+    await approveHandler!(ctx);
+
+    assert.deepEqual(approvals, ['item-1']);
+    assert.equal(callbackMap.size, 0);
+
+  });
+});

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -102,6 +102,35 @@ describe('support service', () => {
     setPoolQuery(originalQuery);
   });
 
+  it('restores open threads from the database', async () => {
+    const rows = [
+      {
+        id: 'thread-restore',
+        user_chat_id: '1001',
+        user_tg_id: '2002',
+        user_message_id: 10,
+        moderator_chat_id: '3003',
+        moderator_message_id: 20,
+        status: 'open',
+      },
+    ];
+
+    setPoolQuery((async (text: string) => {
+      if (/FROM\s+support_threads/i.test(text)) {
+        return { rows } as any;
+      }
+
+      return { rows: [] } as any;
+    }) as typeof pool.query);
+
+    await __testing__.restoreSupportThreads();
+
+    const state = __testing__.threadsById.get('thread-restore');
+    assert.ok(state, 'thread should be tracked after restore');
+    assert.equal(state?.userChatId, 1001);
+    assert.equal(state?.moderatorMessageId, 20);
+  });
+
   it('forwards support messages and records threads', async () => {
     const telegram = createMockTelegram();
 


### PR DESCRIPTION
## Summary
- add a callback_map persistence helper and have moderation queues read/write their tokens during publish and restore
- rehydrate payment and verification queue items, extending executor submissions to include session metadata needed after restarts
- restore open support threads on startup so reply/close actions work across bot restarts and expose an application init hook

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe12bd644832d927de04da618cea5