### PR TITLE
Resolve merge conflict markers in bot flows

### DIFF
--- a/src/bot/copy.ts
+++ b/src/bot/copy.ts
@@ -7,11 +7,8 @@ export const copy = {
   refresh: '🔄 Обновить',
   resume: '🔄 Продолжить',
   home: '🏠 Главное меню',
-<<<<<<< HEAD
-=======
   errorRecovered: 'Произошёл сбой, но я вернул вас к последнему шагу.',
   errorGeneric: 'Произошёл сбой. Попробуйте повторить действие чуть позже.',
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
   invalidPhone: (example = '+7 777 123-45-67') => `Уточните телефон в формате E.164 (пример: ${example}).`,
   statusLine: (emoji: string, text: string) => `${emoji} ${text}`,
   clientMiniStatus: (cityLabel?: string, trialDaysLeft?: number) =>

--- a/src/bot/flows/client/deliveryOrderFlow.ts
+++ b/src/bot/flows/client/deliveryOrderFlow.ts
@@ -51,10 +51,7 @@ import { copy } from '../../copy';
 import { normalizeE164 } from '../../../utils/phone';
 import { buildStatusMessage } from '../../ui/status';
 import { flowStart, flowComplete } from '../../../metrics/agg';
-<<<<<<< HEAD
-=======
 import { registerFlowRecovery } from '../recovery';
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
 
 export const START_DELIVERY_ORDER_ACTION = 'client:order:delivery:start';
 const CONFIRM_DELIVERY_ORDER_ACTION = 'client:order:delivery:confirm';
@@ -684,10 +681,7 @@ const notifyOrderCreated = async (
       ? 'Заказ создан. Оператор свяжется вручную.'
       : 'Заказ отправлен исполнителям. Ожидаем отклика.';
   const statusEmoji = publishStatus === 'missing_channel' ? '⚠️' : '⏳';
-<<<<<<< HEAD
-=======
   const statusPayload = { emoji: statusEmoji, label: statusLabel };
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
   const { text: statusText, reply_markup } = buildStatusMessage(
     statusEmoji,
     statusLabel,
@@ -700,11 +694,8 @@ const notifyOrderCreated = async (
     text: statusText,
     keyboard: reply_markup,
     cleanup: true,
-<<<<<<< HEAD
-=======
     homeAction: CLIENT_MENU_ACTION,
     recovery: { type: 'client:delivery:status', payload: statusPayload },
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
   });
 
   const lines = [

--- a/src/bot/flows/client/taxiOrderFlow.ts
+++ b/src/bot/flows/client/taxiOrderFlow.ts
@@ -47,10 +47,7 @@ import {
 import { copy } from '../../copy';
 import { buildStatusMessage } from '../../ui/status';
 import { flowStart, flowComplete } from '../../../metrics/agg';
-<<<<<<< HEAD
-=======
 import { registerFlowRecovery } from '../recovery';
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
 
 export const START_TAXI_ORDER_ACTION = 'client:order:taxi:start';
 const CONFIRM_TAXI_ORDER_ACTION = 'client:order:taxi:confirm';
@@ -339,10 +336,7 @@ const notifyOrderCreated = async (
       ? 'Заказ создан. Оператор свяжется вручную.'
       : 'Заказ отправлен водителям. Ожидаем отклика.';
   const statusEmoji = publishStatus === 'missing_channel' ? '⚠️' : '⏳';
-<<<<<<< HEAD
-=======
   const statusPayload = { emoji: statusEmoji, label: statusLabel };
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
   const { text: statusText, reply_markup } = buildStatusMessage(
     statusEmoji,
     statusLabel,
@@ -355,11 +349,8 @@ const notifyOrderCreated = async (
     text: statusText,
     keyboard: reply_markup,
     cleanup: true,
-<<<<<<< HEAD
-=======
     homeAction: CLIENT_MENU_ACTION,
     recovery: { type: 'client:taxi:status', payload: statusPayload },
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
   });
 
   const lines = [

--- a/src/bot/ui.ts
+++ b/src/bot/ui.ts
@@ -15,14 +15,11 @@ import { bindInlineKeyboardToUser } from './services/callbackTokens';
 import { copy } from './copy';
 
 const HOME_BUTTON_LABEL = copy.home;
-<<<<<<< HEAD
-=======
 
 export interface FlowRecoveryDescriptor {
   type: string;
   payload?: unknown;
 }
->>>>>>> 27d236d (Add recovery flow handlers and sign inline keyboards)
 
 const ensureUiState = (ctx: BotContext): UiSessionState => {
   if (!ctx.session.ui) {


### PR DESCRIPTION
## Summary
- restore the recovery-related copy strings that were left inside merge markers
- import the flow recovery utilities and persist status payloads in the client delivery and taxi flows
- expose the `FlowRecoveryDescriptor` definition in the shared UI helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b66f6058832dbcfb3cf7aeff988f