### PR TITLE
Fix executor role handling for clients

### DIFF
--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -87,7 +87,12 @@ export const handleStart = async (ctx: BotContext): Promise<void> => {
   await hideClientMenu(ctx, 'Возвращаю стандартную клавиатуру…');
 
   const executorState = ensureExecutorState(ctx);
-  const verification = executorState.verification[executorState.role];
+  const role = executorState.role;
+  if (!role) {
+    await presentRoleSelection(ctx);
+    return;
+  }
+  const verification = executorState.verification[role];
   if (verification.status === 'collecting') {
     await startExecutorVerification(ctx);
     return;

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -40,7 +40,7 @@ const createSubscriptionState = (): ExecutorSubscriptionState => ({
 });
 
 const createExecutorState = (): ExecutorFlowState => ({
-  role: 'courier',
+  role: undefined,
   verification: createVerificationState(),
   subscription: createSubscriptionState(),
 });
@@ -78,6 +78,8 @@ const rebuildExecutorState = (value: unknown): ExecutorFlowState => {
 
   if (isExecutorRole(executor.role)) {
     state.role = executor.role;
+  } else {
+    state.role = undefined;
   }
 
   if (executor.subscription && typeof executor.subscription === 'object') {

--- a/src/bot/services/verify.ts
+++ b/src/bot/services/verify.ts
@@ -39,11 +39,15 @@ export const buildVerificationSummary = (
   options: VerificationSummaryOptions = {},
 ): string => {
   const applicant = ctx.auth.user;
-  const copy = getExecutorRoleCopy(state.role);
-  const verification = state.verification[state.role];
+  const role = state.role;
+  if (!role) {
+    throw new Error('Cannot build verification summary without executor role');
+  }
+  const copy = getExecutorRoleCopy(role);
+  const verification = state.verification[role];
   const lines = [
     `🆕 Новая заявка на верификацию ${copy.genitive}.`,
-    `Роль: ${copy.noun} (${state.role})`,
+    `Роль: ${copy.noun} (${role})`,
     `Telegram ID: ${ctx.from?.id ?? 'неизвестно'}`,
   ];
 
@@ -80,7 +84,11 @@ export const remainingVerificationCooldown = (
   now = Date.now(),
   cooldownMs = DEFAULT_COOLDOWN_MS,
 ): number => {
-  const verification = state.verification[state.role];
+  const role = state.role;
+  if (!role) {
+    return 0;
+  }
+  const verification = state.verification[role];
   if (!verification.submittedAt) {
     return 0;
   }

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -104,7 +104,7 @@ export interface ExecutorSubscriptionState {
 export type ExecutorVerificationState = Record<ExecutorRole, ExecutorVerificationRoleState>;
 
 export interface ExecutorFlowState {
-  role: ExecutorRole;
+  role?: ExecutorRole;
   verification: ExecutorVerificationState;
   subscription: ExecutorSubscriptionState;
 }


### PR DESCRIPTION
## Summary
- derive the executor session role from the authenticated user and clear it for clients while introducing a helper to require a valid executor role
- guard executor menu, orders, subscription, verification, and start flows so they skip executor logic when the user lacks an executor role
- extend the executor role selection test to confirm clients changing cities stay in the client flow without seeing executor verification copy

## Testing
- node --require ts-node/register --test tests/executor-role-select.test.ts
- node --require ts-node/register --test tests/executor-access.test.ts
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8124e97e0832da26b469cb976c7b8