### PR TITLE
refactor: run migrations during bootstrap

### DIFF
--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -1,87 +1,22 @@
-import fs from 'fs/promises';
-import path from 'path';
-import type { PoolClient } from 'pg';
-
 import { pool } from '../src/db/client';
+import { runPendingMigrations, type MigrationLogger } from '../src/db/migrations';
 
-const MIGRATIONS_DIR = path.resolve(__dirname, 'sql');
-const MIGRATIONS_TABLE = 'schema_migrations';
-
-const readMigrationFiles = async (): Promise<string[]> => {
-  const entries = await fs.readdir(MIGRATIONS_DIR, { withFileTypes: true });
-  return entries
-    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.sql'))
-    .map((entry) => entry.name)
-    .sort();
-};
-
-const ensureMigrationsTable = async (client: PoolClient) => {
-  await client.query(`
-    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
-      id bigserial PRIMARY KEY,
-      name text UNIQUE NOT NULL,
-      executed_at timestamptz NOT NULL DEFAULT now()
-    )
-  `);
-};
-
-const applyMigration = async (
-  client: PoolClient,
-  fileName: string,
-  sql: string,
-): Promise<void> => {
-  const trimmed = sql.trim();
-  if (!trimmed) {
-    console.log(`Skipping empty migration ${fileName}`);
-    return;
+const cliLogger: MigrationLogger = ({ name, action }) => {
+  if (action === 'skip') {
+    console.log(`Skipping already applied migration ${name}`);
+  } else {
+    console.log(`Applying migration ${name}...`);
   }
-
-  console.log(`Applying migration ${fileName}...`);
-  await client.query(trimmed);
-  await client.query(
-    `
-      INSERT INTO ${MIGRATIONS_TABLE} (name)
-      VALUES ($1)
-      ON CONFLICT (name) DO UPDATE SET executed_at = now()
-    `,
-    [fileName],
-  );
 };
 
-const hasMigrationRun = async (client: PoolClient, fileName: string): Promise<boolean> => {
-  const { rows } = await client.query<{ exists: boolean }>(
-    `SELECT EXISTS (SELECT 1 FROM ${MIGRATIONS_TABLE} WHERE name = $1) AS exists`,
-    [fileName],
-  );
-  return rows[0]?.exists ?? false;
-};
-
-const runMigrations = async (): Promise<void> => {
-  const files = await readMigrationFiles();
-
-  const client = await pool.connect();
+const main = async (): Promise<void> => {
   try {
-    await ensureMigrationsTable(client);
-
-    for (const file of files) {
-      if (await hasMigrationRun(client, file)) {
-        console.log(`Skipping already applied migration ${file}`);
-        continue;
-      }
-
-      const fullPath = path.join(MIGRATIONS_DIR, file);
-      const sql = await fs.readFile(fullPath, 'utf-8');
-      await applyMigration(client, file, sql);
+    const applied = await runPendingMigrations(cliLogger);
+    if (applied === 0) {
+      console.log('No pending migrations.');
+    } else {
+      console.log(`Applied ${applied} migration${applied === 1 ? '' : 's'}.`);
     }
-  } finally {
-    client.release();
-  }
-};
-
-const main = async () => {
-  try {
-    await runMigrations();
-    console.log('Migrations complete.');
   } finally {
     await pool.end();
   }

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,0 +1,111 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { PoolClient } from 'pg';
+
+import { logger } from '../config';
+import { pool } from './client';
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../db/sql');
+const SNAPSHOT_FILE = 'all_migrations.sql';
+const MIGRATIONS_TABLE = 'schema_migrations';
+
+export type MigrationAction = 'apply' | 'skip';
+
+export interface MigrationEvent {
+  name: string;
+  action: MigrationAction;
+}
+
+export type MigrationLogger = (event: MigrationEvent) => void;
+
+const defaultLogger: MigrationLogger = ({ name, action }) => {
+  if (action === 'skip') {
+    logger.debug({ migration: name }, 'Skipping already applied migration');
+  } else {
+    logger.info({ migration: name }, 'Applying migration');
+  }
+};
+
+export const listMigrationFiles = async (): Promise<string[]> => {
+  const entries = await readdir(MIGRATIONS_DIR, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.sql') && entry.name !== SNAPSHOT_FILE)
+    .map((entry) => entry.name)
+    .sort();
+};
+
+const ensureMigrationsTable = async (client: PoolClient): Promise<void> => {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      id bigserial PRIMARY KEY,
+      name text UNIQUE NOT NULL,
+      executed_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+};
+
+const hasMigrationRun = async (client: PoolClient, fileName: string): Promise<boolean> => {
+  const { rows } = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM ${MIGRATIONS_TABLE} WHERE name = $1) AS exists`,
+    [fileName],
+  );
+
+  return rows[0]?.exists ?? false;
+};
+
+const markMigrationExecuted = async (client: PoolClient, fileName: string): Promise<void> => {
+  await client.query(
+    `
+      INSERT INTO ${MIGRATIONS_TABLE} (name)
+      VALUES ($1)
+      ON CONFLICT (name) DO UPDATE SET executed_at = now()
+    `,
+    [fileName],
+  );
+};
+
+export const applyPendingMigrations = async (
+  client: PoolClient,
+  log: MigrationLogger = defaultLogger,
+): Promise<number> => {
+  const files = await listMigrationFiles();
+  if (files.length === 0) {
+    return 0;
+  }
+
+  await ensureMigrationsTable(client);
+
+  let applied = 0;
+
+  for (const file of files) {
+    if (await hasMigrationRun(client, file)) {
+      log({ name: file, action: 'skip' });
+      continue;
+    }
+
+    const sql = await readFile(path.join(MIGRATIONS_DIR, file), 'utf-8');
+    const trimmed = sql.trim();
+
+    if (!trimmed) {
+      log({ name: file, action: 'skip' });
+      await markMigrationExecuted(client, file);
+      continue;
+    }
+
+    log({ name: file, action: 'apply' });
+    await client.query(trimmed);
+    await markMigrationExecuted(client, file);
+    applied += 1;
+  }
+
+  return applied;
+};
+
+export const runPendingMigrations = async (log: MigrationLogger = defaultLogger): Promise<number> => {
+  const client = await pool.connect();
+  try {
+    return await applyPendingMigrations(client, log);
+  } finally {
+    client.release();
+  }
+};


### PR DESCRIPTION
## Summary
- add a reusable migration runner that executes the incremental SQL files and records their status
- wire bootstrap and the CLI migrator to the shared runner so the app always applies pending migrations
- update bootstrap tests to cover the new incremental migration workflow

## Testing
- npm run check
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4e8687470832dacccfc441861d976