### PR TITLE
Stabilize onboarding role selection and executor flows

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -14,6 +14,7 @@ import { CLIENT_COMMANDS } from '../../commands/sets';
 import { setChatCommands } from '../../services/commands';
 import type { BotContext } from '../../types';
 import { presentRoleSelection } from '../../commands/start';
+import { ensureExecutorState } from '../executor/menu';
 import { promptClientSupport } from './support';
 import { askCity, getCityFromContext, CITY_ACTION_PATTERN } from '../common/citySelect';
 import { CLIENT_ORDERS_ACTION } from './orderActions';
@@ -313,6 +314,9 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     await hideClientMenu(ctx, 'Меняем роль — выберите подходящий вариант ниже.');
+    const executorState = ensureExecutorState(ctx);
+    executorState.awaitingRoleSelection = true;
+    executorState.role = undefined;
     await presentRoleSelection(ctx);
   });
 
@@ -355,6 +359,9 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     await hideClientMenu(ctx, 'Меняем роль — выберите подходящий вариант ниже.');
+    const executorState = ensureExecutorState(ctx);
+    executorState.awaitingRoleSelection = true;
+    executorState.role = undefined;
     await presentRoleSelection(ctx);
   });
 

--- a/src/bot/flows/executor/roleSelect.ts
+++ b/src/bot/flows/executor/roleSelect.ts
@@ -22,6 +22,7 @@ const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise
 
   const state = ensureExecutorState(ctx);
   state.role = role;
+  state.awaitingRoleSelection = false;
   ctx.auth.user.role = role;
   ctx.auth.user.status = 'active_executor';
 

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -787,6 +787,8 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
       await setChatCommands(ctx.telegram, ctx.chat.id, CLIENT_COMMANDS, { showMenuButton: true });
     }
 
+    state.awaitingRoleSelection = true;
+    state.role = undefined;
     await presentRoleSelection(ctx);
   });
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -118,6 +118,7 @@ export interface ExecutorFlowState {
   role?: ExecutorRole;
   verification: ExecutorVerificationState;
   subscription: ExecutorSubscriptionState;
+  awaitingRoleSelection?: boolean;
 }
 
 export type ClientOrderStage =


### PR DESCRIPTION
## Summary
- treat authentication rows with missing menu role or onboarding status as guests so unconfirmed users stay on the role picker
- stop auto-sending the client menu after phone verification and mark users as onboarding to keep the selection flow intact
- track executor role selection state in session so switching roles resets state and all entry points reopen the selector consistently

## Testing
- `npm run check`
- `node --require ts-node/register --test tests/bot/executorVerification.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d90f19d080832d91af82a4a85a387e