### PR TITLE
Preserve executor role during guest fallback

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -201,7 +201,13 @@ export const ensureExecutorState = (ctx: BotContext): ExecutorFlowState => {
       subscription: createSubscriptionState(),
     } satisfies ExecutorFlowState;
   } else {
-    ctx.session.executor.role = derivedRole;
+    if (derivedRole !== undefined) {
+      ctx.session.executor.role = derivedRole;
+    } else if (ctx.session.isAuthenticated === false && ctx.auth.user.role === 'guest') {
+      // Preserve the existing executor role when auth falls back to the guest context.
+    } else {
+      ctx.session.executor.role = undefined;
+    }
     ctx.session.executor.verification = normaliseVerificationState(
       ctx.session.executor.verification,
     );


### PR DESCRIPTION
## Summary
- guard `ensureExecutorState` so the session executor role is only cleared when we know the authenticated user is not an executor, preserving the cached role during guest fallbacks
- cover the guest fallback case in executor role selection tests to ensure verification and menu flows still run using the stored role
- adjust city selection test setup to keep executor menu routing active when the pending action is tracked

## Testing
- `node --require ts-node/register --test --test-reporter spec tests/executor-role-select.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d827574258832dbce376edbb7a5e37