### PR TITLE
Add channel binding columns to channels table

### DIFF
--- a/db/migrations/0004_add_channel_binding_columns.down.sql
+++ b/db/migrations/0004_add_channel_binding_columns.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE channels
+  DROP COLUMN IF EXISTS drivers_channel_id,
+  DROP COLUMN IF EXISTS verify_channel_id,
+  DROP COLUMN IF EXISTS stats_channel_id;
+
+COMMIT;

--- a/db/migrations/0004_add_channel_binding_columns.up.sql
+++ b/db/migrations/0004_add_channel_binding_columns.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE channels
+  ADD COLUMN IF NOT EXISTS drivers_channel_id BIGINT,
+  ADD COLUMN IF NOT EXISTS verify_channel_id BIGINT,
+  ADD COLUMN IF NOT EXISTS stats_channel_id BIGINT;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a database migration that introduces drivers, verify, and stats channel columns on the `channels` table so binding commands can persist

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d644c5b648832dbcb8abb641ee2d07