### PR TITLE
Refactor executor session snapshot handling and fix tests

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -175,11 +175,6 @@ const normaliseSubscriptionState = (
   lastReminderAt: normaliseReminderTimestamp(value?.lastReminderAt),
 });
 
-<<<<<<< HEAD
-export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
-  const authRole = ctx.auth.user.role;
-  if (authRole === 'courier' || authRole === 'driver') {
-=======
 const isExecutorRole = (role: AuthUser['role'] | ExecutorRole | undefined): role is ExecutorRole =>
   role === 'courier' || role === 'driver';
 
@@ -204,18 +199,12 @@ const getCachedExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
 export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
   const authRole = ctx.auth.user.role;
   if (isExecutorRole(authRole)) {
->>>>>>> origin/main
     return true;
   }
 
   if (ctx.session.isAuthenticated === false && authRole === 'guest') {
-<<<<<<< HEAD
-    const sessionRole = ctx.session.executor?.role;
-    return sessionRole === 'courier' || sessionRole === 'driver';
-=======
     const sessionRole = getSessionExecutorRole(ctx);
     return isExecutorRole(sessionRole);
->>>>>>> origin/main
   }
 
   return false;
@@ -228,15 +217,9 @@ const deriveAuthExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
   }
 
   if (ctx.session.isAuthenticated === false && authRole === 'guest') {
-<<<<<<< HEAD
-    const sessionRole = ctx.session.executor?.role;
-    if (sessionRole === 'courier' || sessionRole === 'driver') {
-      return sessionRole;
-=======
     const cachedRole = getCachedExecutorRole(ctx);
     if (isExecutorRole(cachedRole)) {
       return cachedRole;
->>>>>>> origin/main
     }
   }
 
@@ -677,16 +660,9 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     const pendingCityAction = ctx.session.ui?.pendingCityAction;
-<<<<<<< HEAD
-    const looksLikeExecutor = userLooksLikeExecutor(ctx);
-
-    const shouldShowExecutorMenu =
-      pendingCityAction === EXECUTOR_MENU_CITY_ACTION || (!pendingCityAction && looksLikeExecutor);
-=======
     const shouldShowExecutorMenu =
       pendingCityAction === EXECUTOR_MENU_CITY_ACTION ||
       (!pendingCityAction && userLooksLikeExecutor(ctx));
->>>>>>> origin/main
 
     if (!shouldShowExecutorMenu) {
       return;
@@ -703,12 +679,8 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     if (!userLooksLikeExecutor(ctx)) {
-<<<<<<< HEAD
-      await ctx.answerCbQuery('Доступно только для исполнителей.');
-=======
       await ctx.answerCbQuery();
       await showMenu(ctx);
->>>>>>> origin/main
       return;
     }
 
@@ -722,9 +694,6 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
       return;
     }
 
-<<<<<<< HEAD
-    if (!userLooksLikeExecutor(ctx)) {
-=======
     const looksLikeExecutor = userLooksLikeExecutor(ctx);
     const cachedExecutorRole =
       !looksLikeExecutor &&
@@ -734,7 +703,6 @@ export const registerExecutorMenu = (bot: Telegraf<BotContext>): void => {
         : undefined;
 
     if (!looksLikeExecutor && !cachedExecutorRole) {
->>>>>>> origin/main
       await showMenu(ctx);
       return;
     }

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -13,19 +13,11 @@ import {
   loadSessionCache,
   saveSessionCache,
 } from '../../infra/sessionCache';
-<<<<<<< HEAD
-=======
 import { isAppCity } from '../../domain/cities';
->>>>>>> origin/main
 import {
   EXECUTOR_ROLES,
   EXECUTOR_VERIFICATION_PHOTO_COUNT,
   type AuthStateSnapshot,
-<<<<<<< HEAD
-  type AuthStateSnapshotExecutor,
-  type AuthStateSnapshotUser,
-=======
->>>>>>> origin/main
   type BotContext,
   type ClientFlowState,
   type ClientOrderDraftState,
@@ -38,17 +30,9 @@ import {
   type SessionUser,
   type SupportSessionState,
   type UiSessionState,
-<<<<<<< HEAD
-  type UserMenuRole,
   type UserRole,
   type UserStatus,
-=======
-  type UserRole,
-  type UserStatus,
-  type ExecutorRole,
->>>>>>> origin/main
 } from '../types';
-import { isAppCity } from '../../domain/cities';
 
 const createVerificationState = (): ExecutorVerificationState => {
   const verification = {} as ExecutorVerificationState;
@@ -92,12 +76,6 @@ const createSupportState = (): SupportSessionState => ({
   status: 'idle',
 });
 
-<<<<<<< HEAD
-const createAuthSnapshot = (): AuthStateSnapshot => ({
-  stale: false,
-});
-
-=======
 const USER_ROLES: readonly UserRole[] = ['guest', 'client', 'courier', 'driver', 'moderator'];
 const USER_STATUSES: readonly UserStatus[] = [
   'guest',
@@ -191,133 +169,8 @@ const rebuildAuthSnapshot = (value: unknown, sessionUser?: SessionUser): AuthSta
 
   return snapshot;
 };
-
->>>>>>> origin/main
 const isExecutorRole = (value: unknown): value is ExecutorFlowState['role'] =>
   typeof value === 'string' && EXECUTOR_ROLES.includes(value as (typeof EXECUTOR_ROLES)[number]);
-
-const isUserRole = (value: unknown): value is UserRole =>
-  value === 'guest' || value === 'client' || value === 'courier' || value === 'driver' || value === 'moderator';
-
-const isUserStatus = (value: unknown): value is UserStatus =>
-  value === 'guest' ||
-  value === 'onboarding' ||
-  value === 'awaiting_phone' ||
-  value === 'active_client' ||
-  value === 'active_executor' ||
-  value === 'trial_expired' ||
-  value === 'suspended' ||
-  value === 'banned';
-
-const isUserMenuRole = (value: unknown): value is UserMenuRole =>
-  value === 'client' || value === 'courier' || value === 'moderator';
-
-const normaliseTimestamp = (value: unknown): number | undefined => {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number.parseInt(value, 10);
-    if (!Number.isNaN(parsed)) {
-      return parsed;
-    }
-  }
-
-  return undefined;
-};
-
-const normaliseAuthSnapshotUser = (value: unknown): AuthStateSnapshotUser | undefined => {
-  if (!value || typeof value !== 'object') {
-    return undefined;
-  }
-
-  const candidate = value as Partial<AuthStateSnapshotUser> & Record<string, unknown>;
-  const telegramId = typeof candidate.telegramId === 'number' ? candidate.telegramId : undefined;
-  if (telegramId === undefined || !Number.isFinite(telegramId)) {
-    return undefined;
-  }
-
-  const role = isUserRole(candidate.role) ? candidate.role : 'guest';
-  const status = isUserStatus(candidate.status) ? candidate.status : 'guest';
-  const phoneVerified = typeof candidate.phoneVerified === 'boolean' ? candidate.phoneVerified : false;
-  const isVerified = typeof candidate.isVerified === 'boolean' ? candidate.isVerified : false;
-  const isBlocked = typeof candidate.isBlocked === 'boolean' ? candidate.isBlocked : false;
-
-  const snapshot: AuthStateSnapshotUser = {
-    telegramId,
-    username: typeof candidate.username === 'string' ? candidate.username : undefined,
-    firstName: typeof candidate.firstName === 'string' ? candidate.firstName : undefined,
-    lastName: typeof candidate.lastName === 'string' ? candidate.lastName : undefined,
-    phone: typeof candidate.phone === 'string' ? candidate.phone : undefined,
-    phoneVerified,
-    role,
-    status,
-    isVerified,
-    isBlocked,
-    citySelected: isAppCity(candidate.citySelected) ? candidate.citySelected : undefined,
-    verifiedAt: normaliseTimestamp(candidate.verifiedAt),
-    trialEndsAt: normaliseTimestamp(candidate.trialEndsAt),
-    lastMenuRole: isUserMenuRole(candidate.lastMenuRole) ? candidate.lastMenuRole : undefined,
-    keyboardNonce: typeof candidate.keyboardNonce === 'string' ? candidate.keyboardNonce : undefined,
-  };
-
-  return snapshot;
-};
-
-const normaliseAuthSnapshotExecutor = (value: unknown): AuthStateSnapshotExecutor | undefined => {
-  if (!value || typeof value !== 'object') {
-    return undefined;
-  }
-
-  const candidate = value as Partial<AuthStateSnapshotExecutor> & Record<string, unknown>;
-  const verifiedRoles: Record<ExecutorRole, boolean> = { courier: false, driver: false };
-
-  const map = candidate.verifiedRoles;
-  if (map && typeof map === 'object') {
-    for (const role of EXECUTOR_ROLES) {
-      verifiedRoles[role] = Boolean((map as Record<string, unknown>)[role]);
-    }
-  } else {
-    for (const role of EXECUTOR_ROLES) {
-      verifiedRoles[role] = false;
-    }
-  }
-
-  return {
-    verifiedRoles: verifiedRoles as Record<ExecutorRole, boolean>,
-    hasActiveSubscription: Boolean(candidate.hasActiveSubscription),
-    isVerified: Boolean(candidate.isVerified),
-  } satisfies AuthStateSnapshotExecutor;
-};
-
-const rebuildAuthSnapshot = (value: unknown): AuthStateSnapshot => {
-  const snapshot = createAuthSnapshot();
-
-  if (!value || typeof value !== 'object') {
-    return snapshot;
-  }
-
-  const candidate = value as Partial<AuthStateSnapshot> & Record<string, unknown>;
-
-  const user = normaliseAuthSnapshotUser(candidate.user);
-  if (user) {
-    snapshot.user = user;
-  }
-
-  const executor = normaliseAuthSnapshotExecutor(candidate.executor);
-  if (executor) {
-    snapshot.executor = executor;
-  }
-
-  if (typeof candidate.isModerator === 'boolean') {
-    snapshot.isModerator = candidate.isModerator;
-  }
-
-  snapshot.stale = Boolean(candidate.stale);
-
-  return snapshot;
-};
 
 const rebuildExecutorState = (value: unknown): ExecutorFlowState => {
   const state = createExecutorState();
@@ -416,7 +269,10 @@ const normaliseSessionState = (state: SessionState): SessionState => {
 
   working.executor = rebuildExecutorState((working as { executor?: unknown }).executor);
   working.client = rebuildClientState((working as { client?: unknown }).client);
-  working.authSnapshot = rebuildAuthSnapshot((working as { authSnapshot?: unknown }).authSnapshot);
+  working.authSnapshot = rebuildAuthSnapshot(
+    (working as { authSnapshot?: unknown }).authSnapshot,
+    working.user,
+  );
 
   return working;
 };
@@ -431,14 +287,14 @@ const createDefaultState = (): SessionState => ({
   client: createClientState(),
   ui: createUiState(),
   support: createSupportState(),
-  authSnapshot: createAuthSnapshot(),
 });
 
 const prepareFallbackSession = (
   state: SessionState | null | undefined,
 ): SessionState => {
-  const session = state ?? createDefaultState();
+  const session = normaliseSessionState(state ?? createDefaultState());
   session.isAuthenticated = false;
+  session.authSnapshot.stale = true;
   return session;
 };
 
@@ -564,15 +420,8 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
     try {
       client = await pool.connect();
     } catch (error) {
-<<<<<<< HEAD
-      const fallbackState = normaliseSessionState(cachedState ?? createDefaultState());
-      fallbackState.isAuthenticated = false;
-      fallbackState.authSnapshot.stale = true;
-      ctx.session = fallbackState;
-=======
       const fallbackSession = prepareFallbackSession(cachedState);
       ctx.session = fallbackSession;
->>>>>>> origin/main
       logger.warn({ err: error, key }, 'Failed to connect to database for session state');
 
       fallbackMode = true;
@@ -582,15 +431,8 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
 
     const dbClient = client;
     if (!fallbackMode && !dbClient) {
-<<<<<<< HEAD
-      const fallbackState = normaliseSessionState(cachedState ?? createDefaultState());
-      fallbackState.isAuthenticated = false;
-      fallbackState.authSnapshot.stale = true;
-      ctx.session = fallbackState;
-=======
       const fallbackSession = prepareFallbackSession(cachedState);
       ctx.session = fallbackSession;
->>>>>>> origin/main
       logger.warn({ key }, 'Database client was not initialised for session state');
 
       fallbackMode = true;
@@ -606,15 +448,8 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
         const existing = await loadSessionState(activeClient, key);
         state = existing ?? cachedState ?? createDefaultState();
       } catch (error) {
-<<<<<<< HEAD
-        const fallbackState = normaliseSessionState(cachedState ?? createDefaultState());
-        fallbackState.isAuthenticated = false;
-        fallbackState.authSnapshot.stale = true;
-        ctx.session = fallbackState;
-=======
         const fallbackSession = prepareFallbackSession(cachedState);
         ctx.session = fallbackSession;
->>>>>>> origin/main
         logger.warn({ err: error, key }, 'Failed to load session state, using default state');
 
         fallbackMode = true;
@@ -629,31 +464,7 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
         state = cachedState ?? createDefaultState();
       }
 
-<<<<<<< HEAD
       ctx.session = normaliseSessionState(state);
-=======
-      if (!('city' in state)) {
-        state.city = undefined;
-      }
-
-      if (!state.ui) {
-        state.ui = createUiState();
-      }
-
-      if (!state.support) {
-        state.support = createSupportState();
-      }
-
-      state.authSnapshot = rebuildAuthSnapshot(
-        (state as { authSnapshot?: unknown }).authSnapshot,
-        (state as { user?: SessionUser }).user,
-      );
-
-      state.executor = rebuildExecutorState((state as { executor?: unknown }).executor);
-      state.client = rebuildClientState((state as { client?: unknown }).client);
-
-      ctx.session = state;
->>>>>>> origin/main
 
       await invokeNext();
       finalState = ctx.session;
@@ -703,12 +514,8 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
   }
 
   try {
-<<<<<<< HEAD
-    await saveSessionCache(key, finalState);
-=======
     const stateToCache = fallbackMode ? prepareFallbackSession(finalState) : finalState;
     await saveSessionCache(key, stateToCache);
->>>>>>> origin/main
   } catch (error) {
     logger.warn({ err: error, key }, 'Failed to persist session cache');
   }

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -55,37 +55,6 @@ export interface AuthExecutorState {
   isVerified: boolean;
 }
 
-export interface AuthStateSnapshotUser {
-  telegramId: number;
-  username?: string;
-  firstName?: string;
-  lastName?: string;
-  phone?: string;
-  phoneVerified: boolean;
-  role: UserRole;
-  status: UserStatus;
-  isVerified: boolean;
-  isBlocked: boolean;
-  citySelected?: AppCity;
-  verifiedAt?: number;
-  trialEndsAt?: number;
-  lastMenuRole?: UserMenuRole;
-  keyboardNonce?: string;
-}
-
-export interface AuthStateSnapshotExecutor {
-  verifiedRoles: Record<ExecutorRole, boolean>;
-  hasActiveSubscription: boolean;
-  isVerified: boolean;
-}
-
-export interface AuthStateSnapshot {
-  user?: AuthStateSnapshotUser;
-  executor?: AuthStateSnapshotExecutor;
-  isModerator?: boolean;
-  stale: boolean;
-}
-
 export interface AuthState {
   user: AuthUser;
   executor: AuthExecutorState;
@@ -216,7 +185,6 @@ export interface SessionState {
   client: ClientFlowState;
   ui: UiSessionState;
   support: SupportSessionState;
-  authSnapshot: AuthStateSnapshot;
 }
 
 export type BotContext = Context & {

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -55,7 +55,6 @@ const createSessionState = (): BotContext['session'] => ({
   support: {
     status: 'idle',
   },
-  authSnapshot: { stale: false },
 });
 
 const registerChannelPostHandler = () => {

--- a/tests/bot/citySelect.test.ts
+++ b/tests/bot/citySelect.test.ts
@@ -64,8 +64,7 @@ describe('city selection flow', () => {
         },
         ui: { steps: {}, homeActions: [] },
         support: { status: 'idle' },
-        authSnapshot: { stale: false },
-      },
+            },
       auth: {
         user: {
           telegramId: 222,

--- a/tests/bot/clientOrdersFlow.test.ts
+++ b/tests/bot/clientOrdersFlow.test.ts
@@ -87,8 +87,7 @@ const createContext = () => {
       },
       ui: { steps: {}, homeActions: [] },
       support: { status: 'idle' as const },
-      authSnapshot: { stale: false },
-    },
+        },
     auth: {
       user: {
         telegramId: 2002,

--- a/tests/bot/executorMenu.test.ts
+++ b/tests/bot/executorMenu.test.ts
@@ -73,7 +73,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (): BotContext['auth'] => ({

--- a/tests/bot/executorVerification.test.ts
+++ b/tests/bot/executorVerification.test.ts
@@ -62,7 +62,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (telegramId = 710): BotContext['auth'] => ({

--- a/tests/bot/order-publish-failure.test.ts
+++ b/tests/bot/order-publish-failure.test.ts
@@ -95,8 +95,7 @@ const createBaseContext = () => {
     },
     ui: { steps: {}, homeActions: [] },
     support: { status: 'idle' },
-    authSnapshot: { stale: false },
-  };
+    };
 
   const ctx = {
     chat: { id: 1001, type: 'private' as const },

--- a/tests/callback-tokens.test.ts
+++ b/tests/callback-tokens.test.ts
@@ -48,8 +48,7 @@ const createContext = (overrides: Partial<BotContext['auth']['user']>): BotConte
       },
       support: { status: 'idle' },
       ui: { steps: {}, homeActions: [] },
-      authSnapshot: { stale: false },
-    },
+        },
   } as unknown as BotContext;
 };
 

--- a/tests/client-fallback.test.ts
+++ b/tests/client-fallback.test.ts
@@ -49,7 +49,6 @@ const createSessionState = () => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' } as SupportSessionState,
-  authSnapshot: { stale: false },
 });
 
 const captureFallbackHandler = () => {

--- a/tests/client-menu.test.ts
+++ b/tests/client-menu.test.ts
@@ -81,7 +81,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (

--- a/tests/client-support.test.ts
+++ b/tests/client-support.test.ts
@@ -48,7 +48,6 @@ const createSessionState = () => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' as const },
-  authSnapshot: { stale: false },
 });
 
 const createContext = () => {

--- a/tests/executor-access.test.ts
+++ b/tests/executor-access.test.ts
@@ -86,7 +86,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (telegramId = 700): BotContext['auth'] => ({

--- a/tests/executor-role-select.test.ts
+++ b/tests/executor-role-select.test.ts
@@ -107,7 +107,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (): BotContext['auth'] => ({

--- a/tests/executor-verification.test.ts
+++ b/tests/executor-verification.test.ts
@@ -53,7 +53,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (telegramId = 710): BotContext['auth'] => ({

--- a/tests/menu-command-routing.test.ts
+++ b/tests/menu-command-routing.test.ts
@@ -84,7 +84,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (role: BotContext['auth']['user']['role']): BotContext['auth'] => ({
@@ -413,11 +412,7 @@ describe("/menu command routing", () => {
     }
   });
 
-<<<<<<< HEAD
-  it('shows the executor menu when auth falls back to guest but the session retains executor role', async () => {
-=======
   it('uses cached executor snapshot when auth query fails', async () => {
->>>>>>> origin/main
     const showExecutorMenuMock = mock.method(
       executorMenuModule,
       'showExecutorMenu',
@@ -431,21 +426,6 @@ describe("/menu command routing", () => {
     const handler = getCommand('menu');
     assert.ok(handler, 'menu command should be registered');
 
-<<<<<<< HEAD
-    try {
-      const ctx = createContext('courier');
-      ctx.auth.user.role = 'guest';
-      ctx.session.isAuthenticated = false;
-      ctx.session.executor.role = 'courier';
-      ctx.session.authSnapshot = {
-        stale: false,
-        executor: {
-          verifiedRoles: { courier: false, driver: false },
-          hasActiveSubscription: false,
-          isVerified: false,
-        },
-      };
-=======
     const session = createSessionState();
     session.isAuthenticated = true;
     session.user = {
@@ -528,15 +508,12 @@ describe("/menu command routing", () => {
       assert.equal(ctx.auth.executor.verifiedRoles.courier, true);
       assert.equal(ctx.auth.executor.hasActiveSubscription, true);
       assert.equal(ctx.auth.executor.isVerified, true);
->>>>>>> origin/main
 
       await handler(ctx);
 
       assert.equal(showExecutorMenuMock.mock.callCount(), 1);
       assert.equal(showClientMenuMock.mock.callCount(), 0);
     } finally {
-<<<<<<< HEAD
-=======
       queryMock.mock.restore();
       showExecutorMenuMock.mock.restore();
       showClientMenuMock.mock.restore();
@@ -665,7 +642,6 @@ describe("/menu command routing", () => {
       assert.equal(showExecutorMenuMock.mock.callCount(), 0);
       assert.equal(showClientMenuMock.mock.callCount(), 1);
     } finally {
->>>>>>> origin/main
       showExecutorMenuMock.mock.restore();
       showClientMenuMock.mock.restore();
     }

--- a/tests/payment-reminder.job.test.ts
+++ b/tests/payment-reminder.job.test.ts
@@ -78,7 +78,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createBot = () => {

--- a/tests/phone-collect.test.ts
+++ b/tests/phone-collect.test.ts
@@ -43,7 +43,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 afterEach(() => {

--- a/tests/recent-locations.test.ts
+++ b/tests/recent-locations.test.ts
@@ -98,7 +98,6 @@ const createClientSessionState = () => ({
   },
   ui: { steps: {}, homeActions: [] as string[] },
   support: { status: 'idle' as const },
-  authSnapshot: { stale: false },
 });
 
 const createClientContext = () => {

--- a/tests/start-command.test.ts
+++ b/tests/start-command.test.ts
@@ -147,8 +147,7 @@ const createContext = (role: BotContext['auth']['user']['role']): BotContext => 
       client: { taxi: { stage: 'idle' }, delivery: { stage: 'idle' } },
       ui: { steps: {}, homeActions: [] },
       support: { status: 'idle' },
-      authSnapshot: { stale: false },
-    },
+        },
     reply: async (text: string) => {
       replyCalls.push({ text });
       return { message_id: replyCalls.length, chat: { id: 9001 }, text };

--- a/tests/start-contact-flow.test.ts
+++ b/tests/start-contact-flow.test.ts
@@ -54,7 +54,6 @@ const createSessionState = () => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined as string | undefined },
   support: { status: 'idle' as const },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (): BotContext['auth'] => ({

--- a/tests/state-gate.test.ts
+++ b/tests/state-gate.test.ts
@@ -38,7 +38,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (status: BotContext['auth']['user']['status']) => ({

--- a/tests/support.test.ts
+++ b/tests/support.test.ts
@@ -160,7 +160,6 @@ const createSessionState = (): BotContext['session'] => ({
   support: {
     status: 'idle',
   },
-  authSnapshot: { stale: false },
 });
 
 type SupportModule = typeof import('../src/bot/services/support');

--- a/tests/trial-subscription.test.ts
+++ b/tests/trial-subscription.test.ts
@@ -224,8 +224,7 @@ describe('resolveInviteLink with trial subscriptions', () => {
         },
         ui: { steps: {}, homeActions: [] },
         support: { status: 'idle' as const },
-        authSnapshot: { stale: false },
-      },
+            },
       auth: {
         user: {
           telegramId: 777,

--- a/tests/ui.test.ts
+++ b/tests/ui.test.ts
@@ -66,7 +66,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [] },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (): BotContext['auth'] => ({

--- a/tests/verification-gate.test.ts
+++ b/tests/verification-gate.test.ts
@@ -55,7 +55,6 @@ const createSessionState = (): SessionState => ({
   },
   ui: { steps: {}, homeActions: [], pendingCityAction: undefined },
   support: { status: 'idle' },
-  authSnapshot: { stale: false },
 });
 
 const createAuthState = (telegramId = 700): NonNullable<BotContext['auth']> => ({


### PR DESCRIPTION
## Summary
- resolve executor menu merge conflicts with centralized executor role detection and consistent fallbacks
- rebuild session middleware auth snapshot normalization and fallback handling to rely on cached state
- streamline auth middleware cached snapshot recovery and update tests to align with the new snapshot shape

## Testing
- `npm run check`
- `node --require ts-node/register --test tests/menu-command-routing.test.ts tests/auth-middleware.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68d88a3ecb28832dad8540ab52075757