### PR TITLE
Harden database interactions and auth fallback

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -23,6 +23,18 @@ are missing or blank.
 - `DATABASE_SSL` – Enables TLS for the PostgreSQL connection when set to `true`,
   `1` or `yes`. The connection negotiates SSL with certificate validation. Leave
   the variable unset (or explicitly set it to `false`) to connect without TLS.
+- `DATABASE_POOL_MAX` – Maximum number of concurrent client connections in the
+  PostgreSQL pool. Defaults to `10` when not specified.
+- `DATABASE_POOL_IDLE_TIMEOUT_MS` – Time (in milliseconds) after which idle
+  connections are closed. The default is `30000` (30 seconds).
+- `DATABASE_POOL_CONNECTION_TIMEOUT_MS` – Maximum time (in milliseconds) the
+  driver waits for an available connection before failing. Defaults to `5000`.
+- `DATABASE_STATEMENT_TIMEOUT_MS` – Upper bound (in milliseconds) enforced for
+  individual SQL statements. Defaults to `15000` to ensure the bot responds
+  before Telegram retries the update delivery.
+- `DATABASE_QUERY_TIMEOUT_MS` – Safety timeout (in milliseconds) applied by the
+  driver to each query. Defaults to `20000` and should be equal to or greater
+  than the statement timeout.
 
 ## Subscription settings
 

--- a/src/bot/copy.ts
+++ b/src/bot/copy.ts
@@ -42,4 +42,5 @@ export const copy = {
   orderAlreadyTakenToast: 'Увы, заказ уже принят другим исполнителем.',
   orderReleasedToast: 'Вы сняты с заказа.',
   noAccess: 'Недостаточно прав для действия.',
+  serviceUnavailable: 'Сервис временно недоступен. Попробуйте позже.',
 };

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolClient } from 'pg';
 import type { PoolConfig } from 'pg';
 
-import { config } from '../config';
+import { config, logger } from '../config';
 
 const createSslOptions = (): PoolConfig['ssl'] => {
   if (!config.database.ssl) {
@@ -14,6 +14,15 @@ const createSslOptions = (): PoolConfig['ssl'] => {
 const pool = new Pool({
   connectionString: config.database.url,
   ssl: createSslOptions(),
+  max: config.database.pool.max,
+  idleTimeoutMillis: config.database.pool.idleTimeoutMs,
+  connectionTimeoutMillis: config.database.pool.connectionTimeoutMs,
+  statement_timeout: config.database.pool.statementTimeoutMs,
+  query_timeout: config.database.pool.queryTimeoutMs,
+});
+
+pool.on('error', (error) => {
+  logger.error({ err: error }, 'Unexpected error from the database pool');
 });
 
 export { pool };           // Named export (import { pool } from ...)


### PR DESCRIPTION
## Summary
- add configurable pool, connection and statement timeouts to the PostgreSQL client and surface unexpected pool errors in logs
- document the new database timeout environment variables and expose them through the runtime config
- provide a user-facing fallback when authentication fails so callback queries are acknowledged promptly

## Testing
- npm run check
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4cb63bc10832d85f75e38f1d43192