### PR TITLE
Implement UX guardrails and recovery utilities

### DIFF
--- a/db/sql/002_ux_operability.sql
+++ b/db/sql/002_ux_operability.sql
@@ -1,0 +1,86 @@
+BEGIN;
+
+-- Extend session metadata with flow tracking fields
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS flow_state TEXT,
+  ADD COLUMN IF NOT EXISTS flow_payload JSONB DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS last_step_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS nudge_sent_at TIMESTAMPTZ;
+
+-- Journal FSM transitions for diagnostics
+CREATE TABLE IF NOT EXISTS fsm_journal (
+  id BIGSERIAL PRIMARY KEY,
+  scope TEXT NOT NULL,
+  scope_id BIGINT NOT NULL,
+  from_state TEXT,
+  to_state   TEXT,
+  step_id    TEXT,
+  payload    JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS fsm_journal_scope_idx
+  ON fsm_journal(scope, scope_id, created_at DESC);
+
+-- Idempotency guard for user actions
+CREATE TABLE IF NOT EXISTS recent_actions (
+  user_id    BIGINT NOT NULL,
+  key        TEXT   NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (user_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS recent_actions_expires_idx ON recent_actions(expires_at);
+
+-- Remember last used locations for quick re-ordering
+CREATE TABLE IF NOT EXISTS user_recent_locations (
+  user_id   BIGINT NOT NULL,
+  city      TEXT   NOT NULL,
+  kind      TEXT   NOT NULL CHECK (kind IN ('pickup','dropoff')),
+  location_id TEXT NOT NULL,
+  query     TEXT   NOT NULL,
+  address   TEXT   NOT NULL,
+  lat       DOUBLE PRECISION NOT NULL,
+  lon       DOUBLE PRECISION NOT NULL,
+  two_gis_url TEXT,
+  last_used_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, city, kind, location_id),
+  UNIQUE (user_id, city, kind, address)
+);
+
+CREATE INDEX IF NOT EXISTS user_recent_locations_last_used_idx
+  ON user_recent_locations(user_id, city, kind, last_used_at DESC);
+
+-- Keep only the latest five locations per user/city/kind
+CREATE OR REPLACE FUNCTION trim_user_recent_locations() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM user_recent_locations
+  WHERE ctid IN (
+    SELECT ctid
+    FROM user_recent_locations
+    WHERE user_id = NEW.user_id
+      AND city = NEW.city
+      AND kind = NEW.kind
+    ORDER BY last_used_at DESC
+    OFFSET 5
+  );
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_trim_user_recent_locations ON user_recent_locations;
+CREATE TRIGGER trg_trim_user_recent_locations
+AFTER INSERT ON user_recent_locations
+FOR EACH ROW EXECUTE FUNCTION trim_user_recent_locations();
+
+-- Experiment assignments for lightweight A/B tests
+CREATE TABLE IF NOT EXISTS user_experiments (
+  user_id    BIGINT NOT NULL,
+  experiment TEXT   NOT NULL,
+  variant    TEXT   NOT NULL,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, experiment)
+);
+
+COMMIT;

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,7 @@ import {
 import { auth } from './bot/middlewares/auth';
 import { autoDelete } from './bot/middlewares/autoDelete';
 import { errorBoundary } from './bot/middlewares/errorBoundary';
+import { antiFlood } from './bot/middlewares/antiFlood';
 import { session } from './bot/middlewares/session';
 import { keyboardGuard } from './bot/middlewares/keyboardGuard';
 import { stateGate } from './bot/middlewares/stateGate';
@@ -49,6 +50,7 @@ app.catch((error, ctx) => {
 
 app.use(errorBoundary());
 app.use(session());
+app.use(antiFlood());
 app.use(autoDelete());
 app.use(auth());
 app.use(keyboardGuard());

--- a/src/bot/middlewares/callbackDecoder.ts
+++ b/src/bot/middlewares/callbackDecoder.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareFn } from 'telegraf';
 
 import { config, logger } from '../../config';
+import { withLatencyLog } from '../../metrics/latency';
 import type { BotContext } from '../types';
 import { renderMenuFor } from '../ui/menus';
 import {
@@ -54,6 +55,8 @@ export const callbackDecoder = (): MiddlewareFn<BotContext> => async (ctx, next)
   state.callbackPayload = decoded.wrapped;
   (query as { data?: string }).data = decoded.wrapped.raw;
 
-  await next();
+  await withLatencyLog(`callback:${decoded.wrapped.raw}`, async () => {
+    await next();
+  });
 };
 

--- a/src/bot/middlewares/idempotency.ts
+++ b/src/bot/middlewares/idempotency.ts
@@ -1,0 +1,60 @@
+import crypto from 'crypto';
+
+import type { BotContext } from '../types';
+import { pool } from '../../db';
+
+const DEFAULT_TTL_SECONDS = 60;
+
+const buildKey = (userId: number, action: string, payload?: string): string =>
+  crypto.createHash('sha1').update(`${userId}:${action}:${payload ?? ''}`).digest('hex');
+
+const removeExpiredKeys = async (userId: number): Promise<void> => {
+  try {
+    await pool.query('DELETE FROM recent_actions WHERE user_id = $1 AND expires_at < now()', [userId]);
+  } catch {
+    // ignore cleanup failures
+  }
+};
+
+export const withIdempotency = async <T>(
+  ctx: BotContext,
+  action: string,
+  payload: string | undefined,
+  handler: () => Promise<T>,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): Promise<{ status: 'ok'; result: T } | { status: 'duplicate' }> => {
+  const userId = ctx.auth?.user.telegramId ?? ctx.from?.id;
+  if (typeof userId !== 'number') {
+    return { status: 'duplicate' };
+  }
+
+  await removeExpiredKeys(userId);
+
+  const key = buildKey(userId, action, payload);
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+  const insertResult = await pool.query(
+    `
+      INSERT INTO recent_actions (user_id, key, expires_at)
+      VALUES ($1, $2, $3)
+      ON CONFLICT DO NOTHING
+    `,
+    [userId, key, expiresAt.toISOString()],
+  );
+
+  if (insertResult.rowCount === 0) {
+    return { status: 'duplicate' };
+  }
+
+  try {
+    const result = await handler();
+    return { status: 'ok', result };
+  } catch (error) {
+    try {
+      await pool.query('DELETE FROM recent_actions WHERE user_id = $1 AND key = $2', [userId, key]);
+    } catch {
+      // swallow cleanup errors, prefer surfacing original failure
+    }
+    throw error;
+  }
+};

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -125,7 +125,7 @@ const parseScopeId = (value: unknown): string | undefined => {
   return undefined;
 };
 
-const resolveSessionKey = (ctx: BotContext): SessionKey | undefined => {
+export const resolveSessionKey = (ctx: BotContext): SessionKey | undefined => {
   const chatId = parseScopeId(ctx.chat?.id);
   if (chatId !== undefined) {
     return { scope: 'chat', scopeId: chatId } satisfies SessionKey;

--- a/src/bot/services/recentLocations.ts
+++ b/src/bot/services/recentLocations.ts
@@ -1,0 +1,123 @@
+import crypto from 'crypto';
+
+import type { AppCity } from '../../domain/cities';
+import { pool } from '../../db';
+import type { OrderLocation } from '../../types';
+
+export type RecentLocationKind = 'pickup' | 'dropoff';
+
+interface RecentLocationRow {
+  location_id: string;
+  query: string;
+  address: string;
+  lat: number;
+  lon: number;
+  two_gis_url: string | null;
+}
+
+const buildLocationId = (location: OrderLocation): string =>
+  crypto
+    .createHash('sha1')
+    .update(`${location.query}|${location.address}|${location.latitude}|${location.longitude}`)
+    .digest('hex');
+
+const mapRowToLocation = (row: RecentLocationRow): OrderLocation => ({
+  query: row.query,
+  address: row.address,
+  latitude: Number(row.lat),
+  longitude: Number(row.lon),
+  twoGisUrl: row.two_gis_url ?? undefined,
+});
+
+export const rememberLocation = async (
+  userId: number,
+  city: AppCity,
+  kind: RecentLocationKind,
+  location: OrderLocation,
+): Promise<void> => {
+  const locationId = buildLocationId(location);
+  await pool.query(
+    `
+      INSERT INTO user_recent_locations (
+        user_id,
+        city,
+        kind,
+        location_id,
+        query,
+        address,
+        lat,
+        lon,
+        two_gis_url,
+        last_used_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+      ON CONFLICT (user_id, city, kind, location_id) DO UPDATE
+      SET query = EXCLUDED.query,
+          address = EXCLUDED.address,
+          lat = EXCLUDED.lat,
+          lon = EXCLUDED.lon,
+          two_gis_url = EXCLUDED.two_gis_url,
+          last_used_at = now()
+    `,
+    [
+      userId,
+      city,
+      kind,
+      locationId,
+      location.query,
+      location.address,
+      location.latitude,
+      location.longitude,
+      location.twoGisUrl ?? null,
+    ],
+  );
+};
+
+export interface RecentLocationOption {
+  locationId: string;
+  label: string;
+}
+
+export const loadRecentLocations = async (
+  userId: number,
+  city: AppCity,
+  kind: RecentLocationKind,
+  limit = 3,
+): Promise<RecentLocationOption[]> => {
+  const { rows } = await pool.query<RecentLocationRow>(
+    `
+      SELECT location_id, query, address, lat, lon, two_gis_url
+      FROM user_recent_locations
+      WHERE user_id = $1 AND city = $2 AND kind = $3
+      ORDER BY last_used_at DESC
+      LIMIT $4
+    `,
+    [userId, city, kind, limit],
+  );
+
+  return rows.map((row) => ({ locationId: row.location_id, label: row.address }));
+};
+
+export const findRecentLocation = async (
+  userId: number,
+  city: AppCity,
+  kind: RecentLocationKind,
+  locationId: string,
+): Promise<OrderLocation | null> => {
+  const { rows } = await pool.query<RecentLocationRow>(
+    `
+      SELECT location_id, query, address, lat, lon, two_gis_url
+      FROM user_recent_locations
+      WHERE user_id = $1 AND city = $2 AND kind = $3 AND location_id = $4
+      LIMIT 1
+    `,
+    [userId, city, kind, locationId],
+  );
+
+  const [row] = rows;
+  if (!row) {
+    return null;
+  }
+
+  return mapRowToLocation(row);
+};

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -2,6 +2,7 @@ import type { Telegraf } from 'telegraf';
 
 import type { BotContext } from '../bot/types';
 import { startSubscriptionScheduler, stopSubscriptionScheduler } from './scheduler';
+import { startInactivityNudger, stopInactivityNudger } from './nudger';
 
 let initialized = false;
 
@@ -11,6 +12,7 @@ export const registerJobs = (bot: Telegraf<BotContext>): void => {
   }
 
   startSubscriptionScheduler(bot);
+  startInactivityNudger(bot);
   initialized = true;
 };
 
@@ -19,6 +21,7 @@ export const stopJobs = (): void => {
     return;
   }
 
+  stopInactivityNudger();
   stopSubscriptionScheduler();
   initialized = false;
 };

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -1,0 +1,179 @@
+import cron, { type ScheduledTask } from 'node-cron';
+import type { Telegraf } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+import type { BotContext } from '../bot/types';
+import { CLIENT_MENU_ACTION } from '../bot/flows/client/menu';
+import { EXECUTOR_MENU_ACTION } from '../bot/flows/executor/menu';
+import { buildInlineKeyboard } from '../bot/keyboards/common';
+import { wrapCallbackData } from '../bot/services/callbackTokens';
+import { config, logger } from '../config';
+import { pool } from '../db';
+import { markNudged, type SessionKey } from '../db/sessions';
+
+interface PendingSessionRow {
+  scope: string;
+  scope_id: string;
+  flow_state: string | null;
+  flow_payload: unknown;
+  role: string | null;
+  keyboard_nonce: string | null;
+}
+
+interface FlowPayloadShape {
+  homeAction?: string | null;
+}
+
+const secret = config.bot.callbackSignSecret ?? config.bot.token;
+
+const parseFlowPayload = (value: unknown): FlowPayloadShape => {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const homeAction = typeof candidate.homeAction === 'string' ? candidate.homeAction : null;
+  return { homeAction: homeAction ?? undefined };
+};
+
+const bindAction = (
+  action: string,
+  userId: string | null,
+  keyboardNonce: string | null,
+): string => {
+  if (!userId || !keyboardNonce) {
+    return action;
+  }
+
+  return wrapCallbackData(action, {
+    secret,
+    userId,
+    keyboardNonce,
+    bindToUser: true,
+  });
+};
+
+const buildNudgeKeyboard = (
+  payload: FlowPayloadShape,
+  role: string | null,
+  userId: string | null,
+  keyboardNonce: string | null,
+): InlineKeyboardMarkup | undefined => {
+  const rows: { label: string; action: string }[][] = [];
+
+  if (payload.homeAction) {
+    rows.push([
+      {
+        label: '🔄 Продолжить',
+        action: bindAction(payload.homeAction, userId, keyboardNonce),
+      },
+    ]);
+  }
+
+  let fallbackAction: string | null = null;
+  if (role === 'courier' || role === 'driver') {
+    fallbackAction = EXECUTOR_MENU_ACTION;
+  } else if (role === 'client' || role === 'moderator') {
+    fallbackAction = CLIENT_MENU_ACTION;
+  }
+
+  if (fallbackAction) {
+    rows.push([
+      {
+        label: '🏠 Главное меню',
+        action: bindAction(fallbackAction, userId, keyboardNonce),
+      },
+    ]);
+  }
+
+  if (rows.length === 0) {
+    return undefined;
+  }
+
+  return buildInlineKeyboard(rows);
+};
+
+let task: ScheduledTask | null = null;
+
+const buildSessionKey = (row: PendingSessionRow): SessionKey | null => {
+  if (row.scope !== 'chat') {
+    return null;
+  }
+
+  const scopeId = row.scope_id?.trim();
+  if (!scopeId) {
+    return null;
+  }
+
+  return { scope: 'chat', scopeId };
+};
+
+export const startInactivityNudger = (bot: Telegraf<BotContext>): void => {
+  if (task) {
+    return;
+  }
+
+  task = cron.schedule('*/30 * * * * *', async () => {
+    try {
+      const { rows } = await pool.query<PendingSessionRow>(
+        `
+          SELECT s.scope, s.scope_id, s.flow_state, s.flow_payload, u.role, u.keyboard_nonce
+          FROM sessions s
+          LEFT JOIN users u ON u.tg_id = s.scope_id
+          WHERE s.scope = 'chat'
+            AND s.flow_state IS NOT NULL
+            AND s.last_step_at IS NOT NULL
+            AND (s.nudge_sent_at IS NULL OR s.nudge_sent_at < s.last_step_at)
+            AND s.last_step_at < now() - interval '90 seconds'
+          ORDER BY s.last_step_at
+          LIMIT 20
+        `,
+      );
+
+      for (const row of rows) {
+        const key = buildSessionKey(row);
+        if (!key) {
+          continue;
+        }
+
+        const chatIdNumber = Number(row.scope_id);
+        if (!Number.isFinite(chatIdNumber) || chatIdNumber <= 0) {
+          await markNudged(pool, key);
+          continue;
+        }
+
+        const payload = parseFlowPayload(row.flow_payload);
+        const keyboard = buildNudgeKeyboard(payload, row.role, row.scope_id, row.keyboard_nonce);
+        if (!keyboard) {
+          await markNudged(pool, key);
+          continue;
+        }
+
+        try {
+          await bot.telegram.sendMessage(chatIdNumber, 'Что дальше? Выберите действие ниже.', {
+            reply_markup: keyboard,
+          });
+        } catch (error) {
+          logger.debug({ err: error, chatId: chatIdNumber }, 'Failed to send inactivity nudge');
+        } finally {
+          try {
+            await markNudged(pool, key);
+          } catch (markError) {
+            logger.debug({ err: markError, scope: key.scope, scopeId: key.scopeId }, 'Failed to mark nudge sent');
+          }
+        }
+      }
+    } catch (error) {
+      logger.error({ err: error }, 'Inactivity nudger tick failed');
+    }
+  });
+};
+
+export const stopInactivityNudger = (): void => {
+  if (!task) {
+    return;
+  }
+
+  task.stop();
+  task = null;
+};

--- a/src/metrics/latency.ts
+++ b/src/metrics/latency.ts
@@ -1,0 +1,11 @@
+import { logger } from '../config';
+
+export const withLatencyLog = async <T>(name: string, handler: () => Promise<T>): Promise<T> => {
+  const startedAt = Date.now();
+  try {
+    return await handler();
+  } finally {
+    const duration = Date.now() - startedAt;
+    logger.info({ metric: 'latency_ms', name, value: duration }, 'Latency sample');
+  }
+};


### PR DESCRIPTION
## Summary
- extend the schema with flow tracking, idempotency, and recent location tables to support contextual nudges and undo-safe actions.
- track UI steps in the session, add an inactivity nudger job, and gate rapid user input with an anti-flood middleware.
- remember recent pickup/dropoff locations, surface quick-select buttons, personalize the executor menu, and wrap order actions with idempotency checks while logging callback latency.

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d48e82bd60832d901440ff9453581b