### PR TITLE
Route /menu to client menu for non-executors

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -141,7 +141,7 @@ const applyClientRole = async (ctx: BotContext): Promise<void> => {
   }
 };
 
-const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> => {
+export const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> => {
   const role = ctx.auth?.user.role;
   if (!isClientChat(ctx, role)) {
     if (ctx.callbackQuery) {

--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -24,6 +24,7 @@ import {
 } from './verification';
 import { CITY_LABEL } from '../../../domain/cities';
 import { CITY_ACTION_PATTERN, ensureCitySelected } from '../common/citySelect';
+import { showMenu } from '../client/menu';
 
 export const EXECUTOR_VERIFICATION_ACTION = 'executor:verification:start';
 export const EXECUTOR_SUBSCRIPTION_ACTION = 'executor:subscription:link';
@@ -636,6 +637,14 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
 
   bot.command('menu', async (ctx) => {
     if (ctx.chat?.type !== 'private') {
+      return;
+    }
+
+    const role = ctx.auth.user.role;
+    const isExecutor = role === 'courier' || role === 'driver';
+
+    if (!isExecutor) {
+      await showMenu(ctx);
       return;
     }
 

--- a/tests/menu-command-routing.test.ts
+++ b/tests/menu-command-routing.test.ts
@@ -1,0 +1,205 @@
+import './helpers/setup-env';
+
+import assert from 'node:assert/strict';
+import { before, describe, it, mock } from 'node:test';
+import type { Telegraf } from 'telegraf';
+
+import {
+  EXECUTOR_VERIFICATION_PHOTO_COUNT,
+  type BotContext,
+  type SessionState,
+} from '../src/bot/types';
+
+let executorMenuModule: typeof import('../src/bot/flows/executor/menu');
+let clientMenuModule: typeof import('../src/bot/flows/client/menu');
+let registerExecutorMenu: typeof import('../src/bot/flows/executor/menu')['registerExecutorMenu'];
+
+before(async () => {
+  process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? 'test-token';
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? 'postgres://user:pass@localhost:5432/db';
+  process.env.CITY_DEFAULT = process.env.CITY_DEFAULT ?? 'Алматы';
+  process.env.KASPI_CARD = process.env.KASPI_CARD ?? '4400 0000 0000 0000';
+  process.env.KASPI_NAME = process.env.KASPI_NAME ?? 'Freedom Bot';
+  process.env.KASPI_PHONE = process.env.KASPI_PHONE ?? '+7 (700) 000-00-00';
+  process.env.DRIVERS_CHANNEL_INVITE =
+    process.env.DRIVERS_CHANNEL_INVITE ?? 'https://t.me/+freedom-bot-drivers';
+  process.env.SUB_PRICE_7 = process.env.SUB_PRICE_7 ?? '5000';
+  process.env.SUB_PRICE_15 = process.env.SUB_PRICE_15 ?? '9000';
+  process.env.SUB_PRICE_30 = process.env.SUB_PRICE_30 ?? '16000';
+
+  executorMenuModule = await import('../src/bot/flows/executor/menu');
+  clientMenuModule = await import('../src/bot/flows/client/menu');
+  ({ registerExecutorMenu } = executorMenuModule);
+});
+
+const DEFAULT_CITY = 'almaty' as const;
+
+const createSessionState = (): SessionState => ({
+  ephemeralMessages: [],
+  isAuthenticated: true,
+  awaitingPhone: false,
+  phoneNumber: undefined,
+  user: undefined,
+  city: DEFAULT_CITY,
+  executor: {
+    role: undefined,
+    verification: {
+      courier: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+      driver: {
+        status: 'idle',
+        requiredPhotos: EXECUTOR_VERIFICATION_PHOTO_COUNT,
+        uploadedPhotos: [],
+      },
+    },
+    subscription: { status: 'idle' },
+  },
+  client: {
+    taxi: { stage: 'idle' },
+    delivery: { stage: 'idle' },
+  },
+  ui: { steps: {}, homeActions: [] },
+  support: { status: 'idle' },
+});
+
+const createAuthState = (role: BotContext['auth']['user']['role']): BotContext['auth'] => ({
+  user: {
+    telegramId: 101,
+    username: undefined,
+    firstName: undefined,
+    lastName: undefined,
+    phone: undefined,
+    phoneVerified: false,
+    role,
+    status: role === 'client' || role === 'moderator' ? 'active_client' : 'active_executor',
+    isVerified: false,
+    isBlocked: false,
+    citySelected: DEFAULT_CITY,
+  },
+  executor: {
+    verifiedRoles: { courier: false, driver: false },
+    hasActiveSubscription: false,
+    isVerified: false,
+  },
+  isModerator: role === 'moderator',
+});
+
+const createContext = (role: BotContext['auth']['user']['role']): BotContext => {
+  const session = createSessionState();
+  session.executor.role = role === 'courier' || role === 'driver' ? role : undefined;
+
+  const auth = createAuthState(role);
+
+  return {
+    chat: { id: 77, type: 'private' },
+    from: { id: auth.user.telegramId },
+    session,
+    auth,
+    reply: async () => ({
+      message_id: 1,
+      chat: { id: 77, type: 'private' },
+      date: Math.floor(Date.now() / 1000),
+      text: 'ok',
+    }),
+    telegram: {
+      sendMessage: async () => ({
+        message_id: 1,
+        chat: { id: 77, type: 'private' },
+        date: Math.floor(Date.now() / 1000),
+        text: 'ok',
+      }),
+      editMessageText: async () => true,
+      deleteMessage: async () => true,
+      setMyCommands: async () => undefined,
+      setChatMenuButton: async () => undefined,
+    },
+    answerCbQuery: async () => undefined,
+    deleteMessage: async () => true,
+    editMessageReplyMarkup: async () => undefined,
+    update: {} as never,
+    updateType: 'message',
+    botInfo: {} as never,
+    state: {},
+  } as unknown as BotContext;
+};
+
+const createMockBot = () => {
+  const commands = new Map<string, (ctx: BotContext) => Promise<void>>();
+
+  const bot: Partial<Telegraf<BotContext>> = {
+    telegram: {
+      setMyCommands: async () => undefined,
+      setChatMenuButton: async () => undefined,
+    } as unknown as Telegraf<BotContext>['telegram'],
+  };
+
+  bot.action = ((() => bot) as unknown) as Telegraf<BotContext>['action'];
+  bot.hears = ((() => bot) as unknown) as Telegraf<BotContext>['hears'];
+  bot.command = (((command: string, handler: (ctx: BotContext) => Promise<void>) => {
+    commands.set(command, handler);
+    return bot as Telegraf<BotContext>;
+  }) as unknown) as Telegraf<BotContext>['command'];
+
+  return {
+    bot: bot as Telegraf<BotContext>,
+    getCommand: (name: string) => commands.get(name),
+  };
+};
+
+describe("/menu command routing", () => {
+  it('shows the executor menu for couriers', async () => {
+    const showExecutorMenuMock = mock.method(
+      executorMenuModule,
+      'showExecutorMenu',
+      async () => undefined,
+    );
+    const showClientMenuMock = mock.method(clientMenuModule, 'showMenu', async () => undefined);
+
+    const { bot, getCommand } = createMockBot();
+    registerExecutorMenu(bot);
+
+    const handler = getCommand('menu');
+    assert.ok(handler, 'menu command should be registered');
+
+    try {
+      const ctx = createContext('courier');
+      await handler(ctx);
+
+      assert.equal(showExecutorMenuMock.mock.callCount(), 1);
+      assert.equal(showClientMenuMock.mock.callCount(), 0);
+    } finally {
+      showExecutorMenuMock.mock.restore();
+      showClientMenuMock.mock.restore();
+    }
+  });
+
+  it('shows the client menu for client users', async () => {
+    const showExecutorMenuMock = mock.method(
+      executorMenuModule,
+      'showExecutorMenu',
+      async () => undefined,
+    );
+    const showClientMenuMock = mock.method(clientMenuModule, 'showMenu', async () => undefined);
+
+    const { bot, getCommand } = createMockBot();
+    registerExecutorMenu(bot);
+
+    const handler = getCommand('menu');
+    assert.ok(handler, 'menu command should be registered');
+
+    try {
+      const ctx = createContext('client');
+      await handler(ctx);
+
+      assert.equal(showExecutorMenuMock.mock.callCount(), 0);
+      assert.equal(showClientMenuMock.mock.callCount(), 1);
+    } finally {
+      showExecutorMenuMock.mock.restore();
+      showClientMenuMock.mock.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- guard the executor /menu handler so only executors reach the executor menu
- reuse the client menu presenter for non-executor users invoking /menu
- cover the routing logic with a dedicated test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d817ae532c832da20ef5e90bdaddbc