### PR TITLE
Fix /role command gating for executors

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -294,7 +294,7 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
   });
 
   bot.command('role', async (ctx) => {
-    if (!isClientChat(ctx, ctx.auth?.user.role)) {
+    if (ctx.chat?.type !== 'private') {
       await ctx.reply('Смена роли доступна только в личном чате с ботом.');
       return;
     }

--- a/tests/client-menu.test.ts
+++ b/tests/client-menu.test.ts
@@ -374,4 +374,23 @@ describe('client menu role selection', () => {
     assert.equal((firstMarkup.reply_markup as any).remove_keyboard, true);
     assert.match(replyCalls[1].text, /Выберите роль/);
   });
+
+  it('allows executors to open role selection with the /role command in private chat', async () => {
+    const { bot, getCommand } = createMockBot();
+    registerClientMenu(bot);
+
+    const handler = getCommand('role');
+    assert.ok(handler, '/role command should be registered');
+
+    const { ctx, replyCalls } = createMockContext({ role: 'courier' });
+
+    await handler(ctx);
+
+    assert.equal(replyCalls.length, 2);
+    assert.equal(replyCalls[0].text, 'Меняем роль — выберите подходящий вариант ниже.');
+    const firstMarkup = replyCalls[0].extra as { reply_markup?: ReplyKeyboardMarkup };
+    assert.ok(firstMarkup?.reply_markup);
+    assert.equal((firstMarkup.reply_markup as any).remove_keyboard, true);
+    assert.match(replyCalls[1].text, /Выберите роль/);
+  });
 });


### PR DESCRIPTION
## Summary
- allow the /role command to work in private chats even when the user is currently an executor
- add a regression test covering executor access to the role selection flow

## Testing
- node --require ts-node/register --test tests/client-menu.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d654dd214c832daba13026db19b8d8