### PR TITLE
Fix city selection flow and client orders reply button

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -366,6 +366,17 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     await sendClientMenu(ctx, 'Меню обновлено.');
   });
 
+  bot.hears(CLIENT_MENU.orders, async (ctx) => {
+    if (!isClientChat(ctx, ctx.auth?.user.role)) {
+      return;
+    }
+
+    await logClientMenuClick(ctx, 'client_home_menu:orders');
+
+    const { renderOrdersList } = await import('./orders');
+    await renderOrdersList(ctx);
+  });
+
   bot.hears(CLIENT_MENU.support, async (ctx) => {
     if (!isClientChat(ctx, ctx.auth?.user.role)) {
       return;

--- a/src/bot/flows/client/orders.ts
+++ b/src/bot/flows/client/orders.ts
@@ -14,7 +14,7 @@ import { formatDistance, formatEtaMinutes, formatPriceAmount } from '../../servi
 import type { BotContext } from '../../types';
 import type { OrderStatus, OrderWithExecutor } from '../../../types';
 import { ui } from '../../ui';
-import { CLIENT_MENU, isClientChat, sendClientMenu } from '../../../ui/clientMenu';
+import { sendClientMenu } from '../../../ui/clientMenu';
 import { CLIENT_MENU_ACTION, logClientMenuClick } from './menu';
 import {
   CLIENT_CANCEL_ORDER_ACTION_PATTERN,
@@ -378,7 +378,7 @@ const buildOrdersListKeyboard = (orders: OrderWithExecutor[]): InlineKeyboardMar
   return buildInlineKeyboard(rows);
 };
 
-const renderOrdersList = async (
+export const renderOrdersList = async (
   ctx: BotContext,
   orders?: OrderWithExecutor[],
 ): Promise<OrderWithExecutor[] | null> => {
@@ -586,14 +586,6 @@ export const registerClientOrdersFlow = (bot: Telegraf<BotContext>): void => {
     }
 
     await confirmClientOrderCancellation(ctx, orderId);
-  });
-
-  bot.hears(CLIENT_MENU.orders, async (ctx) => {
-    if (!isClientChat(ctx, ctx.auth?.user.role)) {
-      return;
-    }
-
-    await renderOrdersList(ctx);
   });
 
   bot.command('orders', async (ctx) => {


### PR DESCRIPTION
## Summary
- render the city selection prompt via ui.step so the home action is attached and confirmation edits fall back gracefully
- wire the client "🧾 Мои заказы" reply button to the inline orders renderer and export the helper for reuse
- update session migration and executor access tests to stub the new step API and assert against the recorded steps

## Testing
- node --require ts-node/register --test tests/bot/city-session-migration.test.ts
- node --require ts-node/register --test tests/executor-access.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d89e7234f4832d986642b13ad504fc