### PR TITLE
Include phone number in support headers

### DIFF
--- a/src/bot/services/support.ts
+++ b/src/bot/services/support.ts
@@ -525,6 +525,12 @@ const formatSupportHeader = (ctx: BotContext, threadId: string): string => {
     parts.push(`Имя: ${fullName}`);
   }
 
+  const phone = ctx.auth?.user.phone ?? ctx.session?.phoneNumber;
+  const normalisedPhone = phone?.trim();
+  if (normalisedPhone) {
+    parts.push(`Телефон: ${normalisedPhone}`);
+  }
+
   return parts.join('\n');
 };
 


### PR DESCRIPTION
## Summary
- add the user's phone number to the support header when available
- verify the header contents, including the phone number, in the support service test

## Testing
- node --require ts-node/register --test tests/support.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d336773be0832da39cc734ad0c73c3