### PR TITLE
Preserve auth snapshot during query failures

### DIFF
--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -513,6 +513,9 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
         stale: true,
       } satisfies AuthStateSnapshot;
 
+      ctx.session.isAuthenticated = false;
+      ctx.session.authSnapshot = snapshot;
+
       const authState = buildAuthStateFromSnapshot(ctx, snapshot);
       applyAuthState(ctx, authState, { isAuthenticated: false, isStale: true });
       logger.warn(

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -176,6 +176,12 @@ describe('auth middleware', () => {
     assert.equal(ctx.session.isAuthenticated, true);
     assert.equal(ctx.auth.user.telegramId, 321);
     assert.equal(ctx.auth.user.username, 'authuser');
+    assert.equal(ctx.session.authSnapshot.role, 'courier');
+    assert.equal(ctx.session.authSnapshot.status, 'active_executor');
+    assert.equal(ctx.session.authSnapshot.executor.verifiedRoles.courier, true);
+    assert.equal(ctx.session.authSnapshot.executor.hasActiveSubscription, true);
+    assert.equal(ctx.session.authSnapshot.executor.isVerified, true);
+    assert.equal(ctx.session.authSnapshot.stale, false);
     assert.equal(ctx.session.user?.id, 321);
     assert.equal(ctx.session.phoneNumber, '+7 700 000 00 00');
   });

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -795,6 +795,10 @@ describe('executor role selection', () => {
     assert.equal(ctx.session.isAuthenticated, false);
     assert.equal(ctx.session.authSnapshot.stale, true);
     assert.equal(ctx.session.authSnapshot.status, 'active_executor');
+    assert.equal(ctx.session.authSnapshot.role, 'courier');
+    assert.equal(ctx.session.authSnapshot.executor.verifiedRoles.courier, true);
+    assert.equal(ctx.session.authSnapshot.executor.hasActiveSubscription, true);
+    assert.equal(ctx.session.authSnapshot.executor.isVerified, true);
     assert.equal(ctx.auth.user.role, 'courier');
     assert.equal(ctx.auth.user.status, 'active_executor');
     assert.equal(ctx.auth.executor.verifiedRoles.courier, true);


### PR DESCRIPTION
## Summary
- mark sessions unauthenticated and flag cached auth snapshots as stale when auth queries fail so fallbacks retain executor data
- assert snapshot contents after successful auth hydration to prove role, status, and subscription flags are persisted
- extend executor flow regression tests to confirm cached snapshots keep menus rendering through auth outages

## Testing
- node --require ts-node/register --test tests/auth-middleware.test.ts tests/menu-command-routing.test.ts tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d85fd1f590832d8df2a4bcd5167e51