### PR TITLE
Implement inline menu metrics and status UX

### DIFF
--- a/db/sql/003_ab_metrics.sql
+++ b/db/sql/003_ab_metrics.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- 1) UI events for CTR and A/B experiments
+CREATE TABLE IF NOT EXISTS ui_events (
+  id          BIGSERIAL PRIMARY KEY,
+  user_id     BIGINT NOT NULL,
+  experiment  TEXT,
+  variant     TEXT,
+  event       TEXT NOT NULL CHECK (event IN ('expose','click')),
+  target      TEXT NOT NULL,
+  context     JSONB DEFAULT '{}'::jsonb,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ui_events_user_time_idx ON ui_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS ui_events_target_time_idx ON ui_events(target, created_at DESC);
+
+-- 2) Purge expired idempotency keys
+CREATE OR REPLACE FUNCTION purge_recent_actions() RETURNS VOID AS $$
+BEGIN
+  DELETE FROM recent_actions WHERE expires_at < now();
+END; $$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/db/sql/004_ui_ctr_views.sql
+++ b/db/sql/004_ui_ctr_views.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW ui_ctr_daily AS
+SELECT
+  date_trunc('day', created_at) AS day,
+  target,
+  count(*) FILTER (WHERE event = 'expose') AS exposures,
+  count(*) FILTER (WHERE event = 'click')  AS clicks,
+  CASE WHEN count(*) FILTER (WHERE event = 'expose') > 0
+       THEN round(100.0 * count(*) FILTER (WHERE event = 'click') / count(*) FILTER (WHERE event = 'expose'), 2)
+       ELSE NULL END AS ctr
+FROM ui_events
+GROUP BY 1,2
+ORDER BY 1 DESC, 2;
+
+CREATE OR REPLACE VIEW ui_ctr_overall AS
+SELECT
+  target,
+  count(*) FILTER (WHERE event = 'expose') AS exposures,
+  count(*) FILTER (WHERE event = 'click')  AS clicks,
+  CASE WHEN count(*) FILTER (WHERE event = 'expose') > 0
+       THEN round(100.0 * count(*) FILTER (WHERE event = 'click') / count(*) FILTER (WHERE event = 'expose'), 2)
+       ELSE NULL END AS ctr
+FROM ui_events
+GROUP BY 1
+ORDER BY ctr DESC NULLS LAST, exposures DESC;
+
+CREATE OR REPLACE VIEW ui_ctr_by_variant AS
+SELECT
+  COALESCE(experiment, '-') AS experiment,
+  COALESCE(variant, '-')    AS variant,
+  target,
+  count(*) FILTER (WHERE event = 'expose') AS exposures,
+  count(*) FILTER (WHERE event = 'click')  AS clicks,
+  CASE WHEN count(*) FILTER (WHERE event = 'expose') > 0
+       THEN round(100.0 * count(*) FILTER (WHERE event = 'click') / count(*) FILTER (WHERE event = 'expose'), 2)
+       ELSE NULL END AS ctr
+FROM ui_events
+GROUP BY 1,2,3
+ORDER BY 1,2, ctr DESC NULLS LAST, exposures DESC;
+
+COMMIT;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check": "tsc --noEmit",
     "test": "node --require ts-node/register --test --test-concurrency=1 $(find tests -name '*.test.ts')",
     "migrate": "ts-node db/migrate.ts",
-    "backup": "bash db/backup.sh"
+    "backup": "bash db/backup.sh",
+    "ctr:report": "node dist/scripts/ctrReport.js"
   },
   "dependencies": {
     "dotenv": "^16.4.0",

--- a/src/bot/copy.ts
+++ b/src/bot/copy.ts
@@ -1,0 +1,33 @@
+export const copy = {
+  nudge: 'Что дальше? Выберите действие ниже.',
+  expiredButton: 'Кнопка устарела — отправляю актуальное меню…',
+  tooFrequent: 'Слишком часто. Попробуйте через секунду.',
+  waiting: 'Принял. Обрабатываю…',
+  back: '⬅ Назад',
+  refresh: '🔄 Обновить',
+  resume: '🔄 Продолжить',
+  home: '🏠 Главное меню',
+  invalidPhone: (example = '+7 777 123-45-67') => `Уточните телефон в формате E.164 (пример: ${example}).`,
+  statusLine: (emoji: string, text: string) => `${emoji} ${text}`,
+  clientMiniStatus: (cityLabel?: string, trialDaysLeft?: number) =>
+    [
+      cityLabel ? `🏙️ Город: ${cityLabel}` : null,
+      (trialDaysLeft ?? 0) > 0 ? `🧪 Пробный: осталось ${trialDaysLeft} дн.` : null,
+    ].filter(Boolean).join('\n'),
+  executorMiniStatus: (
+    cityLabel: string | undefined,
+    docs: { uploaded: number; required: number },
+    trialDaysLeft?: number,
+  ) =>
+    [
+      cityLabel ? `🏙️ Город: ${cityLabel}` : null,
+      (trialDaysLeft ?? 0) > 0 ? `🧪 Пробный: осталось ${trialDaysLeft} дн.` : null,
+      `🛡️ Документы: ${docs.uploaded}/${docs.required}`,
+    ].filter(Boolean).join('\n'),
+  orderChannelCard: (kind: 'taxi' | 'delivery', price: string, city: string) =>
+    `Новый заказ • ${kind === 'taxi' ? '🚕 Такси' : '📦 Доставка'}\n${city} • ${price}`,
+  orderAcceptedToast: 'Заказ закреплён за вами.',
+  orderAlreadyTakenToast: 'Увы, заказ уже принят другим исполнителем.',
+  orderReleasedToast: 'Вы сняты с заказа.',
+  noAccess: 'Недостаточно прав для действия.',
+};

--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -15,7 +15,7 @@ import type { BotContext } from '../../types';
 import type { OrderStatus, OrderWithExecutor } from '../../../types';
 import { ui } from '../../ui';
 import { CLIENT_MENU, isClientChat, sendClientMenu } from '../../../ui/clientMenu';
-import { CLIENT_MENU_ACTION } from './menu';
+import { CLIENT_MENU_ACTION, logClientMenuClick } from './menu';
 import {
   CLIENT_CANCEL_ORDER_ACTION_PATTERN,
   CLIENT_CANCEL_ORDER_ACTION_PREFIX,
@@ -342,6 +342,8 @@ export const registerClientOrdersFlow = (bot: Telegraf<BotContext>): void => {
     if (!(await ensurePrivateCallback(ctx))) {
       return;
     }
+
+    await logClientMenuClick(ctx, 'client_home_menu:orders');
 
     await renderOrdersList(ctx);
   });

--- a/src/bot/middlewares/antiFlood.ts
+++ b/src/bot/middlewares/antiFlood.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareFn } from 'telegraf';
 
 import type { BotContext } from '../types';
+import { copy } from '../copy';
 
 const WINDOW_MS = 3000;
 const MAX_EVENTS = 6;
@@ -23,7 +24,7 @@ export const antiFlood = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   if (recent.length > MAX_EVENTS) {
     if (typeof ctx.answerCbQuery === 'function') {
       try {
-        await ctx.answerCbQuery('Слишком часто. Попробуйте через секунду.');
+        await ctx.answerCbQuery(copy.tooFrequent);
       } catch {
         // ignore answer errors
       }

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -56,6 +56,7 @@ const createUiState = (): UiSessionState => ({
   steps: {},
   homeActions: [],
   pendingCityAction: undefined,
+  clientMenuVariant: undefined,
 });
 
 const createSupportState = (): SupportSessionState => ({

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -147,6 +147,7 @@ export interface UiSessionState {
   steps: Record<string, UiTrackedStepState | undefined>;
   homeActions: string[];
   pendingCityAction?: 'clientMenu' | 'executorMenu';
+  clientMenuVariant?: 'A' | 'B';
 }
 
 export type SupportRequestStatus = 'idle' | 'awaiting_message';

--- a/src/bot/ui/status.ts
+++ b/src/bot/ui/status.ts
@@ -1,0 +1,19 @@
+import { Markup } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+
+import { copy } from '../copy';
+
+export function buildStatusMessage(
+  emoji: string,
+  line: string,
+  refreshAction: string,
+  backAction: string,
+): { text: string; reply_markup: InlineKeyboardMarkup } {
+  const text = copy.statusLine(emoji, line);
+  const reply_markup = Markup.inlineKeyboard([
+    [Markup.button.callback(copy.refresh, refreshAction)],
+    [Markup.button.callback(copy.back, backAction)],
+  ]).reply_markup as InlineKeyboardMarkup;
+
+  return { text, reply_markup };
+}

--- a/src/experiments/ab.ts
+++ b/src/experiments/ab.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+
+import { pool } from '../db';
+
+export type Variant = 'A' | 'B';
+
+const decideVariant = (userId: number, experiment: string): Variant => {
+  const hash = crypto.createHash('sha1').update(`${userId}:${experiment}`).digest();
+  return hash[0] % 2 === 0 ? 'A' : 'B';
+};
+
+export async function getVariant(userId: number, experiment: string): Promise<Variant> {
+  const existing = await pool.query<{ variant: Variant }>(
+    'SELECT variant FROM user_experiments WHERE user_id = $1 AND experiment = $2',
+    [userId, experiment],
+  );
+
+  if (existing.rowCount && existing.rows[0]?.variant) {
+    return existing.rows[0].variant;
+  }
+
+  const variant = decideVariant(userId, experiment);
+  await pool.query(
+    'INSERT INTO user_experiments(user_id, experiment, variant) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
+    [userId, experiment, variant],
+  );
+
+  return variant;
+}
+
+export async function logUiEvent(
+  userId: number,
+  event: 'expose' | 'click',
+  target: string,
+  experiment?: string,
+  variant?: Variant,
+  context: unknown = {},
+): Promise<void> {
+  await pool.query(
+    'INSERT INTO ui_events(user_id, experiment, variant, event, target, context) VALUES ($1, $2, $3, $4, $5, $6::jsonb)',
+    [userId, experiment ?? null, variant ?? null, event, target, JSON.stringify(context ?? {})],
+  );
+}

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -3,6 +3,7 @@ import type { Telegraf } from 'telegraf';
 import type { BotContext } from '../bot/types';
 import { startSubscriptionScheduler, stopSubscriptionScheduler } from './scheduler';
 import { startInactivityNudger, stopInactivityNudger } from './nudger';
+import { startMetricsReporter, stopMetricsReporter } from './metricsReporter';
 
 let initialized = false;
 
@@ -13,6 +14,7 @@ export const registerJobs = (bot: Telegraf<BotContext>): void => {
 
   startSubscriptionScheduler(bot);
   startInactivityNudger(bot);
+  startMetricsReporter();
   initialized = true;
 };
 
@@ -23,5 +25,6 @@ export const stopJobs = (): void => {
 
   stopInactivityNudger();
   stopSubscriptionScheduler();
+  stopMetricsReporter();
   initialized = false;
 };

--- a/src/jobs/metricsReporter.ts
+++ b/src/jobs/metricsReporter.ts
@@ -1,0 +1,30 @@
+import cron, { type ScheduledTask } from 'node-cron';
+
+import { logger } from '../config';
+import { snapshot } from '../metrics/agg';
+
+let task: ScheduledTask | null = null;
+
+export const startMetricsReporter = (): void => {
+  if (task) {
+    return;
+  }
+
+  task = cron.schedule('*/60 * * * * *', () => {
+    try {
+      const current = snapshot();
+      logger.info({ metric: 'agg', snapshot: current }, 'metrics_snapshot');
+    } catch (error) {
+      logger.error({ err: error }, 'metrics_reporter_failed');
+    }
+  });
+};
+
+export const stopMetricsReporter = (): void => {
+  if (!task) {
+    return;
+  }
+
+  task.stop();
+  task = null;
+};

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -10,6 +10,7 @@ import { wrapCallbackData } from '../bot/services/callbackTokens';
 import { config, logger } from '../config';
 import { pool } from '../db';
 import { markNudged, type SessionKey } from '../db/sessions';
+import { copy } from '../bot/copy';
 
 interface PendingSessionRow {
   scope: string;
@@ -64,7 +65,7 @@ const buildNudgeKeyboard = (
   if (payload.homeAction) {
     rows.push([
       {
-        label: '🔄 Продолжить',
+        label: copy.resume,
         action: bindAction(payload.homeAction, userId, keyboardNonce),
       },
     ]);
@@ -80,7 +81,7 @@ const buildNudgeKeyboard = (
   if (fallbackAction) {
     rows.push([
       {
-        label: '🏠 Главное меню',
+        label: copy.home,
         action: bindAction(fallbackAction, userId, keyboardNonce),
       },
     ]);
@@ -150,7 +151,7 @@ export const startInactivityNudger = (bot: Telegraf<BotContext>): void => {
         }
 
         try {
-          await bot.telegram.sendMessage(chatIdNumber, 'Что дальше? Выберите действие ниже.', {
+          await bot.telegram.sendMessage(chatIdNumber, copy.nudge, {
             reply_markup: keyboard,
           });
         } catch (error) {

--- a/src/metrics/agg.ts
+++ b/src/metrics/agg.ts
@@ -1,0 +1,60 @@
+const latencySamples = new Map<string, number[]>();
+const flowCounters = new Map<string, { started: number; completed: number }>();
+
+export function sampleLatency(name: string, ms: number): void {
+  const bucket = latencySamples.get(name) ?? [];
+  bucket.push(ms);
+  if (bucket.length > 1000) {
+    bucket.shift();
+  }
+  latencySamples.set(name, bucket);
+}
+
+export function p95(name: string): number | null {
+  const bucket = latencySamples.get(name);
+  if (!bucket || bucket.length < 5) {
+    return null;
+  }
+
+  const sorted = [...bucket].sort((a, b) => a - b);
+  const index = Math.floor(0.95 * (sorted.length - 1));
+  return sorted[index];
+}
+
+export function flowStart(flow: string): void {
+  const entry = flowCounters.get(flow) ?? { started: 0, completed: 0 };
+  entry.started += 1;
+  flowCounters.set(flow, entry);
+}
+
+export function flowComplete(flow: string, ok = true): void {
+  const entry = flowCounters.get(flow) ?? { started: 0, completed: 0 };
+  if (ok) {
+    entry.completed += 1;
+  }
+  flowCounters.set(flow, entry);
+}
+
+export function snapshot(): {
+  latP95: Record<string, number>;
+  flows: Record<string, { started: number; completed: number; completionRate: number }>;
+} {
+  const latP95: Record<string, number> = {};
+  for (const key of latencySamples.keys()) {
+    const value = p95(key);
+    if (value !== null) {
+      latP95[key] = value;
+    }
+  }
+
+  const flows: Record<string, { started: number; completed: number; completionRate: number }> = {};
+  for (const [key, value] of flowCounters.entries()) {
+    flows[key] = {
+      started: value.started,
+      completed: value.completed,
+      completionRate: value.started === 0 ? 0 : Math.round((value.completed / value.started) * 100),
+    };
+  }
+
+  return { latP95, flows };
+}

--- a/src/scripts/ctrReport.ts
+++ b/src/scripts/ctrReport.ts
@@ -1,0 +1,47 @@
+import { pool } from '../db';
+
+const printTable = (rows: Record<string, unknown>[], columns: string[]) => {
+  if (rows.length === 0) {
+    console.log('(нет данных)');
+    return;
+  }
+
+  const widths = columns.map((column) =>
+    Math.max(column.length, ...rows.map((row) => String(row[column] ?? '').length)),
+  );
+
+  const printLine = (values: string[]) => {
+    console.log(values.map((value, index) => value.padEnd(widths[index])).join('  '));
+  };
+
+  printLine(columns);
+  printLine(widths.map((width) => '-'.repeat(width)));
+  for (const row of rows) {
+    printLine(columns.map((column) => String(row[column] ?? '')));
+  }
+};
+
+async function main(): Promise<void> {
+  const overall = await pool.query('SELECT * FROM ui_ctr_overall ORDER BY ctr DESC NULLS LAST LIMIT 50');
+  console.log('\n=== CTR (overall) ===');
+  printTable(overall.rows, ['target', 'exposures', 'clicks', 'ctr']);
+
+  const byVariant = await pool.query(
+    "SELECT experiment, variant, target, exposures, clicks, ctr FROM ui_ctr_by_variant WHERE experiment <> '-' ORDER BY experiment, variant, ctr DESC NULLS LAST LIMIT 100",
+  );
+  console.log('\n=== CTR by variant ===');
+  printTable(byVariant.rows, ['experiment', 'variant', 'target', 'exposures', 'clicks', 'ctr']);
+
+  const daily = await pool.query(
+    "SELECT day::date AS day, target, exposures, clicks, ctr FROM ui_ctr_daily WHERE day >= now() - interval '14 days' ORDER BY day DESC, target LIMIT 200",
+  );
+  console.log('\n=== CTR (last 14 days, daily) ===');
+  printTable(daily.rows, ['day', 'target', 'exposures', 'clicks', 'ctr']);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,0 +1,46 @@
+export type E164Result = { ok: true; e164: string } | { ok: false; reason: string };
+
+export function normalizeE164(raw: string, defaultCountry: 'KZ' | 'RU' = 'KZ'): E164Result {
+  if (!raw) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  const plusMatches = trimmed.match(/\+/g) ?? [];
+  if (plusMatches.length > 1) {
+    return { ok: false, reason: 'unsupported_format' };
+  }
+
+  if (plusMatches.length === 1 && !trimmed.startsWith('+')) {
+    return { ok: false, reason: 'unsupported_format' };
+  }
+
+  const digits = trimmed.replace(/[^0-9+]/g, '');
+  if (!digits) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  if (digits.startsWith('+')) {
+    const normalized = digits.replace(/\D/g, '');
+    if (normalized.length < 10 || normalized.length > 15) {
+      return { ok: false, reason: 'bad_length' };
+    }
+    return { ok: true, e164: `+${normalized}` };
+  }
+
+  if (/^[78]\d{10}$/.test(digits)) {
+    return { ok: true, e164: `+7${digits.slice(1)}` };
+  }
+
+  if (/^\d{10}$/.test(digits)) {
+    if (defaultCountry === 'KZ' || defaultCountry === 'RU') {
+      return { ok: true, e164: `+7${digits}` };
+    }
+  }
+
+  return { ok: false, reason: 'unsupported_format' };
+}

--- a/tests/client-menu.test.ts
+++ b/tests/client-menu.test.ts
@@ -37,7 +37,7 @@ before(async () => {
 
 const ROLE_CLIENT_ACTION = 'role:client';
 
-const expectedMenuText = 'Добро пожаловать! Чем можем помочь?';
+const expectedMenuText = '🏙️ Город: Алматы\n\nДобро пожаловать! Чем можем помочь?';
 const DEFAULT_CITY: AppCity = 'almaty';
 
 const createSessionState = (): SessionState => ({

--- a/tests/delivery-order-flow.test.ts
+++ b/tests/delivery-order-flow.test.ts
@@ -11,7 +11,7 @@ describe('deliveryOrderFlow phone normalisation', () => {
   });
 
   it('accepts domestic format without plus sign', () => {
-    assert.equal(normaliseRecipientPhone('87001234567'), '87001234567');
+    assert.equal(normaliseRecipientPhone('87001234567'), '+77001234567');
   });
 
   it('rejects numbers with insufficient digits', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,10 @@
     "src/jobs/**/*.ts",
     "src/types/**/*.ts",
     "src/utils/**/*.ts",
-    "src/lib/**/*.ts"
+    "src/lib/**/*.ts",
+    "src/experiments/**/*.ts",
+    "src/metrics/**/*.ts",
+    "src/scripts/**/*.ts",
+    "src/ui/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add A/B experiment logging, UI event storage, and in-memory metrics reporting with cron job emission
- centralize copy strings, normalize phone numbers to E.164, and introduce shared status blocks for delivery and taxi flows
- redesign client menu to show personalized status with variant ordering, log interactions, and add CTR reporting script and SQL views
- sign inline keyboards per user, reuse text in anti-flood, nudger, and channel toasts, and expose CTR report command

## Testing
- pnpm build
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d49c1704e4832d88febecb93889a6c