### PR TITLE
Handle guest fallback for executor menu

### DIFF
--- a/tests/menu-command-routing.test.ts
+++ b/tests/menu-command-routing.test.ts
@@ -179,6 +179,35 @@ describe("/menu command routing", () => {
     }
   });
 
+  it('shows the executor menu when auth falls back to guest but the session has executor role', async () => {
+    const showExecutorMenuMock = mock.method(
+      executorMenuModule,
+      'showExecutorMenu',
+      async () => undefined,
+    );
+    const showClientMenuMock = mock.method(clientMenuModule, 'showMenu', async () => undefined);
+
+    const { bot, getCommand } = createMockBot();
+    registerExecutorMenu(bot);
+
+    const handler = getCommand('menu');
+    assert.ok(handler, 'menu command should be registered');
+
+    const ctx = createContext('guest');
+    ctx.session.isAuthenticated = false;
+    ctx.session.executor.role = 'courier';
+
+    try {
+      await handler(ctx);
+
+      assert.equal(showExecutorMenuMock.mock.callCount(), 1);
+      assert.equal(showClientMenuMock.mock.callCount(), 0);
+    } finally {
+      showExecutorMenuMock.mock.restore();
+      showClientMenuMock.mock.restore();
+    }
+  });
+
   it('shows the client menu for client users', async () => {
     const showExecutorMenuMock = mock.method(
       executorMenuModule,


### PR DESCRIPTION
## Summary
- add a helper that preserves executor detection when auth temporarily reports a guest
- rely on the helper in the executor city action guard and /menu command so cached executor roles still reach the executor menu
- cover guest fallbacks for executor menu routing in the menu command and city callback tests

## Testing
- TS_NODE_TRANSPILE_ONLY=1 node --require ts-node/register --test --test-concurrency=1 tests/menu-command-routing.test.ts tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8400fc1f4832d8d3189ca5c2b7ffd