### PR TITLE
Add stats channel column to channels table

### DIFF
--- a/db/sql/000_init.sql
+++ b/db/sql/000_init.sql
@@ -134,8 +134,11 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS channels (
   id integer PRIMARY KEY CHECK (id = 1),
   verify_channel_id bigint,
-  drivers_channel_id bigint
+  drivers_channel_id bigint,
+  stats_channel_id bigint
 );
+
+ALTER TABLE channels ADD COLUMN IF NOT EXISTS stats_channel_id bigint;
 
 INSERT INTO channels (id)
 VALUES (1)


### PR DESCRIPTION
## Summary
- add the stats channel identifier to the initial `channels` table definition
- include an idempotent alter to backfill the column for existing databases

## Testing
- npm test *(passes but leaves the Node test runner hanging; terminated after verifying green subtests)*
- npm run migrate *(fails: no PostgreSQL instance running at localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68d4690520b4832d8dccc6238bafa87a