### PR TITLE
Throttle moderation missing channel warnings and cache bindings

### DIFF
--- a/tests/helpers/setup-env.ts
+++ b/tests/helpers/setup-env.ts
@@ -8,6 +8,10 @@ const REQUIRED_ENV_DEFAULTS: Record<string, string> = {
   WEBHOOK_SECRET: 'test-secret',
 };
 
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'test';
+}
+
 for (const [key, value] of Object.entries(REQUIRED_ENV_DEFAULTS)) {
   if (!process.env[key]) {
     process.env[key] = value;


### PR DESCRIPTION
## Summary
- add a short-lived cache for channel bindings so repeated moderation lookups avoid hitting the database
- throttle repeated "missing moderation channel" warnings and reset the timer once a publish succeeds
- update test helpers and bootstrap stubs to reflect the new caching behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d64daf669c832d8fa21072cbd2db14