### PR TITLE
Add migration to activate phone-verified users

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -21,6 +21,7 @@ solely for local development resets.
 | `0002_add_flow_state_index.up.sql` | Keeps a concurrent creation path for the `sessions_scope_state_idx` index when upgrading an existing database. New installations already receive the index from migration 0001. |
 | `0006_update_recent_locations_schema.up.sql` | Expands `user_recent_locations` to track multiple entries per user/city/kind combination and aligns the types with the application service. |
 | `0008_add_user_foreign_keys.up.sql` | Adds cascading foreign keys from analytics and cache tables to `users(tg_id)` to keep auxiliary data in sync. |
+| `0009_activate_verified_clients.up.sql` | Promotes phone-verified users stuck in onboarding to the `active_client` status and stores their previous status for easy rollback. |
 
 If your database is empty, running the migrations once is sufficient — both
 files will be executed and the second one becomes a no-op after the index

--- a/db/migrations/0009_activate_verified_clients.down.sql
+++ b/db/migrations/0009_activate_verified_clients.down.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+UPDATE users u
+SET status = b.previous_status
+FROM migration_0009_user_status_backup b
+WHERE u.tg_id = b.tg_id
+  AND u.status = 'active_client';
+
+DROP TABLE IF EXISTS migration_0009_user_status_backup;
+
+COMMIT;

--- a/db/migrations/0009_activate_verified_clients.up.sql
+++ b/db/migrations/0009_activate_verified_clients.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS migration_0009_user_status_backup (
+  tg_id           BIGINT PRIMARY KEY,
+  previous_status TEXT      NOT NULL
+);
+
+INSERT INTO migration_0009_user_status_backup (tg_id, previous_status)
+SELECT u.tg_id, u.status
+FROM users u
+WHERE u.phone_verified IS TRUE
+  AND u.status IN ('guest', 'awaiting_phone')
+ON CONFLICT (tg_id) DO NOTHING;
+
+UPDATE users
+SET status = 'active_client'
+WHERE phone_verified IS TRUE
+  AND status IN ('guest', 'awaiting_phone');
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add migration 0009 to promote phone-verified users to the active_client status while backing up their prior status for rollback
- include the down migration to restore statuses and clean up the backup table
- document the new migration in the database README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d0de76e8832db21dff95236f46b1