### PR TITLE
Fix executor role switch to prompt for city selection

### DIFF
--- a/src/bot/flows/common/citySelect.ts
+++ b/src/bot/flows/common/citySelect.ts
@@ -46,7 +46,19 @@ export const askCity = async (
 
   const keyboard = buildCityKeyboard();
   const replyMarkup = bindInlineKeyboardToUser(ctx, keyboard) ?? keyboard;
-  await ctx.reply(title, { reply_markup: replyMarkup });
+  try {
+    await ctx.reply(title, { reply_markup: replyMarkup });
+  } catch (error) {
+    if (!ctx.chat?.id) {
+      throw error;
+    }
+
+    try {
+      await ctx.telegram.sendMessage(ctx.chat.id, title, { reply_markup: replyMarkup });
+    } catch {
+      throw error;
+    }
+  }
 };
 
 export const ensureCitySelected = async (

--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -24,7 +24,7 @@ export const EXECUTOR_ORDERS_ACTION = 'executor:orders:link';
 export const EXECUTOR_SUPPORT_ACTION = 'support:contact';
 export const EXECUTOR_MENU_ACTION = 'executor:menu:refresh';
 const EXECUTOR_MENU_STEP_ID = 'executor:menu:main';
-const EXECUTOR_MENU_CITY_ACTION = 'executorMenu';
+export const EXECUTOR_MENU_CITY_ACTION = 'executorMenu';
 
 export const EXECUTOR_MENU_TEXT_LABELS = {
   documents: '📸 Документы',

--- a/src/bot/flows/executor/roleSelect.ts
+++ b/src/bot/flows/executor/roleSelect.ts
@@ -6,7 +6,8 @@ import { updateUserRole } from '../../../db/users';
 import { EXECUTOR_COMMANDS } from '../../commands/sets';
 import { setChatCommands } from '../../services/commands';
 import type { BotContext, ExecutorRole } from '../../types';
-import { ensureExecutorState, showExecutorMenu } from './menu';
+import { askCity } from '../common/citySelect';
+import { ensureExecutorState, EXECUTOR_MENU_CITY_ACTION } from './menu';
 import { getExecutorRoleCopy } from './roleCopy';
 
 const ROLE_COURIER_ACTION = 'role:courier';
@@ -64,8 +65,9 @@ const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise
 
   await setChatCommands(ctx.telegram, ctx.chat.id, EXECUTOR_COMMANDS, { showMenuButton: true });
 
-  await hideClientMenu(ctx, 'Переключаемся в режим исполнителя…');
-  await showExecutorMenu(ctx);
+  await hideClientMenu(ctx, 'Переключаемся…');
+  ctx.session.ui.pendingCityAction = EXECUTOR_MENU_CITY_ACTION;
+  await askCity(ctx, 'Сначала выбери город для работы');
 };
 
 export const registerExecutorRoleSelect = (bot: Telegraf<BotContext>): void => {

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -211,16 +211,17 @@ describe('executor role selection', () => {
     }
 
     const menuStep = recordedSteps.find((step) => step.id === 'executor:menu:main');
-    assert.ok(menuStep, 'executor menu step should be displayed');
+    assert.equal(menuStep, undefined, 'executor menu should wait until city is selected');
+    assert.equal(ctx.session.ui.pendingCityAction, 'executorMenu');
     assert.equal(ctx.auth.user.role, 'driver');
     assert.ok(sendMessageCalls.length >= 1);
-    const fallbackCall = sendMessageCalls.at(-1);
-    assert.ok(fallbackCall, 'fallback sendMessage should be recorded');
-    assert.equal(fallbackCall.chatId, ctx.chat!.id);
-    const fallbackMarkup = (fallbackCall.extra as {
+    const promptCall = sendMessageCalls.at(-1);
+    assert.ok(promptCall, 'city selection prompt should be sent');
+    assert.equal(promptCall.chatId, ctx.chat!.id);
+    const promptMarkup = (promptCall.extra as {
       reply_markup?: InlineKeyboardMarkup | ReplyKeyboardMarkup;
     }).reply_markup;
-    assert.ok(fallbackMarkup);
-    assert.match(fallbackCall.text, /Меню водителя/);
+    assert.ok(promptMarkup, 'city selection keyboard should be attached');
+    assert.match(promptCall.text, /Сначала выбери город/);
   });
 });


### PR DESCRIPTION
## Summary
- require executors to pick a city after switching roles and mark the menu as pending until the selection is made
- harden the shared city prompt to fall back to a direct send when reply-based delivery fails
- export the executor menu city action token and update the executor role selection test expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4e1afcb74832da13678e68333037a