### PR TITLE
Add executor role columns and refactor onboarding

### DIFF
--- a/db/migrations/0010_user_executor_fields.down.sql
+++ b/db/migrations/0010_user_executor_fields.down.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMPTZ;
+
+UPDATE users
+SET is_verified = CASE verify_status WHEN 'active' THEN TRUE ELSE FALSE END;
+
+UPDATE users
+SET trial_ends_at = trial_expires_at
+WHERE trial_expires_at IS NOT NULL;
+
+UPDATE users
+SET role = CASE
+  WHEN role = 'executor' AND executor_kind = 'courier' THEN 'courier'
+  WHEN role = 'executor' AND executor_kind = 'driver' THEN 'driver'
+  ELSE role
+END;
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS executor_kind,
+  DROP COLUMN IF EXISTS verify_status,
+  DROP COLUMN IF EXISTS trial_started_at,
+  DROP COLUMN IF EXISTS trial_expires_at;
+
+DROP TYPE IF EXISTS user_verify_status;
+DROP TYPE IF EXISTS executor_kind;
+
+COMMIT;

--- a/db/migrations/0010_user_executor_fields.up.sql
+++ b/db/migrations/0010_user_executor_fields.up.sql
@@ -1,0 +1,69 @@
+BEGIN;
+
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'guest';
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'executor';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'executor_kind') THEN
+    CREATE TYPE executor_kind AS ENUM ('courier', 'driver');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_verify_status') THEN
+    CREATE TYPE user_verify_status AS ENUM ('none', 'pending', 'active', 'rejected', 'expired');
+  END IF;
+END $$;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS executor_kind executor_kind,
+  ADD COLUMN IF NOT EXISTS verify_status user_verify_status NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ;
+
+UPDATE users
+SET executor_kind = CASE role
+  WHEN 'courier' THEN 'courier'::executor_kind
+  WHEN 'driver' THEN 'driver'::executor_kind
+  ELSE executor_kind
+END
+WHERE role IN ('courier', 'driver');
+
+UPDATE users
+SET role = 'executor'
+WHERE role IN ('courier', 'driver');
+
+WITH latest AS (
+  SELECT DISTINCT ON (user_id) user_id, status
+  FROM verifications
+  ORDER BY user_id, updated_at DESC, id DESC
+)
+UPDATE users AS u
+SET verify_status = CASE
+  WHEN u.is_verified THEN 'active'
+  WHEN latest.status IS NULL THEN 'none'
+  WHEN latest.status = 'active' THEN 'active'
+  WHEN latest.status = 'pending' THEN 'pending'
+  WHEN latest.status = 'rejected' THEN 'rejected'
+  WHEN latest.status = 'expired' THEN 'expired'
+  ELSE 'none'
+END
+FROM latest
+WHERE u.tg_id = latest.user_id;
+
+UPDATE users
+SET verify_status = 'active'
+WHERE verify_status = 'none' AND is_verified IS TRUE;
+
+UPDATE users
+SET trial_started_at = COALESCE(verified_at, trial_ends_at),
+    trial_expires_at = trial_ends_at
+WHERE trial_ends_at IS NOT NULL;
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS trial_ends_at,
+  DROP COLUMN IF EXISTS is_verified;
+
+COMMIT;

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -71,7 +71,7 @@ const applyCommandsForRole = async (ctx: BotContext): Promise<void> => {
     return;
   }
 
-  if (role === 'courier' || role === 'driver') {
+  if (role === 'executor') {
     await setChatCommands(ctx.telegram, ctx.chat.id, EXECUTOR_COMMANDS, { showMenuButton: true });
   }
 };

--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -168,9 +168,9 @@ export const showMenu = async (ctx: BotContext, prompt?: string): Promise<void> 
 
   uiState.pendingCityAction = undefined;
   const cityLabel = CITY_LABEL[city];
-  const trialEndsAt = ctx.auth.user.trialEndsAt;
-  const trialDaysLeft = trialEndsAt
-    ? Math.max(0, Math.ceil((trialEndsAt.getTime() - Date.now()) / 86400000))
+  const trialExpiresAt = ctx.auth.user.trialExpiresAt;
+  const trialDaysLeft = trialExpiresAt
+    ? Math.max(0, Math.ceil((trialExpiresAt.getTime() - Date.now()) / 86400000))
     : undefined;
   const baseText = prompt ?? clientMenuText();
   const miniStatus = copy.clientMiniStatus(cityLabel, trialDaysLeft);

--- a/src/bot/flows/executor/roleSelect.ts
+++ b/src/bot/flows/executor/roleSelect.ts
@@ -23,13 +23,15 @@ const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise
   const state = ensureExecutorState(ctx);
   state.role = role;
   state.awaitingRoleSelection = false;
-  ctx.auth.user.role = role;
+  ctx.auth.user.role = 'executor';
+  ctx.auth.user.executorKind = role;
   ctx.auth.user.status = 'active_executor';
 
   try {
     await updateUserRole({
       telegramId: ctx.auth.user.telegramId,
-      role,
+      role: 'executor',
+      executorKind: role,
       status: 'active_executor',
       menuRole: 'courier',
     });

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -197,7 +197,7 @@ const activateTrialSubscription = async (ctx: BotContext): Promise<void> => {
       firstName: ctx.auth.user.firstName ?? undefined,
       lastName: ctx.auth.user.lastName ?? undefined,
       phone: ctx.auth.user.phone ?? ctx.session.phoneNumber ?? undefined,
-      role,
+      executorKind: role,
       chatId: binding.chatId,
       trialDays: config.subscriptions.trialDays,
       currency: config.subscriptions.prices.currency,

--- a/src/bot/middlewares/keyboardGuard.ts
+++ b/src/bot/middlewares/keyboardGuard.ts
@@ -20,8 +20,7 @@ const isExecutorUser = (ctx: BotContext): boolean => {
     return false;
   }
   return (
-    role === 'courier' ||
-    role === 'driver' ||
+    role === 'executor' ||
     status === 'active_executor'
   );
 };

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -383,7 +383,7 @@ const handleSubscriptionApproval = async (
       firstName: subscription.firstName,
       lastName: subscription.lastName,
       phone: subscription.phone,
-      role: subscription.role,
+      executorKind: subscription.role,
       chatId: binding.chatId,
       periodDays: subscription.period.days,
       periodLabel: subscription.period.label,

--- a/src/bot/moderation/verifyQueue.ts
+++ b/src/bot/moderation/verifyQueue.ts
@@ -338,7 +338,7 @@ const activateVerificationTrial = async (
       firstName: application.applicant.firstName ?? undefined,
       lastName: application.applicant.lastName ?? undefined,
       phone: application.applicant.phone ?? undefined,
-      role: application.role,
+      executorKind: application.role,
       chatId: binding.chatId,
       trialDays: DEFAULT_VERIFICATION_TRIAL_DAYS,
       currency: config.subscriptions.prices.currency,

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -9,7 +9,9 @@ export type ExecutorRole = 'courier' | 'driver';
 
 export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
 
-export type UserRole = 'guest' | 'client' | 'courier' | 'driver' | 'moderator';
+export type UserRole = 'guest' | 'client' | 'executor' | 'moderator';
+
+export type UserVerifyStatus = 'none' | 'pending' | 'active' | 'rejected' | 'expired';
 
 export interface SessionUser {
   id: number;
@@ -39,12 +41,15 @@ export interface AuthUser {
   phone?: string;
   phoneVerified: boolean;
   role: UserRole;
+  executorKind?: ExecutorRole;
   status: UserStatus;
+  verifyStatus: UserVerifyStatus;
   isVerified: boolean;
   isBlocked: boolean;
   citySelected?: AppCity;
   verifiedAt?: Date;
-  trialEndsAt?: Date;
+  trialStartedAt?: Date;
+  trialExpiresAt?: Date;
   lastMenuRole?: UserMenuRole;
   keyboardNonce?: string;
 }
@@ -63,10 +68,14 @@ export interface AuthState {
 
 export interface AuthStateSnapshot {
   role: UserRole;
+  executorKind?: ExecutorRole;
   status: UserStatus;
   phoneVerified: boolean;
+  verifyStatus: UserVerifyStatus;
   userIsVerified: boolean;
   executor: AuthExecutorState;
+  trialStartedAt?: Date;
+  trialExpiresAt?: Date;
   city?: AppCity;
   stale: boolean;
 }

--- a/src/bot/ui/menus.ts
+++ b/src/bot/ui/menus.ts
@@ -60,7 +60,7 @@ export const renderMenuFor = async (
   }
 
   const role = user.role;
-  if (role === 'courier' || role === 'driver') {
+  if (role === 'executor') {
     await ctx.reply(prompt ?? 'Меню исполнителя доступно ниже.', executorKeyboard());
     return;
   }

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -93,7 +93,7 @@ const buildNudgeKeyboard = (
   }
 
   let fallbackAction: string | null = null;
-  if (role === 'courier' || role === 'driver') {
+  if (role === 'executor') {
     fallbackAction = EXECUTOR_MENU_ACTION;
   } else if (role === 'client' || role === 'guest' || role === 'moderator') {
     fallbackAction = CLIENT_MENU_ACTION;


### PR DESCRIPTION
## Summary
- add a migration introducing executor_kind, verify_status and trial timing columns while migrating existing role data
- update database access, auth/session state and verification logic to work with the new executor role semantics
- adjust onboarding, executor flows and guards so role changes persist executor_kind and rely on the new flags

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d93be11424832dac6687c88d8f27ae