### PR TITLE
Handle auth fallback when database is unavailable

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -62,7 +62,7 @@ const applyCommandsForRole = async (ctx: BotContext): Promise<void> => {
   }
 
   const role = ctx.auth?.user.role;
-  if (role === 'client' || role === undefined) {
+  if (role === 'client' || role === 'guest' || role === undefined) {
     await setChatCommands(ctx.telegram, ctx.chat.id, CLIENT_COMMANDS, { showMenuButton: true });
     return;
   }

--- a/src/bot/flows/common/citySelect.ts
+++ b/src/bot/flows/common/citySelect.ts
@@ -32,7 +32,7 @@ const resolveHomeAction = (ctx: BotContext): string => {
   }
 
   const role = ctx.auth?.user.role;
-  if (role === 'client' || role === 'moderator') {
+  if (role === 'client' || role === 'guest' || role === 'moderator') {
     return CLIENT_MENU_HOME_ACTION;
   }
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -9,7 +9,7 @@ export type ExecutorRole = 'courier' | 'driver';
 
 export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
 
-export type UserRole = 'client' | 'courier' | 'driver' | 'moderator';
+export type UserRole = 'guest' | 'client' | 'courier' | 'driver' | 'moderator';
 
 export interface SessionUser {
   id: number;

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -94,7 +94,7 @@ const buildNudgeKeyboard = (
   let fallbackAction: string | null = null;
   if (role === 'courier' || role === 'driver') {
     fallbackAction = EXECUTOR_MENU_ACTION;
-  } else if (role === 'client' || role === 'moderator') {
+  } else if (role === 'client' || role === 'guest' || role === 'moderator') {
     fallbackAction = CLIENT_MENU_ACTION;
   }
 

--- a/src/ui/clientMenu.ts
+++ b/src/ui/clientMenu.ts
@@ -78,7 +78,7 @@ export const hideClientMenu = async (
 };
 
 export const isClientChat = (ctx: BotContext, role?: UserRole): boolean =>
-  ctx.chat?.type === 'private' && (role === 'client' || role === undefined);
+  ctx.chat?.type === 'private' && (role === 'client' || role === 'guest' || role === undefined);
 
 export const clientMenuText = (): string =>
   [


### PR DESCRIPTION
## Summary
- add a guest fallback auth state when database lookups fail so middleware continues processing updates
- extend role handling to recognise the new guest role across city selection, menus and nudger helpers
- cover the fallback scenario with auth middleware tests to ensure commands still run with guest data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73b8d7794832d84f9f2cbec194fec