### PR TITLE
Fix executor menu city callback sequencing

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -563,17 +563,19 @@ export const showExecutorMenu = async (
 
 export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
   bot.action(CITY_ACTION_PATTERN, async (ctx, next) => {
-    if (ctx.session.ui?.pendingCityAction === EXECUTOR_MENU_CITY_ACTION) {
-      ctx.session.ui.pendingCityAction = undefined;
-
-      if (ctx.chat?.type === 'private') {
-        await showExecutorMenu(ctx);
-      }
-    }
-
     if (typeof next === 'function') {
       await next();
     }
+
+    if (ctx.chat?.type !== 'private') {
+      return;
+    }
+
+    if (ctx.session.ui?.pendingCityAction !== EXECUTOR_MENU_CITY_ACTION) {
+      return;
+    }
+
+    await showExecutorMenu(ctx);
   });
 
   bot.action(EXECUTOR_MENU_ACTION, async (ctx) => {


### PR DESCRIPTION
## Summary
- call downstream middlewares before checking executor pending city action so the city selection can be persisted
- add a regression test covering city callbacks when another middleware stores the city

## Testing
- node --require ts-node/register --test tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d75f95e57c832d97f1fa1ab300b970