### PR TITLE
Fix verification albums and restrict taxi order access

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -614,6 +614,7 @@ type OrderActionOutcome =
   | { outcome: 'dismissed'; order: OrderRecord }
   | { outcome: 'already_dismissed' }
   | { outcome: 'limit_exceeded' }
+  | { outcome: 'forbidden_kind'; order: OrderRecord }
   | { outcome: 'city_mismatch'; order: OrderRecord };
 
 interface OrderActionActor {
@@ -671,6 +672,10 @@ const processOrderAction = async (
 
         if (typeof actorId !== 'number') {
           throw new Error('Missing moderator identifier for order claim');
+        }
+
+        if (order.kind === 'taxi' && actor.role !== 'driver') {
+          return { outcome: 'forbidden_kind', order } as const;
         }
 
         if (actor.role === 'driver') {
@@ -884,6 +889,10 @@ const handleOrderDecision = async (
     case 'city_mismatch': {
       await ensureMessageReflectsState(ctx.telegram, state);
       await ctx.answerCbQuery('⚠️ Заказ не из вашего города.', { show_alert: true });
+      return;
+    }
+    case 'forbidden_kind': {
+      await ctx.answerCbQuery('🚫 Этот заказ доступен только водителям.', { show_alert: true });
       return;
     }
     case 'claimed': {

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -810,6 +810,7 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
       'media_group_id' in message &&
       typeof (message as { media_group_id?: unknown }).media_group_id === 'string'
     ) {
+      await next();
       return;
     }
 

--- a/src/bot/moderation/queue.ts
+++ b/src/bot/moderation/queue.ts
@@ -137,9 +137,12 @@ const buildMessageKeyboard = (
     ]);
   });
 
-  if (reasons.length === 0) {
-    rows.push([Markup.button.callback('❌ Отклонить', `${rejectAction}:${token}:0`)]);
-  }
+  const manualIndex = reasons.length;
+  const manualLabel =
+    reasons.length > 0 ? '❌ Отклонить с комментарием' : '❌ Отклонить';
+  rows.push([
+    Markup.button.callback(manualLabel, `${rejectAction}:${token}:${manualIndex.toString(10)}`),
+  ]);
 
   return Markup.inlineKeyboard(rows);
 };
@@ -706,6 +709,13 @@ export const createModerationQueue = <T extends ModerationQueueItemBase<T>>(
     }
 
     const suggestion = entry.rejectionReasons?.[reasonIndex];
+    const trimmedSuggestion = suggestion?.trim();
+
+    if (trimmedSuggestion) {
+      await resolveDecision(ctx, token, 'rejected', trimmedSuggestion);
+      return;
+    }
+
     const promptLines = [
       'Укажите причину отклонения заявки в ответ на это сообщение.',
       suggestion ? `Предложенный вариант: ${suggestion}` : undefined,


### PR DESCRIPTION
## Summary
- allow verification to handle media groups by passing album messages to the group handler
- streamline moderation rejection buttons with predefined reasons and a manual comment option
- block couriers from accepting taxi orders while keeping drivers unrestricted

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d91ec8efd8832daaa5d54054f4ed74