### PR TITLE
Tailor executor verification reminders to role context

### DIFF
--- a/tests/executor-access.test.ts
+++ b/tests/executor-access.test.ts
@@ -197,6 +197,28 @@ describe('executor access control', () => {
       (step) => step.id === 'executor:subscription:verification-required',
     );
     assert.ok(rejection, 'verification reminder should be shown');
+    assert.equal(
+      rejection.text,
+      'Вы пока не прошли модерацию. Отправьте фото удостоверения личности с обеих сторон в этот чат, чтобы мы выдали доступ.',
+    );
+  });
+
+  it('highlights driver-specific verification requirements before subscription', async () => {
+    const { ctx, session, auth } = createContext();
+    session.executor.role = 'driver';
+    auth.user.role = 'driver';
+    ensureExecutorState(ctx);
+
+    await startExecutorSubscription(ctx);
+
+    const rejection = recordedSteps.find(
+      (step) => step.id === 'executor:subscription:verification-required',
+    );
+    assert.ok(rejection, 'verification reminder should be shown');
+    assert.equal(
+      rejection?.text,
+      'Вы пока не прошли модерацию. Отправьте фото водительского удостоверения (лицевая сторона) и селфи с ним в этот чат, чтобы мы выдали доступ.',
+    );
   });
 
   it('shows the default executor menu keyboard when access requirements are not met', async () => {


### PR DESCRIPTION
## Summary
- replace the hard-coded executor subscription verification reminder with a role-aware helper that reuses verification guidance
- call the helper from each subscription guard so drivers and couriers receive the correct document instructions
- extend executor access tests to cover the new role-specific reminder text

## Testing
- node --require ts-node/register --test tests/executor-access.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7004fcfa8832d8892aa6713075a76