### PR TITLE
Update recent locations schema

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -19,9 +19,18 @@ solely for local development resets.
 | ---- | ------- |
 | `0001_initial.up.sql` | Bootstraps the complete production schema, including tables, enums, sequences and indexes. |
 | `0002_add_flow_state_index.up.sql` | Keeps a concurrent creation path for the `sessions_scope_state_idx` index when upgrading an existing database. New installations already receive the index from migration 0001. |
+| `0006_update_recent_locations_schema.up.sql` | Expands `user_recent_locations` to track multiple entries per user/city/kind combination and aligns the types with the application service. |
 
 If your database is empty, running the migrations once is sufficient — both
 files will be executed and the second one becomes a no-op after the index
 exists. On production data the second migration remains safe because it uses
 `IF NOT EXISTS` together with `CREATE INDEX CONCURRENTLY` to avoid locking the
 `sessions` table during the upgrade.
+
+## Notes on migration 0006
+
+Migration `0006_update_recent_locations_schema.up.sql` removes all rows from
+`user_recent_locations` before restructuring the table. The previous schema
+stored only a single location per user, so the data cannot be migrated into the
+new multi-location format in a meaningful way. The next user interaction will
+recreate the entries with the richer structure.

--- a/db/migrations/0006_update_recent_locations_schema.down.sql
+++ b/db/migrations/0006_update_recent_locations_schema.down.sql
@@ -1,0 +1,19 @@
+-- Roll back the recent locations schema revamp.
+
+DROP INDEX IF EXISTS idx_user_recent_locations_last_used_at;
+DROP INDEX IF EXISTS idx_user_recent_locations_user_city_kind;
+
+ALTER TABLE user_recent_locations
+  DROP CONSTRAINT IF EXISTS user_recent_locations_pkey,
+  ALTER COLUMN lat TYPE NUMERIC(9,6) USING lat::NUMERIC(9,6),
+  ALTER COLUMN lon TYPE NUMERIC(9,6) USING lon::NUMERIC(9,6),
+  DROP COLUMN IF EXISTS city,
+  DROP COLUMN IF EXISTS kind,
+  DROP COLUMN IF EXISTS location_id,
+  DROP COLUMN IF EXISTS query,
+  DROP COLUMN IF EXISTS address,
+  DROP COLUMN IF EXISTS two_gis_url,
+  DROP COLUMN IF EXISTS last_used_at;
+
+ALTER TABLE user_recent_locations
+  ADD PRIMARY KEY (user_id);

--- a/db/migrations/0006_update_recent_locations_schema.up.sql
+++ b/db/migrations/0006_update_recent_locations_schema.up.sql
@@ -1,0 +1,36 @@
+-- Revamp the recent locations storage to keep multiple entries per user and
+-- align the schema with src/bot/services/recentLocations.ts expectations.
+
+-- The old structure only kept the last location per user. The new schema tracks
+-- multiple locations per city/kind pair, therefore we wipe the historical data
+-- to avoid populating the new NOT NULL columns with bogus values.
+DELETE FROM user_recent_locations;
+
+ALTER TABLE user_recent_locations
+  DROP CONSTRAINT IF EXISTS user_recent_locations_pkey,
+  ALTER COLUMN lat TYPE DOUBLE PRECISION USING lat::DOUBLE PRECISION,
+  ALTER COLUMN lon TYPE DOUBLE PRECISION USING lon::DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS city TEXT,
+  ADD COLUMN IF NOT EXISTS kind TEXT,
+  ADD COLUMN IF NOT EXISTS location_id TEXT,
+  ADD COLUMN IF NOT EXISTS query TEXT,
+  ADD COLUMN IF NOT EXISTS address TEXT,
+  ADD COLUMN IF NOT EXISTS two_gis_url TEXT,
+  ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Enforce data integrity once the new columns exist.
+ALTER TABLE user_recent_locations
+  ALTER COLUMN city SET NOT NULL,
+  ALTER COLUMN kind SET NOT NULL,
+  ALTER COLUMN location_id SET NOT NULL,
+  ALTER COLUMN query SET NOT NULL,
+  ALTER COLUMN address SET NOT NULL;
+
+ALTER TABLE user_recent_locations
+  ADD PRIMARY KEY (user_id, city, kind, location_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_recent_locations_user_city_kind
+  ON user_recent_locations (user_id, city, kind);
+
+CREATE INDEX IF NOT EXISTS idx_user_recent_locations_last_used_at
+  ON user_recent_locations (user_id, city, kind, last_used_at DESC);


### PR DESCRIPTION
## Summary
- add a migration that revamps user_recent_locations with the additional columns, composite primary key and supporting indexes
- document the schema change and note the required data purge for legacy rows

## Testing
- not run (requires PostgreSQL instance)

------
https://chatgpt.com/codex/tasks/task_e_68d67e284e24832d81409584c905a7d1