### PR TITLE
Add executor quick action reply keyboard and text command support

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -4,6 +4,7 @@ import type { BotContext } from '../types';
 import { phoneCollect } from '../flows/common/phoneCollect';
 import { setChatCommands } from '../services/commands';
 import { CLIENT_COMMANDS, EXECUTOR_COMMANDS } from './sets';
+import { hideClientMenu } from '../../ui/clientMenu';
 
 type RoleKey = 'client' | 'courier' | 'driver';
 
@@ -77,6 +78,7 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
     }
 
     await applyCommandsForRole(ctx);
+    await hideClientMenu(ctx, 'Возвращаю стандартную клавиатуру…');
     await presentRoleSelection(ctx);
   });
 

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -10,6 +10,7 @@ import { config, logger } from '../../../config';
 import type { BotContext } from '../../types';
 import {
   EXECUTOR_MENU_ACTION,
+  EXECUTOR_MENU_TEXT_LABELS,
   EXECUTOR_SUBSCRIPTION_ACTION,
   ensureExecutorState,
   showExecutorMenu,
@@ -470,6 +471,15 @@ export const registerExecutorSubscription = (bot: Telegraf<BotContext>): void =>
     }
 
     await ctx.answerCbQuery();
+    await startExecutorSubscription(ctx);
+  });
+
+  bot.hears(EXECUTOR_MENU_TEXT_LABELS.subscription, async (ctx) => {
+    if (ctx.chat?.type !== 'private') {
+      return;
+    }
+
+    ensureExecutorState(ctx);
     await startExecutorSubscription(ctx);
   });
 

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -11,9 +11,11 @@ import {
 import { persistVerificationSubmission } from '../../../db/verifications';
 import {
   EXECUTOR_MENU_ACTION,
+  EXECUTOR_MENU_TEXT_LABELS,
   EXECUTOR_SUBSCRIPTION_ACTION,
   EXECUTOR_VERIFICATION_ACTION,
   ensureExecutorState,
+  isExecutorMenuTextCommand,
   resetVerificationState,
   showExecutorMenu,
 } from './menu';
@@ -439,6 +441,11 @@ const handleTextDuringCollection = async (ctx: BotContext, next: () => Promise<v
     return;
   }
 
+  if (isExecutorMenuTextCommand(text.trim())) {
+    await next();
+    return;
+  }
+
   await ui.step(ctx, {
     id: VERIFICATION_PHOTO_REMINDER_STEP_ID,
     text: 'Отправьте, пожалуйста, фотографию документа.',
@@ -454,6 +461,15 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
     }
 
     await ctx.answerCbQuery();
+    await startExecutorVerification(ctx);
+  });
+
+  bot.hears(EXECUTOR_MENU_TEXT_LABELS.documents, async (ctx) => {
+    if (ctx.chat?.type !== 'private') {
+      return;
+    }
+
+    ensureExecutorState(ctx);
     await startExecutorVerification(ctx);
   });
 

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -3,7 +3,7 @@ import './helpers/setup-env';
 import assert from 'node:assert/strict';
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import type { Telegraf } from 'telegraf';
-import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+import type { InlineKeyboardMarkup, ReplyKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import {
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
@@ -216,7 +216,10 @@ describe('executor role selection', () => {
     const fallbackCall = sendMessageCalls.at(-1);
     assert.ok(fallbackCall, 'fallback sendMessage should be recorded');
     assert.equal(fallbackCall.chatId, ctx.chat!.id);
-    assert.ok((fallbackCall.extra as { reply_markup?: InlineKeyboardMarkup }).reply_markup);
+    const fallbackMarkup = (fallbackCall.extra as {
+      reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup;
+    }).reply_markup;
+    assert.ok(fallbackMarkup);
     assert.match(fallbackCall.text, /Меню водителя/);
   });
 });

--- a/tests/executor-verification.test.ts
+++ b/tests/executor-verification.test.ts
@@ -96,6 +96,7 @@ const registerVerificationHandlers = (): { handlePhoto: PhotoHandler } => {
       return bot;
     },
     command: () => bot,
+    hears: () => bot,
   } as unknown as import('telegraf').Telegraf<BotContext>;
 
   registerExecutorVerification(bot);


### PR DESCRIPTION
## Summary
- display a persistent reply keyboard with quick actions when showing the executor menu and handle the new text commands across verification, subscription, orders and support flows
- remove executor/client keyboards when returning to start and ensure Telegraf UI helpers accept reply keyboards without editing them
- extend tests to cover the new reply keyboard layout and updated mock bots

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4519933d4832dbe9b12f4e8c3575f