### PR TITLE
Allow moderation callbacks through verification gate

### DIFF
--- a/src/bot/middlewares/verificationGate.ts
+++ b/src/bot/middlewares/verificationGate.ts
@@ -50,7 +50,10 @@ export const ensureVerifiedExecutor: MiddlewareFn<BotContext> = async (ctx, next
   const callbackQuery = ctx.callbackQuery;
   if (callbackQuery && 'data' in callbackQuery) {
     const callbackData = callbackQuery.data;
-    if (typeof callbackData === 'string' && CITY_ACTION_PATTERN.test(callbackData)) {
+    if (
+      typeof callbackData === 'string' &&
+      (callbackData.startsWith('mod:') || CITY_ACTION_PATTERN.test(callbackData))
+    ) {
       await next();
       return;
     }


### PR DESCRIPTION
## Summary
- allow moderation callbacks with the "mod:" prefix to bypass the executor verification gate while preserving existing city selector handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6ca28ab18832d8c961053a509e157