### PR TITLE
Ensure session cache fallback resets authentication flag

### DIFF
--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -345,6 +345,7 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
       client = await pool.connect();
     } catch (error) {
       ctx.session = cachedState ?? createDefaultState();
+      ctx.session.isAuthenticated = false;
       logger.warn({ err: error, key }, 'Failed to connect to database for session state');
 
       fallbackMode = true;
@@ -355,6 +356,7 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     const dbClient = client;
     if (!fallbackMode && !dbClient) {
       ctx.session = cachedState ?? createDefaultState();
+      ctx.session.isAuthenticated = false;
       logger.warn({ key }, 'Database client was not initialised for session state');
 
       fallbackMode = true;
@@ -371,6 +373,7 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
         state = existing ?? cachedState ?? createDefaultState();
       } catch (error) {
         ctx.session = cachedState ?? createDefaultState();
+        ctx.session.isAuthenticated = false;
         logger.warn({ err: error, key }, 'Failed to load session state, using default state');
 
         fallbackMode = true;


### PR DESCRIPTION
## Summary
- reset the session authentication flag whenever the middleware falls back to cached or default state
- cover the Redis fallback path to confirm the executor menu still renders during database outages

## Testing
- node --require ts-node/register --test --test-concurrency=1 tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d84c2afaac832d9c950ea6b600f89c