### PR TITLE
Improve idempotency fallback and resilience

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -1438,10 +1438,6 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:accept', String(orderId), () =>
       handleOrderDecision(ctx, orderId, 'accept'),
     );
-    if (guard.status === 'error') {
-      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
-      return;
-    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1471,10 +1467,6 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:release', String(orderId), () =>
       handleOrderRelease(ctx, orderId),
     );
-    if (guard.status === 'error') {
-      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
-      return;
-    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1492,10 +1484,6 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:complete', String(orderId), () =>
       handleOrderCompletion(ctx, orderId),
     );
-    if (guard.status === 'error') {
-      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
-      return;
-    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1513,10 +1501,6 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:undo-release', String(orderId), () =>
       handleUndoOrderRelease(ctx, orderId),
     );
-    if (guard.status === 'error') {
-      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
-      return;
-    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }
@@ -1534,10 +1518,6 @@ export const registerOrdersChannel = (bot: Telegraf<BotContext>): void => {
     const guard = await withIdempotency(ctx, 'order:undo-complete', String(orderId), () =>
       handleUndoOrderCompletion(ctx, orderId),
     );
-    if (guard.status === 'error') {
-      await ctx.answerCbQuery(copy.serviceUnavailable, { show_alert: true });
-      return;
-    }
     if (guard.status === 'duplicate') {
       await ctx.answerCbQuery('Запрос уже обработан.');
     }

--- a/tests/bot/middlewares/idempotency.test.ts
+++ b/tests/bot/middlewares/idempotency.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { afterEach, before, describe, it, mock } from 'node:test';
+
+import type { BotContext } from '../../../src/bot/types';
+
+process.env.BOT_TOKEN ??= 'test-bot-token';
+process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/testdb';
+process.env.KASPI_CARD ??= '1234';
+process.env.KASPI_NAME ??= 'Test User';
+process.env.KASPI_PHONE ??= '+77770000000';
+process.env.WEBHOOK_DOMAIN ??= 'example.com';
+process.env.WEBHOOK_SECRET ??= 'secret';
+
+type IdempotencyModule = typeof import('../../../src/bot/middlewares/idempotency');
+type DbModule = typeof import('../../../src/db');
+
+let withIdempotency: IdempotencyModule['withIdempotency'];
+let pool: DbModule['pool'];
+
+before(async () => {
+  ({ withIdempotency } = await import('../../../src/bot/middlewares/idempotency'));
+  ({ pool } = await import('../../../src/db'));
+});
+
+describe('withIdempotency', () => {
+  let poolQueryMock: ReturnType<typeof mock.method> | undefined;
+
+  afterEach(() => {
+    poolQueryMock?.mock.restore();
+    poolQueryMock = undefined;
+  });
+
+  const createCtx = (userId = 12345): BotContext =>
+    ({ from: { id: userId } } as unknown as BotContext);
+
+  it('runs the handler exactly once when the key insert fails', async () => {
+    let handlerCalls = 0;
+    poolQueryMock = mock.method(pool, 'query', async (...args: unknown[]) => {
+      const [sql] = args as [string];
+      if (sql.includes('expires_at < now()')) {
+        return { rowCount: 0, rows: [] };
+      }
+      throw new Error('insert failed');
+    });
+
+    const result = await withIdempotency(createCtx(), 'test-action', undefined, async () => {
+      handlerCalls += 1;
+      return 'handled';
+    });
+
+    assert.ok(poolQueryMock, 'pool.query should be mocked');
+    assert.equal(poolQueryMock.mock.callCount(), 2);
+    assert.equal(handlerCalls, 1);
+    assert.deepEqual(result, { status: 'ok', result: 'handled' });
+  });
+
+  it('keeps throwing the original handler error even if cleanup fails', async () => {
+    let handlerCalls = 0;
+    let cleanupAttempts = 0;
+
+    poolQueryMock = mock.method(pool, 'query', async (...args: unknown[]) => {
+      const [sql] = args as [string];
+      if (sql.includes('expires_at < now()')) {
+        return { rowCount: 0, rows: [] };
+      }
+      if (sql.includes('INSERT INTO recent_actions')) {
+        return { rowCount: 1, rows: [] };
+      }
+      if (sql.includes('DELETE FROM recent_actions WHERE user_id = $1 AND key = $2')) {
+        cleanupAttempts += 1;
+        throw new Error('cleanup failed');
+      }
+      return { rowCount: 0, rows: [] };
+    });
+
+    const handlerError = new Error('handler blew up');
+
+    await assert.rejects(
+      () =>
+        withIdempotency(createCtx(), 'test-action', undefined, async () => {
+          handlerCalls += 1;
+          throw handlerError;
+        }),
+      handlerError,
+    );
+
+    assert.ok(poolQueryMock, 'pool.query should be mocked');
+    assert.equal(handlerCalls, 1);
+    assert.equal(cleanupAttempts, 1);
+  });
+});

--- a/tests/bot/ordersChannel.test.ts
+++ b/tests/bot/ordersChannel.test.ts
@@ -316,7 +316,7 @@ describe('registerOrdersChannel', () => {
     withIdempotencyMock = undefined;
   });
 
-  it('answers callback with service unavailable when idempotency guard fails', async () => {
+  it('answers callback with duplicate warning when idempotency guard detects repeat', async () => {
     const actions: Array<{ pattern: RegExp; handler: (ctx: BotContext) => Promise<void> }> = [];
     const bot = {
       action: (pattern: RegExp, handler: (ctx: BotContext) => Promise<void>) => {
@@ -339,7 +339,7 @@ describe('registerOrdersChannel', () => {
       from: { id: 12345 },
     } as unknown as BotContext;
 
-    withIdempotencyMock = mock.method(idempotency, 'withIdempotency', async () => ({ status: 'error' }));
+    withIdempotencyMock = mock.method(idempotency, 'withIdempotency', async () => ({ status: 'duplicate' }));
 
     await acceptAction.handler(ctx);
 
@@ -349,7 +349,7 @@ describe('registerOrdersChannel', () => {
     assert.equal(answerCbQuery.mock.callCount(), 1);
     const [answerCall] = answerCbQuery.mock.calls;
     assert.ok(answerCall, 'answerCbQuery should be invoked');
-    assert.equal(answerCall.arguments[0], copy.serviceUnavailable);
-    assert.deepEqual(answerCall.arguments[1], { show_alert: true });
+    assert.equal(answerCall.arguments[0], 'Запрос уже обработан.');
+    assert.deepEqual(answerCall.arguments[1], undefined);
   });
 });


### PR DESCRIPTION
## Summary
- allow idempotency middleware to execute handlers when key insertion fails and log cleanup issues without masking the original error
- simplify order channel actions to treat only duplicate status responses from the guard
- add middleware tests covering storage failures and update channel tests for duplicate handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73f2c88d0832da1b59ba24ce4c9df