### PR TITLE
Persist auth snapshot and fallback on query errors

### DIFF
--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -178,7 +178,7 @@ export interface SessionState {
   phoneNumber?: string;
   user?: SessionUser;
   city?: AppCity;
-  authSnapshot?: AuthStateSnapshot;
+  authSnapshot: AuthStateSnapshot;
   executor: ExecutorFlowState;
   client: ClientFlowState;
   ui: UiSessionState;

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -23,6 +23,17 @@ const createSessionState = (): BotContext['session'] => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest' as const,
+    status: 'guest' as const,
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {
@@ -200,6 +211,8 @@ describe('auth middleware', () => {
     assert.equal(ctx.auth.user.telegramId, 777);
     assert.equal(ctx.auth.user.username, 'guestuser');
     assert.equal(ctx.session.isAuthenticated, false);
+    assert.equal(ctx.session.authSnapshot.stale, true);
+    assert.equal(ctx.session.authSnapshot.role, 'guest');
     assert.equal(ctx.session.user?.id, 777);
     assert.equal(ctx.session.user?.username, 'guestuser');
     assert.equal(replyCalled, false);

--- a/tests/bot/executorMenu.test.ts
+++ b/tests/bot/executorMenu.test.ts
@@ -38,6 +38,17 @@ const createSessionState = (): SessionState => ({
   phoneNumber: undefined,
   user: undefined,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/bot/executorVerification.test.ts
+++ b/tests/bot/executorVerification.test.ts
@@ -27,6 +27,17 @@ const createSessionState = (): SessionState => ({
   awaitingPhone: false,
   city: DEFAULT_CITY,
   user: { id: 710, phoneVerified: true },
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/bot/order-publish-failure.test.ts
+++ b/tests/bot/order-publish-failure.test.ts
@@ -68,6 +68,17 @@ const createBaseContext = () => {
     awaitingPhone: false,
     phoneNumber: '+77001234567',
     city: 'almaty',
+    authSnapshot: {
+      role: 'guest',
+      status: 'guest',
+      executor: {
+        verifiedRoles: { courier: false, driver: false },
+        hasActiveSubscription: false,
+        isVerified: false,
+      },
+      city: undefined,
+      stale: false,
+    },
     executor: {
       role: 'courier',
       verification: {

--- a/tests/client-fallback.test.ts
+++ b/tests/client-fallback.test.ts
@@ -14,6 +14,17 @@ const createSessionState = () => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest' as const,
+    status: 'guest' as const,
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier' as const,
     verification: {

--- a/tests/client-menu.test.ts
+++ b/tests/client-menu.test.ts
@@ -46,6 +46,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: false,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/client-support.test.ts
+++ b/tests/client-support.test.ts
@@ -13,6 +13,17 @@ const createSessionState = () => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest' as const,
+    status: 'guest' as const,
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/executor-access.test.ts
+++ b/tests/executor-access.test.ts
@@ -51,6 +51,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: false,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -69,6 +69,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: false,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {
@@ -719,10 +730,10 @@ describe('executor role selection', () => {
     const menuStep = recordedSteps.find((step) => step.id === 'executor:menu:main');
     assert.ok(menuStep, 'executor menu should be displayed after auth snapshot fallback');
     assert.equal(ctx.session.isAuthenticated, false);
-    assert.equal(ctx.session.authSnapshot?.stale, true);
-    assert.equal(ctx.session.authSnapshot?.status, 'active_executor');
-    assert.equal(ctx.auth.user.role, 'guest');
-    assert.equal(ctx.auth.user.status, 'guest');
+    assert.equal(ctx.session.authSnapshot.stale, true);
+    assert.equal(ctx.session.authSnapshot.status, 'active_executor');
+    assert.equal(ctx.auth.user.role, 'courier');
+    assert.equal(ctx.auth.user.status, 'active_executor');
     assert.equal(ctx.auth.executor.verifiedRoles.courier, true);
     assert.equal(ctx.auth.executor.hasActiveSubscription, true);
     assert.equal(ctx.auth.executor.isVerified, true);

--- a/tests/executor-verification.test.ts
+++ b/tests/executor-verification.test.ts
@@ -18,6 +18,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: false,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/menu-command-routing.test.ts
+++ b/tests/menu-command-routing.test.ts
@@ -44,6 +44,17 @@ const createSessionState = (): SessionState => ({
   phoneNumber: undefined,
   user: undefined,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: undefined,
     verification: {
@@ -351,12 +362,12 @@ describe("/menu command routing", () => {
       await authMiddleware(ctx, async () => {});
 
       assert.equal(ctx.session.isAuthenticated, false);
-      assert.equal(ctx.session.authSnapshot?.stale, true);
-      assert.equal(ctx.session.authSnapshot?.executor.verifiedRoles.courier, true);
-      assert.equal(ctx.session.authSnapshot?.executor.hasActiveSubscription, true);
-      assert.equal(ctx.session.authSnapshot?.status, 'active_executor');
-      assert.equal(ctx.auth.user.role, 'guest');
-      assert.equal(ctx.auth.user.status, 'guest');
+      assert.equal(ctx.session.authSnapshot.stale, true);
+      assert.equal(ctx.session.authSnapshot.executor.verifiedRoles.courier, true);
+      assert.equal(ctx.session.authSnapshot.executor.hasActiveSubscription, true);
+      assert.equal(ctx.session.authSnapshot.status, 'active_executor');
+      assert.equal(ctx.auth.user.role, 'courier');
+      assert.equal(ctx.auth.user.status, 'active_executor');
       assert.equal(ctx.auth.executor.verifiedRoles.courier, true);
       assert.equal(ctx.auth.executor.hasActiveSubscription, true);
       assert.equal(ctx.auth.executor.isVerified, true);
@@ -446,7 +457,8 @@ describe("/menu command routing", () => {
     try {
       await authMiddleware(ctx, async () => {});
 
-      assert.equal(ctx.auth.user.role, 'guest');
+      assert.equal(ctx.auth.user.role, 'courier');
+      assert.equal(ctx.auth.user.status, 'active_executor');
       assert.equal(ctx.session.isAuthenticated, false);
 
       await handler(ctx);

--- a/tests/payment-reminder.job.test.ts
+++ b/tests/payment-reminder.job.test.ts
@@ -49,6 +49,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: true,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/phone-collect.test.ts
+++ b/tests/phone-collect.test.ts
@@ -16,6 +16,17 @@ const createSessionState = (): SessionState => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/start-contact-flow.test.ts
+++ b/tests/start-contact-flow.test.ts
@@ -27,6 +27,17 @@ const createSessionState = () => ({
   awaitingPhone: false,
   phoneNumber: undefined as string | undefined,
   user: { id: 1001, phoneVerified: false },
+  authSnapshot: {
+    role: 'guest' as const,
+    status: 'guest' as const,
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier' as const,
     verification: {

--- a/tests/state-gate.test.ts
+++ b/tests/state-gate.test.ts
@@ -11,6 +11,17 @@ const createSessionState = (): SessionState => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -128,6 +128,17 @@ const createSessionState = (): BotContext['session'] => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest' as const,
+    status: 'guest' as const,
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -31,6 +31,17 @@ const createSessionState = (): SessionState => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   awaitingPhone: false,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {

--- a/tests/verification-gate.test.ts
+++ b/tests/verification-gate.test.ts
@@ -20,6 +20,17 @@ const createSessionState = (): SessionState => ({
   isAuthenticated: false,
   awaitingPhone: false,
   city: DEFAULT_CITY,
+  authSnapshot: {
+    role: 'guest',
+    status: 'guest',
+    executor: {
+      verifiedRoles: { courier: false, driver: false },
+      hasActiveSubscription: false,
+      isVerified: false,
+    },
+    city: undefined,
+    stale: false,
+  },
   executor: {
     role: 'courier',
     verification: {


### PR DESCRIPTION
## Summary
- require session auth snapshots and initialise defaults across tests
- reuse cached auth snapshots after database failures and mark fallback states as stale
- add executor menu and city routing coverage for snapshot-backed authentication failures

## Testing
- node --require ts-node/register --test tests/menu-command-routing.test.ts tests/executor-role-select.test.ts tests/bot/order-publish-failure.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d857faeaac832dbd2cf137a708c7b2