### PR TITLE
Ensure executor menu resumes after city selection

### DIFF
--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -119,7 +119,7 @@ export interface UiTrackedStepState {
 export interface UiSessionState {
   steps: Record<string, UiTrackedStepState | undefined>;
   homeActions: string[];
-  pendingCityAction?: 'clientMenu';
+  pendingCityAction?: 'clientMenu' | 'executorMenu';
 }
 
 export type SupportRequestStatus = 'idle' | 'awaiting_message';


### PR DESCRIPTION
## Summary
- set a pending city action when the executor menu requires a city and rerender the menu once the city is selected
- extend the UI session state to track executor-specific city prompts and handle the callback action
- add a regression test that covers the executor city selection flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0371f1f38832d80c010c49d9a52cc