### PR TITLE
Handle channel binding query failures gracefully

### DIFF
--- a/src/bot/channels/membership.ts
+++ b/src/bot/channels/membership.ts
@@ -49,14 +49,7 @@ export const registerMembershipSync = (
       return;
     }
 
-    let binding;
-    try {
-      binding = await getChannelBinding('drivers');
-    } catch (error) {
-      logger.error({ err: error }, 'Failed to resolve drivers channel binding');
-      return;
-    }
-
+    const binding = await getChannelBinding('drivers');
     if (!binding || binding.chatId !== update.chat.id) {
       return;
     }

--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -225,16 +225,9 @@ const resolveAuthorizedChatId = async (
     return chatId;
   }
 
-  try {
-    const binding = await getChannelBinding('drivers');
-    if (binding && binding.chatId === chatId) {
-      return chatId;
-    }
-  } catch (error) {
-    logger.error(
-      { err: error, orderId, chatId },
-      'Failed to resolve drivers channel binding while validating callback context',
-    );
+  const binding = await getChannelBinding('drivers');
+  if (binding && binding.chatId === chatId) {
+    return chatId;
   }
 
   return null;
@@ -331,22 +324,18 @@ export const handleClientOrderCancellation = async (
     orderStates.delete(order.id);
 
     if (typeof order.channelMessageId === 'number') {
-      try {
-        const binding = await getChannelBinding('drivers');
-        if (!binding) {
-          logger.warn({ orderId: order.id }, 'Drivers channel binding missing during cancellation');
-        } else {
-          try {
-            await telegram.deleteMessage(binding.chatId, order.channelMessageId);
-          } catch (error) {
-            logger.debug(
-              { err: error, orderId: order.id, chatId: binding.chatId, messageId: order.channelMessageId },
-              'Failed to delete drivers channel message for cancelled order',
-            );
-          }
+      const binding = await getChannelBinding('drivers');
+      if (!binding) {
+        logger.warn({ orderId: order.id }, 'Drivers channel binding missing during cancellation');
+      } else {
+        try {
+          await telegram.deleteMessage(binding.chatId, order.channelMessageId);
+        } catch (error) {
+          logger.debug(
+            { err: error, orderId: order.id, chatId: binding.chatId, messageId: order.channelMessageId },
+            'Failed to delete drivers channel message for cancelled order',
+          );
         }
-      } catch (error) {
-        logger.error({ err: error, orderId: order.id }, 'Failed to resolve drivers channel binding');
       }
     }
   }


### PR DESCRIPTION
## Summary
- guard channel binding lookups against database failures by caching the last known value and using configured fallbacks
- simplify drivers channel callers now that getChannelBinding always returns safely
- add tests that cover database failures during channel binding reads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d74355c6f4832d9f856866484e1f79