### PR TITLE
Persist user phone numbers when contacts are shared

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -57,9 +57,14 @@ const applyClientRole = async (ctx: BotContext): Promise<void> => {
   const username = ctx.from?.username ?? authUser.username;
   const firstName = ctx.from?.first_name ?? authUser.firstName;
   const lastName = ctx.from?.last_name ?? authUser.lastName;
-  const phone = authUser.phone ?? ctx.session.phoneNumber;
+  const sessionPhone = ctx.session.phoneNumber;
+  const authPhone = authUser.phone;
+  const phone = sessionPhone ?? authPhone;
 
-  if (authUser.role !== 'client') {
+  const shouldEnsureRole = authUser.role !== 'client';
+  const shouldUpdatePhone = Boolean(phone && authPhone !== phone);
+
+  if (shouldEnsureRole || shouldUpdatePhone) {
     try {
       await ensureClientRole({
         telegramId: authUser.telegramId,
@@ -80,7 +85,7 @@ const applyClientRole = async (ctx: BotContext): Promise<void> => {
   authUser.username = username ?? undefined;
   authUser.firstName = firstName ?? undefined;
   authUser.lastName = lastName ?? undefined;
-  if (!authUser.phone && phone) {
+  if (phone) {
     authUser.phone = phone;
   }
   ctx.auth.isModerator = false;

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -49,3 +49,24 @@ export const ensureClientRole = async ({
     ],
   );
 };
+
+export interface UpdateUserPhoneParams {
+  telegramId: number;
+  phone: string;
+}
+
+export const updateUserPhone = async ({
+  telegramId,
+  phone,
+}: UpdateUserPhoneParams): Promise<void> => {
+  await pool.query(
+    `
+      UPDATE users
+      SET
+        phone = $2,
+        updated_at = now()
+      WHERE tg_id = $1
+    `,
+    [telegramId, phone],
+  );
+};


### PR DESCRIPTION
## Summary
- persist collected phone numbers in the database when a user shares contact details
- ensure client role upsert runs whenever the selected phone differs from the stored value

## Testing
- npm run check
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d3562c627c832d8164b9c03083f79e