### PR TITLE
Handle guest executor fallback in menu flow

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -175,9 +175,25 @@ const normaliseSubscriptionState = (
   lastReminderAt: normaliseReminderTimestamp(value?.lastReminderAt),
 });
 
+const isExecutorRole = (role: AuthUser['role'] | ExecutorRole | undefined): role is ExecutorRole =>
+  role === 'courier' || role === 'driver';
+
+export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
+  const authRole = ctx.auth.user.role;
+  if (isExecutorRole(authRole)) {
+    return true;
+  }
+
+  if (ctx.session.isAuthenticated === false && authRole === 'guest') {
+    return isExecutorRole(ctx.session.executor?.role);
+  }
+
+  return false;
+};
+
 const deriveAuthExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
   const authRole = ctx.auth.user.role;
-  if (authRole === 'courier' || authRole === 'driver') {
+  if (isExecutorRole(authRole)) {
     return authRole;
   }
 
@@ -618,11 +634,9 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     const pendingCityAction = ctx.session.ui?.pendingCityAction;
-    const userRole = ctx.auth.user.role;
-    const hasExecutorRole = userRole === 'courier' || userRole === 'driver';
-
     const shouldShowExecutorMenu =
-      pendingCityAction === EXECUTOR_MENU_CITY_ACTION || (!pendingCityAction && hasExecutorRole);
+      pendingCityAction === EXECUTOR_MENU_CITY_ACTION ||
+      (!pendingCityAction && userLooksLikeExecutor(ctx));
 
     if (!shouldShowExecutorMenu) {
       return;
@@ -648,10 +662,7 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
       return;
     }
 
-    const role = ctx.auth.user.role;
-    const isExecutor = role === 'courier' || role === 'driver';
-
-    if (!isExecutor) {
+    if (!userLooksLikeExecutor(ctx)) {
       await showMenu(ctx);
       return;
     }

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -444,6 +444,47 @@ describe('executor role selection', () => {
     assert.equal(ctx.session.executor.role, 'courier');
   });
 
+  it('shows the executor menu when auth reports guest but the cached executor role is available', async () => {
+    const setUserCitySelectedMock = mock.method(
+      usersService,
+      'setUserCitySelected',
+      async () => undefined,
+    );
+
+    const { bot, dispatchAction } = createMockBot();
+    registerCityAction(bot);
+    registerExecutorMenu(bot);
+    registerExecutorVerification(bot);
+
+    const { ctx } = createMockContext();
+    ctx.session.city = undefined;
+    ctx.auth.user.citySelected = undefined;
+    ctx.session.ui.pendingCityAction = undefined;
+
+    ctx.session.isAuthenticated = false;
+    ctx.auth.user.role = 'guest';
+    ctx.session.executor.role = 'courier';
+
+    Object.assign(ctx as BotContext & { callbackQuery?: typeof ctx.callbackQuery }, {
+      callbackQuery: {
+        data: 'city:almaty',
+        message: { message_id: 360, chat: ctx.chat },
+      } as typeof ctx.callbackQuery,
+    });
+
+    try {
+      await dispatchAction('city:almaty', ctx);
+    } finally {
+      setUserCitySelectedMock.mock.restore();
+    }
+
+    const menuStep = recordedSteps.find((step) => step.id === 'executor:menu:main');
+    assert.ok(
+      menuStep,
+      'executor menu should still be displayed when auth falls back to guest but session has executor role',
+    );
+  });
+
   it('keeps clients in the client menu when changing the city', async () => {
     const setUserCitySelectedMock = mock.method(
       usersService,


### PR DESCRIPTION
## Summary
- add a helper to recognise executor roles from either the auth state or the cached session fallback
- reuse the helper in the city callback and /menu command handlers so executors retain access during guest fallbacks
- cover the guest fallback scenario in the executor role selection tests

## Testing
- `npm test` *(fails: missing optional dependency ioredis in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83d85e340832dabccd87676a1e9fe