### PR TITLE
Prevent executor photo albums from falling through to other handlers

### DIFF
--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -779,7 +779,6 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
       'media_group_id' in message &&
       typeof (message as { media_group_id?: unknown }).media_group_id === 'string'
     ) {
-      await next();
       return;
     }
 


### PR DESCRIPTION
## Summary
- stop the executor verification photo middleware from delegating album messages to downstream handlers
- add a harness that wires verification and subscription flows together and exercises album + receipt handling
- ensure subscription receipt uploads still route to the subscription middleware when awaiting a payment

## Testing
- node --require ts-node/register --test --test-concurrency=1 tests/bot/executorVerification.test.ts tests/executor-verification.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8048419c0832dac98f82707990d07