### PR TITLE
Fix executor city menu guest fallback

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -203,7 +203,7 @@ export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
   }
 
   if (ctx.session.isAuthenticated === false && authRole === 'guest') {
-    const sessionRole = ctx.session.executor?.role;
+    const sessionRole = getSessionExecutorRole(ctx);
     return isExecutorRole(sessionRole);
   }
 

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -892,9 +892,11 @@ describe('executor role selection', () => {
     ctx.session.ui.pendingCityAction = undefined;
     ctx.session.isAuthenticated = false;
     ctx.auth.user.role = 'guest';
+    ctx.auth.user.status = 'guest';
     ctx.session.executor.role = 'courier';
     ctx.auth.executor.verifiedRoles.courier = true;
     ctx.auth.executor.hasActiveSubscription = true;
+    ctx.session.authSnapshot.role = 'guest';
 
     Object.assign(ctx as BotContext & { callbackQuery?: typeof ctx.callbackQuery }, {
       callbackQuery: {
@@ -919,6 +921,11 @@ describe('executor role selection', () => {
       showExecutorMenuCallCount,
       1,
       'city callback should continue to render the executor menu during guest fallback',
+    );
+    assert.equal(
+      executorMenuModule.userLooksLikeExecutor(ctx),
+      true,
+      'guest fallback should still be recognised as an executor via session role',
     );
   });
 


### PR DESCRIPTION
## Summary
- reuse the executor role helper when auth temporarily falls back to guest
- extend the guest fallback city callback test to assert the helper and session role behaviour

## Testing
- node --require ts-node/register --test --test-concurrency=1 tests/executor-role-select.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8752b3858832d9ddfb5736b9bb0e4