### PR TITLE
Fix proxy trust and add channels table migration

### DIFF
--- a/db/migrations/0003_add_channels_table.down.sql
+++ b/db/migrations/0003_add_channels_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS channels;
+
+COMMIT;

--- a/db/migrations/0003_add_channels_table.up.sql
+++ b/db/migrations/0003_add_channels_table.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS channels (
+  id          SERIAL PRIMARY KEY,
+  tg_id       BIGINT      UNIQUE,
+  title       TEXT,
+  username    TEXT,
+  is_enabled  BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_channels_tg_id ON channels (tg_id);
+
+COMMIT;

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ const asyncHandler = (
 
 const startServer = async (webhookPath: string, port: number): Promise<Server> => {
   const serverApp = express();
+  serverApp.set('trust proxy', 1);
 
   const sentryHandlers = initSentry({
     dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
## Summary
- configure the Express server to trust the first upstream proxy so rate limiting can read client IPs
- add a migration that creates the missing channels table and supporting index

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d63e53a448832d8d34fd7291074ea4