### PR TITLE
Fix TypeScript build for Prometheus metrics

### DIFF
--- a/src/types/prom-client.d.ts
+++ b/src/types/prom-client.d.ts
@@ -27,6 +27,26 @@ declare module 'prom-client' {
     reset(): void;
   }
 
+  export interface GaugeConfiguration<TLabel extends string = string> {
+    name: string;
+    help: string;
+    labelNames?: readonly TLabel[];
+    registers?: Registry[];
+  }
+
+  export class Gauge<TLabel extends string = string> {
+    constructor(configuration: GaugeConfiguration<TLabel>);
+    inc(labels?: Record<TLabel, string>, value?: number): void;
+    dec(labels?: Record<TLabel, string>, value?: number): void;
+    set(labels: Record<TLabel, string>, value: number): void;
+    set(value: number): void;
+    setToCurrentTime(labels?: Record<TLabel, string>): void;
+    startTimer(labels?: Record<TLabel, string>): () => number;
+    labels(...values: string[]): Gauge<TLabel>;
+    labels(labels: Record<TLabel, string>): Gauge<TLabel>;
+    reset(): void;
+  }
+
   export class Histogram<TLabel extends string = string> {
     constructor(configuration: HistogramConfiguration<TLabel>);
     startTimer(labels?: Record<TLabel, string>): () => void;


### PR DESCRIPTION
## Summary
- extend the local prom-client module declaration to include Gauge typings so the business metrics module can import Gauge without errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6337814e4832d90edb3342f060ddf