### PR TITLE
Handle bare start messages

### DIFF
--- a/tests/bot/executorVerification.test.ts
+++ b/tests/bot/executorVerification.test.ts
@@ -271,6 +271,7 @@ describe('executor verification media group handler', () => {
           startHandler = handler;
           return startBot;
         },
+        hears: () => startBot,
         on: () => startBot,
       } as unknown as import('telegraf').Telegraf<BotContext>;
 


### PR DESCRIPTION
## Summary
- extract the /start command logic into a reusable `handleStart` handler and register it for both `/start` and bare `start` messages
- update the mocked Telegraf helpers in tests to support `hears` registrations and cover the bare `start` flow
- extend the `/start` command tests to assert that plain text `start` triggers the same behaviour as the command

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d719fafea8832da2925fed4b5d75b3