### PR TITLE
Fix taxi dropoff recent address selection

### DIFF
--- a/src/bot/services/orders.ts
+++ b/src/bot/services/orders.ts
@@ -54,8 +54,14 @@ export interface OrderSummaryOptions {
   instructions?: string[];
 }
 
+type OrderSummaryDraft = ClientOrderDraftState & {
+  pickup: OrderLocation;
+  dropoff: OrderLocation;
+  price: OrderPriceDetails;
+};
+
 export const buildOrderSummary = (
-  draft: CompletedOrderDraft,
+  draft: OrderSummaryDraft,
   options: OrderSummaryOptions,
 ): string => {
   const lines = [options.title.trim(), ''];


### PR DESCRIPTION
## Summary
- ensure taxi orders use a dedicated readiness guard so selecting a recent dropoff shows the confirmation step
- allow the shared order summary helper to work with taxi drafts that only provide pickup, dropoff, and pricing data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d770791b84832db381cb7e2b6654b5