### PR TITLE
Fix auto deletion and support reply handling

### DIFF
--- a/src/bot/middlewares/autoDelete.ts
+++ b/src/bot/middlewares/autoDelete.ts
@@ -1,43 +1,8 @@
 import type { MiddlewareFn } from 'telegraf';
 
 import { logger } from '../../config';
-import { safeDeleteMessage } from '../../utils/tg';
 import { ui } from '../ui';
 import type { BotContext } from '../types';
-
-interface MessageReference {
-  chatId: number;
-  messageId: number;
-  chatType?: string;
-}
-
-const resolveIncomingMessage = (ctx: BotContext): MessageReference | null => {
-  const message = ctx.message as
-    | ({ message_id: number; chat?: { id?: number; type?: string }; from?: { is_bot?: boolean } })
-    | undefined;
-
-  if (!message || typeof message.message_id !== 'number') {
-    return null;
-  }
-
-  const chatId = message.chat?.id;
-  if (typeof chatId !== 'number') {
-    return null;
-  }
-
-  if (message.from?.is_bot) {
-    return null;
-  }
-
-  return {
-    chatId,
-    messageId: message.message_id,
-    chatType: message.chat?.type,
-  } satisfies MessageReference;
-};
-
-const shouldDeleteIncoming = (ref: MessageReference | null): ref is MessageReference =>
-  Boolean(ref && ref.chatType === 'private');
 
 export const autoDelete = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   if (ctx.chat?.id && ctx.session.ephemeralMessages.length > 0) {
@@ -66,23 +31,5 @@ export const autoDelete = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     await ui.clear(ctx);
   }
 
-  const incomingMessage = resolveIncomingMessage(ctx);
-
   await next();
-
-  if (!shouldDeleteIncoming(incomingMessage)) {
-    return;
-  }
-
-  const success = await safeDeleteMessage(ctx.telegram, incomingMessage.chatId, incomingMessage.messageId);
-  if (!success) {
-    logger.debug(
-      {
-        chatId: incomingMessage.chatId,
-        messageId: incomingMessage.messageId,
-        chatType: incomingMessage.chatType,
-      },
-      'Failed to delete incoming message',
-    );
-  }
 };


### PR DESCRIPTION
## Summary
- stop deleting user messages in the autoDelete middleware so role and support conversations remain visible
- allow moderators to answer support threads by replying to the forwarded message directly, with graceful handling of closed threads
- add tests covering the direct reply flow for support threads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc54d6c818832d91f1188102266005