### PR TITLE
Handle executor city callbacks without pending state

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -578,10 +578,22 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
       return;
     }
 
-    if (ctx.session.ui?.pendingCityAction !== EXECUTOR_MENU_CITY_ACTION) {
+    const pendingCityAction = ctx.session.ui?.pendingCityAction;
+    const userRole = ctx.auth.user.role;
+    const sessionExecutorRole = ctx.session.executor?.role;
+    const hasExecutorRole =
+      userRole === 'courier' ||
+      userRole === 'driver' ||
+      (sessionExecutorRole ? EXECUTOR_ROLES.includes(sessionExecutorRole) : false);
+
+    const shouldShowExecutorMenu =
+      pendingCityAction === EXECUTOR_MENU_CITY_ACTION || (!pendingCityAction && hasExecutorRole);
+
+    if (!shouldShowExecutorMenu) {
       return;
     }
 
+    ensureExecutorState(ctx);
     await showExecutorMenu(ctx);
   });
 

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -348,6 +348,49 @@ describe('executor role selection', () => {
     assert.equal(ctx.session.ui.pendingCityAction, undefined);
   });
 
+  it('shows verification prompt and menu for courier after city callback without pending action', async () => {
+    const setUserCitySelectedMock = mock.method(
+      usersService,
+      'setUserCitySelected',
+      async () => undefined,
+    );
+
+    const { bot, dispatchAction } = createMockBot();
+    registerCityAction(bot);
+    registerExecutorMenu(bot);
+    registerExecutorVerification(bot);
+
+    const { ctx } = createMockContext();
+    ctx.session.city = undefined;
+    ctx.auth.user.citySelected = undefined;
+    ctx.session.ui.pendingCityAction = undefined;
+
+    Object.assign(ctx as BotContext & { callbackQuery?: typeof ctx.callbackQuery }, {
+      callbackQuery: {
+        data: 'city:almaty',
+        message: { message_id: 250, chat: ctx.chat },
+      } as typeof ctx.callbackQuery,
+    });
+
+    try {
+      await dispatchAction('city:almaty', ctx);
+    } finally {
+      setUserCitySelectedMock.mock.restore();
+    }
+
+    const verificationPrompt = recordedSteps.find(
+      (step) => step.id === 'executor:verification:prompt',
+    );
+    assert.ok(
+      verificationPrompt,
+      'courier should see verification prompt after selecting city without pending action',
+    );
+
+    const menuStep = recordedSteps.find((step) => step.id === 'executor:menu:main');
+    assert.ok(menuStep, 'executor menu should be displayed after verification prompt');
+    assert.equal(ctx.session.executor.verification.courier.status, 'collecting');
+  });
+
   it('starts driver verification after confirming the work city', async () => {
     const setChatCommandsMock = mock.method(
       commandsService,


### PR DESCRIPTION
## Summary
- ensure executor city callbacks render the menu when the city prompt was acknowledged without a pending marker
- normalise executor state before showing the menu so verification flow can resume
- add regression test covering courier flow when pending city action is missing

## Testing
- npm test -- tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7f266de94832dab8a69240a022cff