### PR TITLE
Align bot scheduling with Astana timezone

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -1,6 +1,7 @@
 import { Markup, Telegraf } from 'telegraf';
 import type { InlineKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
+import { config } from '../../../config';
 import {
   EXECUTOR_ROLES,
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
@@ -251,6 +252,7 @@ const formatTimestamp = (timestamp: number): string => {
   return new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(new Date(timestamp));
 };
 

--- a/src/bot/flows/executor/orders.ts
+++ b/src/bot/flows/executor/orders.ts
@@ -23,6 +23,7 @@ const formatDateTime = (value: Date): string =>
   new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(value);
 
 type InviteSource = 'generated' | 'cached' | 'config' | 'none';

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -40,6 +40,7 @@ const formatDateTime = (value?: Date | number | string): string | undefined => {
   return new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(date);
 };
 

--- a/src/bot/moderation/verifyQueue.ts
+++ b/src/bot/moderation/verifyQueue.ts
@@ -80,6 +80,7 @@ const formatDateTime = (value?: Date | number | string): string | undefined => {
   return new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(date);
 };
 

--- a/src/bot/services/reports.ts
+++ b/src/bot/services/reports.ts
@@ -44,6 +44,7 @@ const formatDateTime = (value?: Date | number | string): string | undefined => {
   return new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(date);
 };
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -299,6 +299,7 @@ export interface AppConfig {
   city: {
     default?: string;
   };
+  timezone: string;
   jobs: {
     nudger: string;
     subscription: string;
@@ -360,6 +361,7 @@ export const loadConfig = (): AppConfig => ({
   city: {
     default: getOptionalString('CITY_DEFAULT'),
   },
+  timezone: getOptionalString('TIMEZONE') ?? 'Asia/Almaty',
   jobs: {
     nudger: getCronExpression('JOBS_NUDGER_CRON', '*/1 * * * *'),
     subscription: getCronExpression('JOBS_SUBSCRIPTION_CRON', '*/10 * * * *'),

--- a/src/jobs/metricsReporter.ts
+++ b/src/jobs/metricsReporter.ts
@@ -10,14 +10,18 @@ export const startMetricsReporter = (): void => {
     return;
   }
 
-  task = cron.schedule(config.jobs.metrics, () => {
-    try {
-      const current = snapshot();
-      logger.info({ metric: 'agg', snapshot: current }, 'metrics_snapshot');
-    } catch (error) {
-      logger.error({ err: error }, 'metrics_reporter_failed');
-    }
-  });
+  task = cron.schedule(
+    config.jobs.metrics,
+    () => {
+      try {
+        const current = snapshot();
+        logger.info({ metric: 'agg', snapshot: current }, 'metrics_snapshot');
+      } catch (error) {
+        logger.error({ err: error }, 'metrics_reporter_failed');
+      }
+    },
+    { timezone: config.timezone },
+  );
 };
 
 export const stopMetricsReporter = (): void => {

--- a/src/jobs/paymentReminder.ts
+++ b/src/jobs/paymentReminder.ts
@@ -197,6 +197,7 @@ const formatDateTime = (date: Date): string =>
   new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'medium',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(date);
 
 const buildReminderMessage = (
@@ -365,7 +366,11 @@ export const startPaymentReminderJob = (bot: Telegraf<BotContext>): void => {
     return;
   }
 
-  task = cron.schedule(config.jobs.paymentReminder, () => runSafely(bot));
+  task = cron.schedule(
+    config.jobs.paymentReminder,
+    () => runSafely(bot),
+    { timezone: config.timezone },
+  );
 };
 
 export const stopPaymentReminderJob = (): void => {

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -40,6 +40,7 @@ const formatDateTime = (date: Date): string =>
   new Intl.DateTimeFormat('ru-RU', {
     dateStyle: 'long',
     timeStyle: 'short',
+    timeZone: config.timezone,
   }).format(date);
 
 const buildUserLabel = (subscription: SubscriptionWithUser): string => {
@@ -274,17 +275,21 @@ export const startSubscriptionScheduler = (
     return;
   }
 
-  task = cron.schedule(config.jobs.subscription, () => {
-    if (running) {
-      logger.warn('Previous subscription maintenance is still running, skipping');
-      return;
-    }
+  task = cron.schedule(
+    config.jobs.subscription,
+    () => {
+      if (running) {
+        logger.warn('Previous subscription maintenance is still running, skipping');
+        return;
+      }
 
-    running = true;
-    void runMaintenance(bot.telegram).finally(() => {
-      running = false;
-    });
-  });
+      running = true;
+      void runMaintenance(bot.telegram).finally(() => {
+        running = false;
+      });
+    },
+    { timezone: config.timezone },
+  );
 
   logger.info('Subscription scheduler initialised');
 };


### PR DESCRIPTION
## Summary
- add a timezone setting that defaults to Asia/Almaty and feed it into scheduled jobs
- render user-facing timestamps in the configured timezone across moderation, reports, and executor flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73855f43c832d87364ead3909fb46