### PR TITLE
Enforce callback TTL and align trial duration

### DIFF
--- a/src/bot/channels/ordersChannel.ts
+++ b/src/bot/channels/ordersChannel.ts
@@ -528,13 +528,21 @@ const buildActionKeyboard = (order: OrderRecord): InlineKeyboardMarkup => {
     [
       {
         label: '✅ Беру заказ',
-        action: wrapCallbackData(acceptRaw, { secret: callbackSecret, bindToUser: false }),
+        action: wrapCallbackData(acceptRaw, {
+          secret: callbackSecret,
+          bindToUser: false,
+          ttlSeconds: config.bot.callbackTtlSeconds,
+        }),
       },
     ],
     [
       {
         label: '❌ Недоступен',
-        action: wrapCallbackData(declineRaw, { secret: callbackSecret, bindToUser: false }),
+        action: wrapCallbackData(declineRaw, {
+          secret: callbackSecret,
+          bindToUser: false,
+          ttlSeconds: config.bot.callbackTtlSeconds,
+        }),
       },
     ],
   ]);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -275,6 +275,7 @@ export interface AppConfig {
   bot: {
     token: string;
     callbackSignSecret?: string;
+    callbackTtlSeconds: number;
   };
   features: {
     trialEnabled: boolean;
@@ -345,6 +346,7 @@ export const loadConfig = (): AppConfig => {
     bot: {
       token: process.env.BOT_TOKEN as string,
       callbackSignSecret: getOptionalString('CALLBACK_SIGN_SECRET'),
+      callbackTtlSeconds: parsePositiveInt('CALLBACK_TTL_SECONDS', 600),
     },
     features: {
       trialEnabled: parseBoolean(process.env.FEATURE_TRIAL_ENABLED, true),
@@ -388,7 +390,7 @@ export const loadConfig = (): AppConfig => {
     tariff: parseGeneralTariff(),
     subscriptions: {
       warnHoursBefore: parseWarnHours(process.env.SUB_WARN_HOURS_BEFORE),
-      trialDays: parsePositiveNumber('SUB_TRIAL_DAYS', 7),
+      trialDays: parsePositiveNumber('SUB_TRIAL_DAYS', 2),
       prices: parseSubscriptionPrices(),
       payment: {
         kaspi: {

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -71,6 +71,7 @@ const bindAction = (
     userId,
     keyboardNonce,
     bindToUser: true,
+    ttlSeconds: config.bot.callbackTtlSeconds,
   });
 };
 


### PR DESCRIPTION
## Summary
- add expiry metadata to signed callback payloads and reject stale interactions
- propagate the configured callback TTL when generating inline keyboards, including driver channel messages and inactivity nudges
- update the default executor trial length to 48 hours per product requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d932957770832d90661eaf58d2bf67