### PR TITLE
Adjust log level when bot already stopped during shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -134,7 +134,7 @@ export const setupGracefulShutdown = (bot: Telegraf<BotContext>): void => {
             bot.stop(`Received ${signal}`);
           } catch (error) {
             if (isBotAlreadyStoppedError(error)) {
-              logger.warn({ err: error }, 'Bot already stopped before cleanup, continuing shutdown');
+              logger.info({ err: error }, 'Bot already stopped before cleanup, continuing shutdown');
             } else {
               throw error;
             }


### PR DESCRIPTION
## Summary
- downgrade the log level when Telegraf is already stopped so that expected shutdowns are not reported as warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6537be954832db2edb668e3e3b3f3