### PR TITLE
Fix executor menu guest fallback

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -695,7 +695,14 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     const looksLikeExecutor = userLooksLikeExecutor(ctx);
-    if (!looksLikeExecutor) {
+    const cachedExecutorRole =
+      !looksLikeExecutor &&
+      ctx.session.isAuthenticated === false &&
+      ctx.auth.user.role === 'guest'
+        ? getCachedExecutorRole(ctx)
+        : undefined;
+
+    if (!looksLikeExecutor && !cachedExecutorRole) {
       await showMenu(ctx);
       return;
     }


### PR DESCRIPTION
## Summary
- ensure the `/menu` handler consults the cached executor role when auth reports a guest fallback
- keep routing to the client menu when no executor role can be recovered
- add a routing test that covers the cached snapshot guest fallback scenario

## Testing
- npm test -- tests/menu-command-routing.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8768ab264832da39fa3a476c113f0