### PR TITLE
Include city_selected in auth upsert returning

### DIFF
--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -117,7 +117,7 @@ const loadAuthState = async (
           first_name = COALESCE(EXCLUDED.first_name, users.first_name),
           last_name = COALESCE(EXCLUDED.last_name, users.last_name),
           updated_at = now()
-        RETURNING tg_id, username, first_name, last_name, phone, role, is_verified, is_blocked
+        RETURNING tg_id, username, first_name, last_name, phone, role, is_verified, is_blocked, city_selected
       )
       SELECT
         u.tg_id,


### PR DESCRIPTION
## Summary
- include the users.city_selected column in the auth upsert returning clause so the subsequent select can read it without errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb032d334832d9adf92bcf5985d60