### PR TITLE
Adjust verification trial CTA to orders

### DIFF
--- a/src/bot/moderation/verifyQueue.ts
+++ b/src/bot/moderation/verifyQueue.ts
@@ -31,7 +31,10 @@ import {
 } from '../../db';
 import { getChannelBinding } from '../channels/bindings';
 import { getExecutorRoleCopy } from '../copy';
-import { EXECUTOR_SUBSCRIPTION_ACTION } from '../flows/executor/menu';
+import {
+  EXECUTOR_ORDERS_ACTION,
+  EXECUTOR_SUBSCRIPTION_ACTION,
+} from '../flows/executor/menu';
 import {
   createTrialSubscription,
   TrialSubscriptionUnavailableError,
@@ -292,6 +295,9 @@ const buildApprovalKeyboard = (): InlineKeyboardMarkup =>
     [Markup.button.callback('📨 Получить ссылку на канал', EXECUTOR_SUBSCRIPTION_ACTION)],
   ]).reply_markup;
 
+const buildTrialApprovalKeyboard = (): InlineKeyboardMarkup =>
+  Markup.inlineKeyboard([[Markup.button.callback('Заказы', EXECUTOR_ORDERS_ACTION)]]).reply_markup;
+
 const buildFallbackApprovalNotification = (
   application: VerificationApplication,
 ): { text: string; keyboard: InlineKeyboardMarkup } => {
@@ -309,7 +315,6 @@ const buildFallbackApprovalNotification = (
 
 const activateVerificationTrial = async (
   application: VerificationApplication,
-  keyboard: InlineKeyboardMarkup,
 ): Promise<{ text: string; keyboard: InlineKeyboardMarkup } | null> => {
   const applicantId = application.applicant.telegramId;
   if (!applicantId) {
@@ -363,7 +368,7 @@ const activateVerificationTrial = async (
     lines.push(`Нажмите кнопку ниже, чтобы получить ссылку на канал ${copy.genitive}.`);
     lines.push('Если потребуется помощь, напишите в поддержку.');
 
-    return { text: lines.join('\n'), keyboard };
+    return { text: lines.join('\n'), keyboard: buildTrialApprovalKeyboard() };
   } catch (error) {
     if (error instanceof TrialSubscriptionUnavailableError) {
       logger.info(
@@ -396,7 +401,7 @@ export const notifyVerificationApproval = async (
 
   const fallback = buildFallbackApprovalNotification(application);
   const notification = application.approvalNotification;
-  const trialNotification = await activateVerificationTrial(application, fallback.keyboard);
+  const trialNotification = await activateVerificationTrial(application);
   const text = notification?.text?.trim() || trialNotification?.text || fallback.text;
   const keyboard = notification?.keyboard ?? trialNotification?.keyboard ?? fallback.keyboard;
 

--- a/tests/moderation/verifyQueue.test.ts
+++ b/tests/moderation/verifyQueue.test.ts
@@ -3,6 +3,7 @@ import '../helpers/setup-env';
 import assert from 'node:assert/strict';
 import { afterEach, describe, it, mock } from 'node:test';
 
+import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 import type { Telegram } from 'telegraf';
 
 import { notifyVerificationApproval, type VerificationApplication } from '../../src/bot/moderation/verifyQueue';
@@ -83,6 +84,13 @@ describe('notifyVerificationApproval', () => {
     assert.ok(extra && typeof extra === 'object');
     if (extra && typeof extra === 'object') {
       assert.ok('reply_markup' in extra);
+      const replyMarkup = extra.reply_markup as InlineKeyboardMarkup;
+      assert.ok(replyMarkup?.inline_keyboard);
+      const [row] = replyMarkup.inline_keyboard ?? [];
+      assert.ok(row);
+      const [button] = row;
+      assert.ok(button);
+      assert.equal(button.text, 'Заказы');
     }
   });
 
@@ -103,10 +111,17 @@ describe('notifyVerificationApproval', () => {
     assert.equal(createTrialMock.mock.callCount(), 1);
     const [messageCall] = sendMessage.mock.calls;
     assert.ok(messageCall);
-    const [, text] = messageCall.arguments;
+    const [, text, extra] = messageCall.arguments;
     assert.equal(typeof text, 'string');
     if (typeof text === 'string') {
       assert.ok(text.includes('оформите подписку'));
     }
+    const replyMarkup = extra?.reply_markup as InlineKeyboardMarkup | undefined;
+    assert.ok(replyMarkup?.inline_keyboard);
+    const [row] = replyMarkup.inline_keyboard ?? [];
+    assert.ok(row);
+    const [button] = row;
+    assert.ok(button);
+    assert.equal(button.text, '📨 Получить ссылку на канал');
   });
 });


### PR DESCRIPTION
## Summary
- switch verification trial approvals to offer the executor orders button when activation succeeds
- keep paid approvals on the existing subscription CTA while updating notification selection logic
- extend moderation queue tests to ensure trial approvals expose the orders button

## Testing
- npm test -- tests/moderation/verifyQueue.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6ad401484832d8f741aac5dbf778b