### PR TITLE
Ensure fallback sessions remain unauthenticated

### DIFF
--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -468,6 +468,9 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   }
 
   try {
+    if (fallbackMode) {
+      finalState.isAuthenticated = false;
+    }
     await saveSessionCache(key, finalState);
   } catch (error) {
     logger.warn({ err: error, key }, 'Failed to persist session cache');

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -499,6 +499,69 @@ describe('executor role selection', () => {
     assert.equal(savedState.executor.role, 'courier');
   });
 
+  it('persists an unauthenticated default session when Redis fallback bootstraps state', async () => {
+    const { bot, dispatchAction } = createMockBot();
+    registerExecutorMenu(bot);
+
+    const { ctx } = createMockContext();
+    ctx.auth.user.role = 'guest';
+    ctx.auth.executor.verifiedRoles.courier = true;
+    ctx.auth.executor.hasActiveSubscription = true;
+    ctx.auth.executor.isVerified = true;
+    ctx.auth.user.citySelected = DEFAULT_CITY;
+
+    Object.assign(ctx as BotContext & { callbackQuery?: typeof ctx.callbackQuery }, {
+      callbackQuery: {
+        data: EXECUTOR_MENU_ACTION,
+        message: { message_id: 991, chat: ctx.chat },
+      } as typeof ctx.callbackQuery,
+    });
+
+    const loadCacheMock = mock.method(sessionCache, 'loadSessionCache', async () => null);
+    const saveCacheMock = mock.method(sessionCache, 'saveSessionCache', async () => undefined);
+    const connectMock = mock.method(pool, 'connect', async () => {
+      throw new Error('database offline');
+    });
+    const showExecutorMenuMock = mock.method(
+      executorMenuModule,
+      'showExecutorMenu',
+      async () => undefined,
+    );
+
+    const sessionMiddleware = sessionMiddlewareFactory();
+
+    let cachedCalls: typeof saveCacheMock.mock.calls = [];
+    let showExecutorCallCount = 0;
+
+    try {
+      await sessionMiddleware(ctx, async () => {
+        ctx.session.executor.role = 'courier';
+        await dispatchAction(EXECUTOR_MENU_ACTION, ctx);
+      });
+      cachedCalls = saveCacheMock.mock.calls;
+      showExecutorCallCount = showExecutorMenuMock.mock.callCount();
+    } finally {
+      connectMock.mock.restore();
+      loadCacheMock.mock.restore();
+      saveCacheMock.mock.restore();
+      showExecutorMenuMock.mock.restore();
+    }
+
+    assert.equal(
+      showExecutorCallCount,
+      1,
+      'executor menu should render when fallback creates a default session state',
+    );
+    assert.equal(ctx.session.executor.role, 'courier');
+    assert.equal(ctx.session.isAuthenticated, false);
+
+    const lastCall = cachedCalls.at(-1);
+    assert.ok(lastCall, 'fallback session should be cached after request');
+    const savedState = lastCall.arguments[1] as SessionState;
+    assert.equal(savedState.isAuthenticated, false);
+    assert.equal(savedState.executor.role, 'courier');
+  });
+
   it('keeps clients in the client menu when the executor refresh action is used', async () => {
     const { bot, dispatchAction } = createMockBot();
     registerExecutorMenu(bot);


### PR DESCRIPTION
## Summary
- force fallback session branches to reset authentication state before using cached or default data
- prevent fallback persistence from writing authenticated flags and cover the behavior with executor menu tests

## Testing
- node --require ts-node/register --test --test-concurrency=1 --test-name-pattern="Redis fallback" tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d85b6fd0fc832d88fd46643ffe3469