### PR TITLE
Allow executor menu access during guest auth fallback

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -181,6 +181,13 @@ const deriveAuthExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
     return authRole;
   }
 
+  if (ctx.session.isAuthenticated === false && ctx.auth.user.role === 'guest') {
+    const sessionRole = ctx.session.executor?.role;
+    if (sessionRole === 'courier' || sessionRole === 'driver') {
+      return sessionRole;
+    }
+  }
+
   return undefined;
 };
 
@@ -649,7 +656,16 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     const role = ctx.auth.user.role;
-    const isExecutor = role === 'courier' || role === 'driver';
+    let isExecutor = role === 'courier' || role === 'driver';
+
+    if (
+      !isExecutor &&
+      ctx.session.isAuthenticated === false &&
+      ctx.auth.user.role === 'guest'
+    ) {
+      const sessionRole = ctx.session.executor?.role;
+      isExecutor = sessionRole === 'courier' || sessionRole === 'driver';
+    }
 
     if (!isExecutor) {
       await showMenu(ctx);


### PR DESCRIPTION
## Summary
- allow executor role detection to reuse the session role when authentication temporarily reports a guest
- apply the same fallback when handling /menu and extend the executor role tests to drive the command path
- enhance the executor test harness with command dispatch support for the new scenario

## Testing
- node --require ts-node/register/transpile-only --test tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d83b242efc832da5d6c3088223d5e8