### PR TITLE
Fix subscription receipt flow for active executors

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -189,8 +189,16 @@ export const ensureExecutorState = (ctx: BotContext): ExecutorFlowState => {
 
     const subscription = ctx.session.executor.subscription;
     if (ctx.auth.executor.hasActiveSubscription) {
-      if (subscription.status !== 'idle') {
-        subscription.status = 'idle';
+      const preserveSubscriptionFlow =
+        subscription.status === 'selectingPeriod' ||
+        subscription.status === 'awaitingReceipt' ||
+        subscription.status === 'pendingModeration';
+
+      if (!preserveSubscriptionFlow) {
+        if (subscription.status !== 'idle') {
+          subscription.status = 'idle';
+        }
+
         subscription.selectedPeriodId = undefined;
         subscription.pendingPaymentId = undefined;
       }


### PR DESCRIPTION
## Summary
- keep the executor subscription flow state when an active subscription exists but a renewal is in progress
- prevent the verification photo handler from intercepting payment receipts for verified executors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d720b56914832d828746c0d4c51634