### PR TITLE
Fix driver role verification gating

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -4,9 +4,11 @@ import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram'
 import {
   EXECUTOR_ROLES,
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
+  type AuthExecutorState,
   type AuthUser,
   type BotContext,
   type ExecutorFlowState,
+  type ExecutorRole,
   type ExecutorSubscriptionState,
   type ExecutorVerificationRoleState,
 } from '../../types';
@@ -249,13 +251,28 @@ interface ExecutorAccessStatus {
   hasActiveSubscription: boolean;
 }
 
+const hasRoleVerificationFlags = (verifiedRoles: AuthExecutorState['verifiedRoles']): boolean =>
+  EXECUTOR_ROLES.some((role) => Boolean(verifiedRoles[role]));
+
+export const isExecutorRoleVerified = (ctx: BotContext, role: ExecutorRole): boolean => {
+  const verifiedRoles = ctx.auth.executor.verifiedRoles;
+
+  if (Boolean(verifiedRoles[role])) {
+    return true;
+  }
+
+  if (!hasRoleVerificationFlags(verifiedRoles)) {
+    return ctx.auth.executor.isVerified;
+  }
+
+  return false;
+};
+
 const determineExecutorAccessStatus = (
   ctx: BotContext,
   state: ExecutorFlowState,
 ): ExecutorAccessStatus => {
-  const verifiedRoles = ctx.auth.executor.verifiedRoles;
-  const role = state.role;
-  const isVerified = Boolean(verifiedRoles[role]) || ctx.auth.executor.isVerified;
+  const isVerified = isExecutorRoleVerified(ctx, state.role);
 
   return {
     isVerified,

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -13,6 +13,7 @@ import {
   EXECUTOR_MENU_TEXT_LABELS,
   EXECUTOR_SUBSCRIPTION_ACTION,
   ensureExecutorState,
+  isExecutorRoleVerified,
   showExecutorMenu,
 } from './menu';
 import { getExecutorRoleCopy } from '../../copy';
@@ -150,7 +151,7 @@ const activateTrialSubscription = async (ctx: BotContext): Promise<void> => {
     return;
   }
 
-  const isVerified = Boolean(ctx.auth.executor.verifiedRoles[state.role]) || ctx.auth.executor.isVerified;
+  const isVerified = isExecutorRoleVerified(ctx, state.role);
   if (!isVerified) {
     state.subscription.status = 'idle';
     state.subscription.selectedPeriodId = undefined;
@@ -268,7 +269,7 @@ export const startExecutorSubscription = async (
   const state = ensureExecutorState(ctx);
   const copy = getExecutorRoleCopy(state.role);
 
-  const isVerified = Boolean(ctx.auth.executor.verifiedRoles[state.role]) || ctx.auth.executor.isVerified;
+  const isVerified = isExecutorRoleVerified(ctx, state.role);
 
   if (!options.skipVerificationCheck && !isVerified) {
     state.subscription.status = 'idle';
@@ -327,7 +328,7 @@ const handlePeriodSelection = async (
   }
 
   const state = ensureExecutorState(ctx);
-  const isVerified = Boolean(ctx.auth.executor.verifiedRoles[state.role]) || ctx.auth.executor.isVerified;
+  const isVerified = isExecutorRoleVerified(ctx, state.role);
 
   if (!isVerified) {
     state.subscription.status = 'idle';

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -17,6 +17,7 @@ import {
   EXECUTOR_SUBSCRIPTION_ACTION,
   EXECUTOR_VERIFICATION_ACTION,
   ensureExecutorState,
+  isExecutorRoleVerified,
   isExecutorMenuTextCommand,
   resetVerificationState,
   showExecutorMenu,
@@ -351,7 +352,7 @@ export const startExecutorVerification = async (
   const state = ctx.session.executor;
   const role = state.role;
   const verification = state.verification[role];
-  const alreadyVerified = Boolean(ctx.auth.executor.verifiedRoles[role]) || ctx.auth.executor.isVerified;
+  const alreadyVerified = isExecutorRoleVerified(ctx, role);
   const copy = getExecutorRoleCopy(role);
 
   if (alreadyVerified) {
@@ -407,7 +408,7 @@ const handleIncomingPhoto = async (
   const role = state.role;
   let verification = state.verification[role];
   const copy = getExecutorRoleCopy(role);
-  const alreadyVerified = Boolean(ctx.auth.executor.verifiedRoles[role]) || ctx.auth.executor.isVerified;
+  const alreadyVerified = isExecutorRoleVerified(ctx, role);
 
   if (alreadyVerified) {
     await ui.step(ctx, {


### PR DESCRIPTION
## Summary
- ensure executor access checks use role-specific verification flags with a fallback for legacy data
- reuse the verification helper across menu, subscription, and verification flows so drivers cannot skip document checks
- extend executor role selection tests to cover driver onboarding scenarios, including legacy courier verification

## Testing
- node --require ts-node/register --test tests/executor-role-select.test.ts
- node --require ts-node/register --test tests/executor-access.test.ts
- node --require ts-node/register --test tests/executor-verification.test.ts
- node --require ts-node/register --test tests/bot/executorMenu.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d7215c8438832db44a2bad4621029c