### PR TITLE
Handle verification gate command passthrough

### DIFF
--- a/src/bot/middlewares/verificationGate.ts
+++ b/src/bot/middlewares/verificationGate.ts
@@ -60,14 +60,23 @@ export const ensureVerifiedExecutor: MiddlewareFn<BotContext> = async (ctx, next
   }
 
   const message = ctx.message;
-  const hasPhoto = message && 'photo' in message && Array.isArray(message.photo) && message.photo.length > 0;
+  const hasPhoto =
+    message && 'photo' in message && Array.isArray(message.photo) && message.photo.length > 0;
+  const messageText = message && 'text' in message ? message.text : undefined;
+  const isCommand = typeof messageText === 'string' && messageText.startsWith('/');
 
   if (executorState?.status === 'collecting' && hasPhoto) {
     await next();
     return;
   }
 
+  if (executorState?.status === 'collecting' && isCommand) {
+    await next();
+    return;
+  }
+
   if (executorState?.status === 'collecting') {
+    await startExecutorVerification(ctx);
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow the verification gate to re-prompt executors when they send non-photo updates during collection
- whitelist command messages such as /start while collecting so they reach downstream handlers
- extend middleware tests to cover both the re-prompt and command pass-through behaviours

## Testing
- node --require ts-node/register --test tests/verification-gate.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8106feed0832d913cc4f9f1094f7e