### PR TITLE
Prevent session timeouts and streamline executor menu

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -1,5 +1,5 @@
 import { Markup, Telegraf } from 'telegraf';
-import type { InlineKeyboardMarkup, ReplyKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import {
   EXECUTOR_ROLES,
@@ -24,7 +24,6 @@ export const EXECUTOR_ORDERS_ACTION = 'executor:orders:link';
 export const EXECUTOR_SUPPORT_ACTION = 'support:contact';
 export const EXECUTOR_MENU_ACTION = 'executor:menu:refresh';
 const EXECUTOR_MENU_STEP_ID = 'executor:menu:main';
-const EXECUTOR_MENU_REPLY_STEP_ID = 'executor:menu:actions';
 const EXECUTOR_MENU_CITY_ACTION = 'executorMenu';
 
 export const EXECUTOR_MENU_TEXT_LABELS = {
@@ -217,16 +216,6 @@ const buildMenuKeyboard = (
     [Markup.button.callback('🔄 Обновить меню', EXECUTOR_MENU_ACTION)],
   ]).reply_markup;
 };
-
-const buildMenuReplyKeyboard = (): ReplyKeyboardMarkup =>
-  Markup.keyboard([
-    [EXECUTOR_MENU_TEXT_LABELS.documents, EXECUTOR_MENU_TEXT_LABELS.subscription],
-    [EXECUTOR_MENU_TEXT_LABELS.orders],
-    [EXECUTOR_MENU_TEXT_LABELS.support],
-    [EXECUTOR_MENU_TEXT_LABELS.refresh],
-  ])
-    .resize()
-    .persistent().reply_markup;
 
 const formatTimestamp = (timestamp: number): string => {
   return new Intl.DateTimeFormat('ru-RU', {
@@ -512,15 +501,6 @@ export const showExecutorMenu = async (
 
   const text = buildMenuText(state, access, CITY_LABEL[city], ctx.auth.user);
   const keyboard = buildMenuKeyboard(state, access);
-
-  if (ctx.chat.type === 'private') {
-    await ui.step(ctx, {
-      id: EXECUTOR_MENU_REPLY_STEP_ID,
-      text: 'Быстрые действия доступны через клавиатуру ниже.',
-      keyboard: buildMenuReplyKeyboard(),
-      cleanup: false,
-    });
-  }
 
   await ui.step(ctx, {
     id: EXECUTOR_MENU_STEP_ID,

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -169,9 +169,7 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   let nextError: unknown;
 
   try {
-    await client.query('BEGIN');
-
-    const existing = await loadSessionState(client, key, { forUpdate: true });
+    const existing = await loadSessionState(client, key);
     const state = existing ?? createDefaultState();
 
     if (!('city' in state)) {
@@ -199,16 +197,6 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     } else {
       await saveSessionState(client, key, ctx.session);
     }
-
-    await client.query('COMMIT');
-  } catch (error) {
-    try {
-      await client.query('ROLLBACK');
-    } catch (rollbackError) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to rollback session transaction', rollbackError);
-    }
-    throw error;
   } finally {
     setSessionMeta(ctx, undefined);
     client.release();

--- a/tests/executor-access.test.ts
+++ b/tests/executor-access.test.ts
@@ -137,16 +137,6 @@ const mapKeyboard = (
   );
 };
 
-const mapReplyKeyboard = (keyboard: ReplyKeyboardMarkup | undefined): string[][] => {
-  if (!keyboard || !('keyboard' in keyboard)) {
-    return [];
-  }
-
-  return keyboard.keyboard.map((row) =>
-    row.map((button) => (typeof button === 'string' ? button : button.text)),
-  );
-};
-
 let originalStep: typeof uiHelper.step;
 let recordedSteps: UiStepOptions[];
 
@@ -238,24 +228,6 @@ describe('executor access control', () => {
           callback_data: EXECUTOR_MENU_ACTION,
         },
       ],
-    ]);
-  });
-
-  it('shows the quick action reply keyboard when rendering the executor menu', async () => {
-    const { ctx } = createContext();
-    ensureExecutorState(ctx);
-
-    await showExecutorMenu(ctx, { skipAccessCheck: true });
-
-    const actionsStep = recordedSteps.find((step) => step.id === 'executor:menu:actions');
-    assert.ok(actionsStep, 'quick action step should be displayed');
-
-    const layout = mapReplyKeyboard(actionsStep.keyboard as ReplyKeyboardMarkup | undefined);
-    assert.deepEqual(layout, [
-      [EXECUTOR_MENU_TEXT_LABELS.documents, EXECUTOR_MENU_TEXT_LABELS.subscription],
-      [EXECUTOR_MENU_TEXT_LABELS.orders],
-      [EXECUTOR_MENU_TEXT_LABELS.support],
-      [EXECUTOR_MENU_TEXT_LABELS.refresh],
     ]);
   });
 


### PR DESCRIPTION
## Summary
- stop wrapping Telegram update handling in a long-running transaction so session rows are not locked for the entire interaction
- keep executor actions on the inline keyboard only to remove the persistent reply keyboard message and reduce chat spam
- adjust executor access tests to reflect the inline keyboard-only menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d13484c8832d8c6feaed4f657cbe