### PR TITLE
Preserve executor state via auth snapshot fallback

### DIFF
--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -704,8 +704,8 @@ describe('executor role selection', () => {
     assert.equal(ctx.session.isAuthenticated, false);
     assert.equal(ctx.session.authSnapshot?.stale, true);
     assert.equal(ctx.session.authSnapshot?.status, 'active_executor');
-    assert.equal(ctx.auth.user.role, 'courier');
-    assert.equal(ctx.auth.user.status, 'active_executor');
+    assert.equal(ctx.auth.user.role, 'guest');
+    assert.equal(ctx.auth.user.status, 'guest');
     assert.equal(ctx.auth.executor.verifiedRoles.courier, true);
     assert.equal(ctx.auth.executor.hasActiveSubscription, true);
     assert.equal(ctx.auth.executor.isVerified, true);


### PR DESCRIPTION
## Summary
- hydrate cached auth snapshots without elevating roles while keeping session metadata and executor flags intact
- treat cached executor roles as fallback context when auth returns a guest and adjust helper heuristics accordingly
- add regression coverage for cached snapshot flows during /menu and city actions and update executor role selection expectations

## Testing
- node --require ts-node/register --test tests/auth-middleware.test.ts
- node --require ts-node/register --test tests/menu-command-routing.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d85049d36c832d8a276e8e1edd501d