### PR TITLE
Handle idempotency failures in orders channel

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -1438,6 +1438,10 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:accept', String(orderId), () =>
       handleOrderDecision(ctx, orderId, 'accept'),
     );
+    if (guard.status === 'error') {
+      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
+      return;
+    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1467,6 +1471,10 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:release', String(orderId), () =>
       handleOrderRelease(ctx, orderId),
     );
+    if (guard.status === 'error') {
+      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
+      return;
+    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1484,6 +1492,10 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:complete', String(orderId), () =>
       handleOrderCompletion(ctx, orderId),
     );
+    if (guard.status === 'error') {
+      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
+      return;
+    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1501,6 +1513,10 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:undo-release', String(orderId), () =>
       handleUndoOrderRelease(ctx, orderId),
     );
+    if (guard.status === 'error') {
+      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
+      return;
+    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1518,6 +1534,10 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:undo-complete', String(orderId), () =>
       handleUndoOrderCompletion(ctx, orderId),
     );
+    if (guard.status === 'error') {
+      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
+      return;
+    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }


### PR DESCRIPTION
## Summary
- return a distinct error status from the idempotency middleware when the key insert fails and avoid deleting keys that were never created
- surface the service unavailable toast in all orders channel actions when the idempotency guard errors out
- add a regression test that simulates an idempotency failure and asserts the handler notifies the executor

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6fcb7c024832d8d3abe0d7ab27c9c