### PR TITLE
Fix user role enum comparison in payment reminder

### DIFF
--- a/src/jobs/paymentReminder.ts
+++ b/src/jobs/paymentReminder.ts
@@ -106,7 +106,7 @@ const gatherReminderDescriptors = async (
       FROM sessions s
       JOIN users u ON u.tg_id = s.scope_id
       WHERE s.scope = 'chat'
-        AND u.role = ANY($3::text[])
+        AND u.role = ANY($3::user_role[])
         AND u.trial_ends_at IS NOT NULL
         AND u.trial_ends_at > $1
         AND u.trial_ends_at <= $2


### PR DESCRIPTION
## Summary
- ensure payment reminder trial selection casts role comparisons to the user_role enum

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c4501b74832d8d73f70a37ad75cb