### PR TITLE
Add executor payment reminder job

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -137,6 +137,21 @@ const normaliseVerificationState = (
   return verification;
 };
 
+const normaliseReminderTimestamp = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
 const normaliseSubscriptionState = (
   value: Partial<ExecutorSubscriptionState> | undefined,
 ): ExecutorSubscriptionState => ({
@@ -147,6 +162,7 @@ const normaliseSubscriptionState = (
   moderationMessageId: value?.moderationMessageId,
   lastInviteLink: value?.lastInviteLink,
   lastIssuedAt: value?.lastIssuedAt,
+  lastReminderAt: normaliseReminderTimestamp(value?.lastReminderAt),
 });
 
 export const ensureExecutorState = (ctx: BotContext): ExecutorFlowState => {

--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -411,6 +411,11 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   await next();
 };
 
+export const loadAuthStateByTelegramId = async (telegramId: number): Promise<AuthState> => {
+  const from = { id: telegramId } as NonNullable<BotContext['from']>;
+  return loadAuthState(from);
+};
+
 export const __testing__ = {
   loadAuthState,
   mapAuthRow,

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -97,6 +97,7 @@ export interface ExecutorSubscriptionState {
   moderationMessageId?: number;
   lastInviteLink?: string;
   lastIssuedAt?: number;
+  lastReminderAt?: number;
 }
 
 export type ExecutorVerificationState = Record<ExecutorRole, ExecutorVerificationRoleState>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -283,6 +283,7 @@ export interface AppConfig {
     nudger: string;
     subscription: string;
     metrics: string;
+    paymentReminder: string;
   };
   tariff: TariffRates | null;
   subscriptions: {
@@ -342,6 +343,7 @@ export const loadConfig = (): AppConfig => ({
     nudger: getCronExpression('JOBS_NUDGER_CRON', '*/1 * * * *'),
     subscription: getCronExpression('JOBS_SUBSCRIPTION_CRON', '*/10 * * * *'),
     metrics: getCronExpression('JOBS_METRICS_CRON', '*/60 * * * * *'),
+    paymentReminder: getCronExpression('JOBS_PAYMENT_REMINDER_CRON', '*/10 * * * *'),
   },
   tariff: parseGeneralTariff(),
   subscriptions: {

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -4,6 +4,7 @@ import type { BotContext } from '../bot/types';
 import { startSubscriptionScheduler, stopSubscriptionScheduler } from './scheduler';
 import { startInactivityNudger, stopInactivityNudger } from './nudger';
 import { startMetricsReporter, stopMetricsReporter } from './metricsReporter';
+import { startPaymentReminderJob, stopPaymentReminderJob } from './paymentReminder';
 
 let initialized = false;
 
@@ -15,6 +16,7 @@ export const registerJobs = (bot: Telegraf<BotContext>): void => {
   startSubscriptionScheduler(bot);
   startInactivityNudger(bot);
   startMetricsReporter();
+  startPaymentReminderJob(bot);
   initialized = true;
 };
 
@@ -26,5 +28,6 @@ export const stopJobs = (): void => {
   stopInactivityNudger();
   stopSubscriptionScheduler();
   stopMetricsReporter();
+  stopPaymentReminderJob();
   initialized = false;
 };

--- a/src/jobs/paymentReminder.ts
+++ b/src/jobs/paymentReminder.ts
@@ -1,0 +1,384 @@
+import cron, { type ScheduledTask } from 'node-cron';
+import type { Telegraf } from 'telegraf';
+
+import { ui } from '../bot/ui';
+import { ensureExecutorState, showExecutorMenu } from '../bot/flows/executor/menu';
+import { loadAuthStateByTelegramId } from '../bot/middlewares/auth';
+import type { BotContext, SessionState } from '../bot/types';
+import { config, logger } from '../config';
+import type { PoolClient } from '../db/client';
+import { pool } from '../db/client';
+import { loadSessionState, saveSessionState, type SessionKey } from '../db/sessions';
+
+type ReminderReason = 'awaitingReceipt' | 'trialEnding';
+
+interface ReminderDescriptor {
+  reasons: Set<ReminderReason>;
+  trialEndsAt?: Date;
+}
+
+interface ReminderCandidate extends ReminderDescriptor {
+  key: SessionKey;
+  session: SessionState;
+}
+
+const REMINDER_INTERVAL_MS = 2 * 60 * 60 * 1000;
+const TRIAL_WINDOW_MS = 2 * 60 * 60 * 1000;
+const REMINDER_STEP_ID = 'executor:subscription:reminder';
+
+const parseScopeId = (value: string | number | null | undefined): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value).toString();
+  }
+
+  return null;
+};
+
+const parseTimestamp = (value: Date | string | null | undefined): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+const parseReminderTimestamp = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  return undefined;
+};
+
+const gatherReminderDescriptors = async (
+  client: PoolClient,
+  now: Date,
+): Promise<Map<string, ReminderDescriptor>> => {
+  const descriptors = new Map<string, ReminderDescriptor>();
+
+  const awaiting = await client.query<{ scope_id: string | number | null }>(
+    `
+      SELECT scope_id
+      FROM sessions
+      WHERE scope = 'chat'
+        AND state->'executor'->'subscription'->>'status' = 'awaitingReceipt'
+    `,
+  );
+
+  for (const row of awaiting.rows) {
+    const scopeId = parseScopeId(row.scope_id);
+    if (!scopeId) {
+      continue;
+    }
+
+    const descriptor = descriptors.get(scopeId) ?? { reasons: new Set<ReminderReason>() };
+    descriptor.reasons.add('awaitingReceipt');
+    descriptors.set(scopeId, descriptor);
+  }
+
+  const trialDeadline = new Date(now.getTime() + TRIAL_WINDOW_MS);
+  const trialRows = await client.query<{
+    scope_id: string | number | null;
+    trial_ends_at: Date | string | null;
+  }>(
+    `
+      SELECT s.scope_id, u.trial_ends_at
+      FROM sessions s
+      JOIN users u ON u.tg_id = s.scope_id
+      WHERE s.scope = 'chat'
+        AND u.role = ANY($3::text[])
+        AND u.trial_ends_at IS NOT NULL
+        AND u.trial_ends_at > $1
+        AND u.trial_ends_at <= $2
+    `,
+    [now, trialDeadline, ['courier', 'driver']],
+  );
+
+  for (const row of trialRows.rows) {
+    const scopeId = parseScopeId(row.scope_id);
+    if (!scopeId) {
+      continue;
+    }
+
+    const trialEndsAt = parseTimestamp(row.trial_ends_at);
+    if (!trialEndsAt) {
+      continue;
+    }
+
+    const descriptor = descriptors.get(scopeId) ?? { reasons: new Set<ReminderReason>() };
+    descriptor.reasons.add('trialEnding');
+    descriptor.trialEndsAt = trialEndsAt;
+    descriptors.set(scopeId, descriptor);
+  }
+
+  return descriptors;
+};
+
+const loadReminderCandidates = async (
+  client: PoolClient,
+  descriptors: Map<string, ReminderDescriptor>,
+): Promise<ReminderCandidate[]> => {
+  const candidates: ReminderCandidate[] = [];
+
+  for (const [scopeId, descriptor] of descriptors.entries()) {
+    const key: SessionKey = { scope: 'chat', scopeId };
+    try {
+      const session = await loadSessionState(client, key);
+      if (!session) {
+        continue;
+      }
+
+      if (!session.executor || !session.executor.subscription) {
+        continue;
+      }
+
+      candidates.push({
+        key,
+        session,
+        reasons: new Set(descriptor.reasons),
+        trialEndsAt: descriptor.trialEndsAt,
+      });
+    } catch (error) {
+      logger.error({ err: error, scopeId }, 'Failed to load session for payment reminder');
+    }
+  }
+
+  return candidates;
+};
+
+const determineEffectiveReasons = (
+  candidate: ReminderCandidate,
+  now: Date,
+): Set<ReminderReason> => {
+  const reasons = new Set<ReminderReason>();
+  const subscription = candidate.session.executor?.subscription;
+  if (!subscription) {
+    return reasons;
+  }
+
+  if (
+    candidate.reasons.has('awaitingReceipt') &&
+    subscription.status === 'awaitingReceipt'
+  ) {
+    reasons.add('awaitingReceipt');
+  }
+
+  if (candidate.reasons.has('trialEnding')) {
+    const trialEndsAt = candidate.trialEndsAt;
+    if (trialEndsAt && trialEndsAt.getTime() > now.getTime()) {
+      reasons.add('trialEnding');
+    }
+  }
+
+  return reasons;
+};
+
+const formatDateTime = (date: Date): string =>
+  new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+
+const buildReminderMessage = (
+  reasons: Set<ReminderReason>,
+  trialEndsAt?: Date,
+): string => {
+  const lines: string[] = [];
+
+  if (reasons.has('awaitingReceipt')) {
+    lines.push(
+      '💸 Мы всё ещё ожидаем чек об оплате.',
+      'Отправьте чек в этот чат, чтобы мы подтвердили оплату и выдали ссылку на канал.',
+    );
+  }
+
+  if (reasons.has('trialEnding') && trialEndsAt) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(
+      '🕑 Пробный период скоро закончится.',
+      `Доступ будет отключён ${formatDateTime(trialEndsAt)}. Оформите подписку заранее, чтобы не потерять доступ.`,
+    );
+  }
+
+  if (lines.length === 0) {
+    return '';
+  }
+
+  lines.push(
+    '',
+    'Мы обновили меню ниже — используйте кнопку «📨 Получить ссылку на канал», чтобы завершить оплату.',
+  );
+
+  return lines.join('\n');
+};
+
+const sendReminder = async (
+  bot: Telegraf<BotContext>,
+  candidate: ReminderCandidate,
+  reasons: Set<ReminderReason>,
+  now: Date,
+): Promise<void> => {
+  const chatId = Number.parseInt(candidate.key.scopeId, 10);
+  if (!Number.isFinite(chatId)) {
+    logger.warn({ scopeId: candidate.key.scopeId }, 'Skipping reminder, invalid chat identifier');
+    return;
+  }
+
+  let auth;
+  try {
+    auth = await loadAuthStateByTelegramId(chatId);
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'Failed to load auth state for payment reminder');
+    return;
+  }
+
+  const session = candidate.session;
+  session.ui = session.ui ?? {
+    steps: {},
+    homeActions: [],
+    pendingCityAction: undefined,
+    clientMenuVariant: undefined,
+  };
+
+  const ctx = {
+    chat: { id: chatId, type: 'private' as const },
+    from: { id: chatId } as NonNullable<BotContext['from']>,
+    session,
+    auth,
+    telegram: bot.telegram,
+    reply: (text: string, extra?: Parameters<typeof bot.telegram.sendMessage>[2]) =>
+      bot.telegram.sendMessage(chatId, text, extra),
+    answerCbQuery: async () => undefined,
+  } as unknown as BotContext;
+
+  ensureExecutorState(ctx);
+
+  const message = buildReminderMessage(reasons, candidate.trialEndsAt);
+  if (message) {
+    await ui.step(ctx, {
+      id: REMINDER_STEP_ID,
+      text: message,
+      cleanup: false,
+    });
+  }
+
+  await showExecutorMenu(ctx, { skipAccessCheck: true });
+
+  const subscription = ctx.session.executor.subscription;
+  subscription.lastReminderAt = now.getTime();
+
+  await saveSessionState(pool, candidate.key, ctx.session);
+  logger.info(
+    { chatId, reasons: Array.from(reasons), trialEndsAt: candidate.trialEndsAt?.toISOString() },
+    'Sent executor payment reminder',
+  );
+};
+
+const executeReminderCycle = async (
+  bot: Telegraf<BotContext>,
+  now = new Date(),
+): Promise<void> => {
+  const client = await pool.connect();
+  let candidates: ReminderCandidate[] = [];
+  try {
+    const descriptors = await gatherReminderDescriptors(client, now);
+    candidates = await loadReminderCandidates(client, descriptors);
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to prepare payment reminder candidates');
+  } finally {
+    client.release();
+  }
+
+  for (const candidate of candidates) {
+    const reasons = determineEffectiveReasons(candidate, now);
+    if (reasons.size === 0) {
+      continue;
+    }
+
+    const subscription = candidate.session.executor?.subscription;
+    if (!subscription) {
+      continue;
+    }
+
+    const lastReminderAt = parseReminderTimestamp(subscription.lastReminderAt);
+    if (
+      lastReminderAt !== undefined &&
+      now.getTime() - lastReminderAt < REMINDER_INTERVAL_MS
+    ) {
+      continue;
+    }
+
+    try {
+      await sendReminder(bot, candidate, reasons, now);
+    } catch (error) {
+      logger.error(
+        { err: error, chatId: candidate.key.scopeId },
+        'Failed to send payment reminder',
+      );
+    }
+  }
+};
+
+let task: ScheduledTask | null = null;
+let running = false;
+
+const runSafely = (bot: Telegraf<BotContext>): void => {
+  if (running) {
+    logger.warn('Payment reminder task is already running, skipping this tick');
+    return;
+  }
+
+  running = true;
+  void executeReminderCycle(bot)
+    .catch((error) => {
+      logger.error({ err: error }, 'Unhandled payment reminder error');
+    })
+    .finally(() => {
+      running = false;
+    });
+};
+
+export const startPaymentReminderJob = (bot: Telegraf<BotContext>): void => {
+  if (task) {
+    return;
+  }
+
+  task = cron.schedule(config.jobs.paymentReminder, () => runSafely(bot));
+};
+
+export const stopPaymentReminderJob = (): void => {
+  if (!task) {
+    return;
+  }
+
+  task.stop();
+  task = null;
+  running = false;
+};
+
+export const __testing__ = {
+  executeReminderCycle,
+  REMINDER_INTERVAL_MS,
+};

--- a/tests/payment-reminder.job.test.ts
+++ b/tests/payment-reminder.job.test.ts
@@ -1,0 +1,221 @@
+import './helpers/setup-env';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import type { Telegraf } from 'telegraf';
+
+import type { AuthState, BotContext, SessionState } from '../src/bot/types';
+import { ui, type UiStepOptions } from '../src/bot/ui';
+import * as executorMenu from '../src/bot/flows/executor/menu';
+import { __testing__ as paymentReminderTesting } from '../src/jobs/paymentReminder';
+import { pool } from '../src/db/client';
+import type { PoolClient } from '../src/db/client';
+import * as sessionsDb from '../src/db/sessions';
+import * as authMiddleware from '../src/bot/middlewares/auth';
+
+const { executeReminderCycle, REMINDER_INTERVAL_MS } = paymentReminderTesting;
+
+type QueryResult = { rows: any[] };
+
+type QueryHandler = (sql: string, params?: unknown[]) => Promise<QueryResult>;
+
+const DEFAULT_CITY = 'almaty' as const;
+
+const createAuthState = (telegramId: number): AuthState => ({
+  user: {
+    telegramId,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    phoneVerified: false,
+    role: 'courier',
+    status: 'active_executor',
+    isVerified: false,
+    isBlocked: false,
+    citySelected: DEFAULT_CITY,
+    trialEndsAt: undefined,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: false,
+});
+
+const createSessionState = (): SessionState => ({
+  ephemeralMessages: [],
+  isAuthenticated: true,
+  awaitingPhone: false,
+  city: DEFAULT_CITY,
+  executor: {
+    role: 'courier',
+    verification: {
+      courier: { status: 'idle', requiredPhotos: 2, uploadedPhotos: [] },
+      driver: { status: 'idle', requiredPhotos: 2, uploadedPhotos: [] },
+    },
+    subscription: {
+      status: 'idle',
+    },
+  },
+  client: {
+    taxi: { stage: 'idle' },
+    delivery: { stage: 'idle' },
+  },
+  ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
+  support: { status: 'idle' },
+});
+
+const createBot = () => {
+  const telegram = {
+    sendMessage: mock.fn(async () => ({ message_id: 1, date: 0, chat: { id: 1001 } })),
+    editMessageText: mock.fn(async () => true),
+    deleteMessage: mock.fn(async () => true),
+    copyMessage: mock.fn(async () => true),
+  };
+
+  return { telegram } as unknown as Telegraf<BotContext>;
+};
+
+describe('payment reminder job', () => {
+  let originalConnect: typeof pool.connect;
+  let loadSessionStateMock: ReturnType<typeof mock.method>;
+  let saveSessionStateMock: ReturnType<typeof mock.method>;
+  let loadAuthStateMock: ReturnType<typeof mock.method>;
+  let recordedSteps: UiStepOptions[];
+  let originalStep: typeof ui.step;
+  let showExecutorMenuMock: ReturnType<typeof mock.method>;
+
+  beforeEach(() => {
+    originalConnect = pool.connect;
+    loadSessionStateMock = mock.method(sessionsDb, 'loadSessionState', async () => createSessionState());
+    saveSessionStateMock = mock.method(sessionsDb, 'saveSessionState', async () => undefined);
+    loadAuthStateMock = mock.method(authMiddleware, 'loadAuthStateByTelegramId', async (telegramId: number) =>
+      createAuthState(telegramId),
+    );
+
+    recordedSteps = [];
+    originalStep = ui.step;
+    (ui as { step: typeof ui.step }).step = mock.fn(async (_ctx, options) => {
+      recordedSteps.push(options);
+      return { messageId: recordedSteps.length, sent: true };
+    });
+
+    showExecutorMenuMock = mock.method(executorMenu, 'showExecutorMenu', async () => undefined);
+  });
+
+  afterEach(() => {
+    pool.connect = originalConnect;
+    loadSessionStateMock.mock.restore();
+    saveSessionStateMock.mock.restore();
+    loadAuthStateMock.mock.restore();
+    (ui as { step: typeof ui.step }).step = originalStep;
+    showExecutorMenuMock.mock.restore();
+  });
+
+  const stubQueries = (handler: QueryHandler): void => {
+    pool.connect = async (): Promise<PoolClient> => ({
+      query: handler,
+      release: () => {},
+    } as unknown as PoolClient);
+  };
+
+  it('sends a reminder when awaitingReceipt is stale', async () => {
+    const now = new Date('2024-01-01T10:00:00Z');
+    const session = createSessionState();
+    session.executor.subscription.status = 'awaitingReceipt';
+    session.executor.subscription.lastReminderAt = now.getTime() - 3 * 60 * 60 * 1000;
+
+    loadSessionStateMock.mock.mockImplementation(async () => session);
+
+    const query: QueryHandler = async (sql) => {
+      if (sql.includes("state->'executor'->'subscription'->>'status' = 'awaitingReceipt'")) {
+        return { rows: [{ scope_id: '1001' }] };
+      }
+      if (sql.includes('trial_ends_at')) {
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    };
+
+    stubQueries(query);
+
+    const bot = createBot();
+
+    await executeReminderCycle(bot, now);
+
+    assert.equal(recordedSteps.length, 1);
+    assert.match(recordedSteps[0]!.text, /ожидаем чек/i);
+    assert.equal(showExecutorMenuMock.mock.callCount(), 1);
+    assert.equal(saveSessionStateMock.mock.callCount(), 1);
+    assert.equal(session.executor.subscription.lastReminderAt, now.getTime());
+  });
+
+  it('skips reminders if the previous one was sent less than 2 hours ago', async () => {
+    const now = new Date('2024-01-01T12:00:00Z');
+    const session = createSessionState();
+    session.executor.subscription.status = 'awaitingReceipt';
+    session.executor.subscription.lastReminderAt =
+      now.getTime() - (REMINDER_INTERVAL_MS - 15 * 60 * 1000);
+
+    loadSessionStateMock.mock.mockImplementation(async () => session);
+
+    const query: QueryHandler = async (sql) => {
+      if (sql.includes("state->'executor'->'subscription'->>'status' = 'awaitingReceipt'")) {
+        return { rows: [{ scope_id: '1001' }] };
+      }
+      if (sql.includes('trial_ends_at')) {
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    };
+
+    stubQueries(query);
+
+    const bot = createBot();
+
+    await executeReminderCycle(bot, now);
+
+    assert.equal(recordedSteps.length, 0);
+    assert.equal(showExecutorMenuMock.mock.callCount(), 0);
+    assert.equal(saveSessionStateMock.mock.callCount(), 0);
+  });
+
+  it('reminds executors when the trial period ends soon', async () => {
+    const now = new Date('2024-01-02T08:00:00Z');
+    const trialEndsAt = new Date(now.getTime() + 60 * 60 * 1000);
+    const session = createSessionState();
+    session.executor.subscription.status = 'idle';
+    session.executor.subscription.lastReminderAt = now.getTime() - 3 * 60 * 60 * 1000;
+
+    loadSessionStateMock.mock.mockImplementation(async () => session);
+    loadAuthStateMock.mock.mockImplementation(async (telegramId: number) => {
+      const auth = createAuthState(telegramId);
+      auth.user.trialEndsAt = trialEndsAt;
+      return auth;
+    });
+
+    const query: QueryHandler = async (sql) => {
+      if (sql.includes("state->'executor'->'subscription'->>'status' = 'awaitingReceipt'")) {
+        return { rows: [] };
+      }
+      if (sql.includes('trial_ends_at')) {
+        return { rows: [{ scope_id: '1001', trial_ends_at: trialEndsAt.toISOString() }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    };
+
+    stubQueries(query);
+
+    const bot = createBot();
+
+    await executeReminderCycle(bot, now);
+
+    assert.equal(recordedSteps.length, 1);
+    assert.match(recordedSteps[0]!.text, /Пробный период/i);
+    assert.equal(showExecutorMenuMock.mock.callCount(), 1);
+    assert.equal(saveSessionStateMock.mock.callCount(), 1);
+    assert.equal(session.executor.subscription.lastReminderAt, now.getTime());
+  });
+});


### PR DESCRIPTION
## Summary
- add a payment reminder cron job that prompts executors with pending payments or trials expiring soon and records reminder timestamps
- extend configuration, session types, and job registration to support the new reminder worker
- cover the reminder cadence with integration tests and update the jobs lifecycle tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d69ace4148832d89c591fbd5a7cc8c