### PR TITLE
Adjust delivery pricing to ignore general tariff

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -56,11 +56,12 @@ Omitting any of them keeps the built-in defaults.
 
 The following values describe default tariff parameters used in external automations.
 They are optional but must be defined together when used. When present, Freedom Bot
-also applies them to price quotes shown to customers and executors using the
-`base + per_km * distance + per_min * eta` formula. The ETA is approximated with a
-5-minute pickup buffer and an average city speed of roughly 27 km/h, then rounded
-to the nearest minute before calculating the time component. The final quote is
-rounded to the nearest tenge for consistency with legacy pricing.
+applies them to taxi price quotes shown to customers and executors using the
+`base + per_km * distance + per_min * eta` formula. Delivery quotes continue to rely
+on the configured delivery tariffs. The ETA is approximated with a 5-minute pickup
+buffer and an average city speed of roughly 27 km/h, then rounded to the nearest
+minute before calculating the time component. The final quote is rounded to the
+nearest tenge for consistency with legacy pricing.
 
 - `TARIFF_BASE` – Base fare applied to a new order.
 - `TARIFF_PER_KM` – Distance component calculated per kilometre.

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -90,7 +90,7 @@ export const createPricingService = (
   generalTariff: TariffRates | null = null,
 ) => ({
   estimateTaxiPrice: createEstimator(pricing.taxi, generalTariff),
-  estimateDeliveryPrice: createEstimator(pricing.delivery, generalTariff),
+  estimateDeliveryPrice: createEstimator(pricing.delivery, null),
 });
 
 const defaultPricingService = createPricingService(config.pricing, config.tariff);

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -137,7 +137,7 @@ describe('pricing service', () => {
     }
   });
 
-  it('prefers general tariff when provided', async () => {
+  it('uses the general tariff for taxi quotes when provided', async () => {
     const originalEnv = { ...process.env };
     const baseEnv = {
       BOT_TOKEN: originalEnv.BOT_TOKEN ?? 'test-token',
@@ -196,10 +196,13 @@ describe('pricing service', () => {
       const deliveryQuote = service.estimateDeliveryPrice(from, to);
       assert.equal(deliveryQuote.distanceKm, distance);
       assert.equal(deliveryQuote.etaMinutes, eta);
-      assert.equal(deliveryQuote.amount, computeGeneralAmount(distance, eta, generalTariff));
-      assert.notStrictEqual(
+      assert.equal(
         deliveryQuote.amount,
         computeServiceAmount(distance, configWithTariff.pricing.delivery),
+      );
+      assert.notStrictEqual(
+        deliveryQuote.amount,
+        computeGeneralAmount(distance, eta, generalTariff),
       );
     } finally {
       process.env = originalEnv;


### PR DESCRIPTION
## Summary
- stop applying the global tariff override to delivery price estimates so distance-based delivery fares are respected
- update pricing tests to cover the new behaviour and keep taxi quotes using the general tariff
- clarify the environment documentation about how tariff hints affect taxi versus delivery quotes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0589bcf04832da9d6b86bed0e09c4