### PR TITLE
Handle moderation callback failures with manual review

### DIFF
--- a/tests/moderation-queue.test.ts
+++ b/tests/moderation-queue.test.ts
@@ -1,7 +1,7 @@
 import './helpers/setup-env';
 
 import assert from 'node:assert/strict';
-import { afterEach, beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 
 import type { Telegraf } from 'telegraf';
 import type { Telegram } from 'telegraf';
@@ -29,6 +29,8 @@ const channelsRow = {
   drivers_channel_id: null,
   stats_channel_id: '-100777888',
 };
+
+const MANUAL_REVIEW_MESSAGE = 'Не удалось обработать заявку. Требуется ручная проверка.';
 
 const originalQuery = pool.query.bind(pool);
 
@@ -211,4 +213,187 @@ describe('moderation queue persistence', () => {
     assert.equal(callbackMap.size, 0);
 
   });
+
+  it('stops approval when the decision callback fails', async () => {
+    const queue = createModerationQueue<TestItem>({
+      type: 'test',
+      channelType: 'verify',
+      defaultRejectionReasons: ['Нет данных'],
+      renderMessage: (item) => item.label,
+    });
+
+    const sendMessageMock = mock.fn<
+      (chatId: number, text: string, extra?: unknown) => Promise<{ message_id: number; chat: { id: number; type: string } }>
+    >(async () => ({ message_id: 201, chat: { id: 555, type: 'supergroup' } }));
+    const editMessageTextMock = mock.fn<
+      (chatId: number, messageId: number, inlineMessageId: undefined, text: string, extra?: unknown) => Promise<void>
+    >(async () => {});
+
+    const telegram = {
+      sendMessage: sendMessageMock as unknown as Telegram['sendMessage'],
+      editMessageText: editMessageTextMock as unknown as Telegram['editMessageText'],
+    } as Telegram;
+
+    const publishResult = await queue.publish(telegram, {
+      id: 'item-approval-failure',
+      label: 'Approval failure',
+      async onApprove() {
+        throw new Error('db lookup failed');
+      },
+    });
+
+    assert.equal(publishResult.status, 'published');
+    const token = publishResult.token;
+    assert.ok(token);
+
+    let approveHandler: ((ctx: BotContext) => Promise<void>) | undefined;
+    const bot = {
+      action(pattern: RegExp, handler: (ctx: BotContext) => Promise<void>) {
+        if (token && pattern.test(`mod:test:accept:${token}`)) {
+          approveHandler = handler;
+        }
+      },
+      on() {},
+    } as unknown as Telegraf<BotContext>;
+
+    queue.register(bot);
+    assert.ok(approveHandler, 'Approve handler should be registered');
+
+    const answerCbQueryMock = mock.fn<(text?: string) => Promise<void>>(async () => {});
+    const ctx = {
+      match: [`mod:test:accept:${token}`, token],
+      telegram,
+      from: { id: 42 },
+      chat: { id: 555, type: 'supergroup' },
+      answerCbQuery: answerCbQueryMock as unknown as BotContext['answerCbQuery'],
+    } as unknown as BotContext;
+
+    await approveHandler!(ctx);
+
+    assert.equal(answerCbQueryMock.mock.callCount(), 1);
+    const [answerCall] = answerCbQueryMock.mock.calls;
+    assert.ok(answerCall);
+    const [response] = answerCall.arguments;
+    assert.equal(response, MANUAL_REVIEW_MESSAGE);
+
+    assert.equal(editMessageTextMock.mock.callCount(), 0);
+    assert.ok(token);
+    const stored = callbackMap.get(token!);
+    assert.ok(stored);
+    assert.equal(stored?.payload?.failed, true);
+    assert.equal(stored?.payload?.status, 'pending');
+  });
+
+  it('stops rejection when the decision callback fails', async () => {
+    const queue = createModerationQueue<TestItem>({
+      type: 'test',
+      channelType: 'verify',
+      defaultRejectionReasons: ['Нет данных'],
+      renderMessage: (item) => item.label,
+    });
+
+    const sendMessageMock = mock.fn<
+      (chatId: number, text: string, extra?: unknown) => Promise<{ message_id: number; chat: { id: number; type: string } }>
+    >(async () => ({ message_id: 301, chat: { id: 555, type: 'supergroup' } }));
+    const editMessageTextMock = mock.fn<
+      (chatId: number, messageId: number, inlineMessageId: undefined, text: string, extra?: unknown) => Promise<void>
+    >(async () => {});
+
+    const telegram = {
+      sendMessage: sendMessageMock as unknown as Telegram['sendMessage'],
+      editMessageText: editMessageTextMock as unknown as Telegram['editMessageText'],
+    } as Telegram;
+
+    const publishResult = await queue.publish(telegram, {
+      id: 'item-rejection-failure',
+      label: 'Rejection failure',
+      rejectionReasons: ['Нет данных'],
+      async onReject() {
+        throw new Error('db lookup failed');
+      },
+    });
+
+    assert.equal(publishResult.status, 'published');
+    const token = publishResult.token;
+    assert.ok(token);
+
+    let rejectHandler: ((ctx: BotContext) => Promise<void>) | undefined;
+    let textHandler: ((ctx: BotContext, next?: () => Promise<void>) => Promise<void>) | undefined;
+
+    const bot = {
+      action(pattern: RegExp, handler: (ctx: BotContext) => Promise<void>) {
+        const source = pattern.toString();
+        if (source.includes(':reject')) {
+          rejectHandler = handler;
+        }
+      },
+      on(event: string, handler: (ctx: BotContext, next?: () => Promise<void>) => Promise<void>) {
+        if (event === 'text') {
+          textHandler = handler;
+        }
+      },
+    } as unknown as Telegraf<BotContext>;
+
+    queue.register(bot);
+    assert.ok(rejectHandler, 'Reject handler should be registered');
+    assert.ok(textHandler, 'Text handler should be registered');
+
+    const answerCbQueryMock = mock.fn<(text?: string) => Promise<void>>(async () => {});
+    const promptReplyMock = mock.fn<
+      (text: string, extra?: { reply_markup?: unknown }) => Promise<{ message_id: number; chat: { id: number } }>
+    >(async () => ({ message_id: 777, chat: { id: 555 } }));
+
+    const rejectCtx = {
+      match: [`mod:test:reject:${token}:0`, token, '0'],
+      telegram,
+      from: { id: 42 },
+      chat: { id: 555, type: 'supergroup' },
+      answerCbQuery: answerCbQueryMock as unknown as BotContext['answerCbQuery'],
+      reply: promptReplyMock as unknown as BotContext['reply'],
+    } as unknown as BotContext;
+
+    await rejectHandler!(rejectCtx);
+
+    assert.equal(promptReplyMock.mock.callCount(), 1);
+
+    const responseReplyMock = mock.fn<
+      (text: string, extra?: { reply_parameters?: { message_id: number } }) => Promise<unknown>
+    >(async () => ({}));
+
+    const textCtx = {
+      message: {
+        text: 'Причина',
+        message_id: 900,
+        reply_to_message: { message_id: 777 },
+      },
+      chat: { id: 555, type: 'supergroup' },
+      telegram,
+      from: { id: 42 },
+      reply: responseReplyMock as unknown as BotContext['reply'],
+    } as unknown as BotContext;
+
+    await textHandler!(textCtx);
+
+    assert.equal(responseReplyMock.mock.callCount(), 1);
+    const [replyCall] = responseReplyMock.mock.calls;
+    assert.ok(replyCall);
+    const [replyMessage, replyOptions] = replyCall.arguments;
+    assert.equal(replyMessage, MANUAL_REVIEW_MESSAGE);
+    assert.ok(replyOptions && typeof replyOptions === 'object');
+    if (replyOptions && typeof replyOptions === 'object') {
+      const params = (replyOptions as { reply_parameters?: { message_id?: number } }).reply_parameters;
+      assert.ok(params);
+      if (params) {
+        assert.equal(params.message_id, 900);
+      }
+    }
+
+    assert.equal(editMessageTextMock.mock.callCount(), 0);
+    assert.ok(token);
+    const stored = callbackMap.get(token!);
+    assert.ok(stored);
+    assert.equal(stored?.payload?.failed, true);
+    assert.equal(stored?.payload?.status, 'pending');
+  });
+
 });


### PR DESCRIPTION
## Summary
- add a manual review failure response to moderation queue items and persist the failed state
- stop auto-approving or rejecting when decision callbacks throw, logging and surfacing the manual review message
- expand moderation queue tests to cover approval and rejection failure paths

## Testing
- node --require ts-node/register --test tests/moderation-queue.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d74a3b5394832d88568e7abb8c0cdb