### PR TITLE
Fix client menu fallback after role selection

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -198,10 +198,10 @@ const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> => {
 
     try {
       await ctx.editMessageText(header, { reply_markup: keyboard });
+      return;
     } catch (error) {
       logger.debug({ err: error, chatId: ctx.chat?.id }, 'Failed to edit client menu message');
     }
-    return;
   }
 
   await sendClientMenu(ctx, header);


### PR DESCRIPTION
## Summary
- ensure the client menu falls back to sending a new message when editing the deleted role prompt fails
- extend the client menu tests to cover callback interactions and the new fallback behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c98dea48832d8bf10a1ce86ac7f5