### PR TITLE
Refactor user roles to executor kind

### DIFF
--- a/db/migrations/0011_user_role_enum_refactor.down.sql
+++ b/db/migrations/0011_user_role_enum_refactor.down.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMPTZ;
+
+UPDATE users
+SET is_verified = CASE verify_status WHEN 'active' THEN TRUE ELSE FALSE END;
+
+UPDATE users
+SET trial_ends_at = trial_expires_at
+WHERE trial_expires_at IS NOT NULL;
+
+ALTER TYPE user_role RENAME TO user_role_new;
+
+CREATE TYPE user_role AS ENUM ('client', 'courier', 'driver', 'moderator');
+
+ALTER TABLE users
+  ALTER COLUMN role DROP DEFAULT,
+  ALTER COLUMN role TYPE user_role USING (
+    CASE
+      WHEN role::text = 'executor' AND executor_kind = 'courier' THEN 'courier'
+      WHEN role::text = 'executor' AND executor_kind = 'driver' THEN 'driver'
+      WHEN role::text = 'executor' THEN 'client'
+      WHEN role::text = 'guest' THEN 'guest'
+      WHEN role::text = 'client' THEN 'client'
+      WHEN role::text = 'moderator' THEN 'moderator'
+      ELSE 'guest'
+    END
+  )::user_role,
+  ALTER COLUMN role SET DEFAULT 'client';
+
+DROP TYPE user_role_new;
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS executor_kind,
+  DROP COLUMN IF EXISTS verify_status,
+  DROP COLUMN IF EXISTS trial_started_at,
+  DROP COLUMN IF EXISTS trial_expires_at;
+
+DROP TYPE IF EXISTS user_verify_status;
+DROP TYPE IF EXISTS executor_kind;
+
+COMMIT;

--- a/db/migrations/0011_user_role_enum_refactor.up.sql
+++ b/db/migrations/0011_user_role_enum_refactor.up.sql
@@ -1,0 +1,82 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'executor_kind') THEN
+    CREATE TYPE executor_kind AS ENUM ('courier', 'driver');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_verify_status') THEN
+    CREATE TYPE user_verify_status AS ENUM ('none', 'pending', 'active', 'rejected', 'expired');
+  END IF;
+END $$;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS executor_kind executor_kind,
+  ADD COLUMN IF NOT EXISTS verify_status user_verify_status NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ;
+
+UPDATE users
+SET executor_kind = CASE role::text
+  WHEN 'courier' THEN 'courier'::executor_kind
+  WHEN 'driver' THEN 'driver'::executor_kind
+  ELSE executor_kind
+END
+WHERE role::text IN ('courier', 'driver');
+
+WITH latest AS (
+  SELECT DISTINCT ON (user_id) user_id, status
+  FROM verifications
+  ORDER BY user_id, updated_at DESC, id DESC
+)
+UPDATE users AS u
+SET verify_status = CASE
+  WHEN u.is_verified THEN 'active'
+  WHEN latest.status IS NULL THEN 'none'
+  WHEN latest.status = 'active' THEN 'active'
+  WHEN latest.status = 'pending' THEN 'pending'
+  WHEN latest.status = 'rejected' THEN 'rejected'
+  WHEN latest.status = 'expired' THEN 'expired'
+  ELSE 'none'
+END
+FROM latest
+WHERE u.tg_id = latest.user_id;
+
+UPDATE users
+SET verify_status = 'active'
+WHERE verify_status = 'none' AND is_verified IS TRUE;
+
+UPDATE users
+SET trial_started_at = COALESCE(verified_at, trial_ends_at),
+    trial_expires_at = trial_ends_at
+WHERE trial_ends_at IS NOT NULL;
+
+ALTER TYPE user_role RENAME TO user_role_old;
+
+CREATE TYPE user_role AS ENUM ('guest', 'client', 'executor', 'moderator');
+
+ALTER TABLE users
+  ALTER COLUMN role DROP DEFAULT,
+  ALTER COLUMN role TYPE user_role USING (
+    CASE
+      WHEN role::text IN ('courier', 'driver') THEN 'executor'
+      WHEN role::text = 'guest' THEN 'guest'
+      WHEN role::text = 'client' THEN 'client'
+      WHEN role::text = 'moderator' THEN 'moderator'
+      WHEN role::text = 'executor' THEN 'executor'
+      ELSE 'guest'
+    END
+  )::user_role,
+  ALTER COLUMN role SET DEFAULT 'client';
+
+DROP TYPE user_role_old;
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS trial_ends_at,
+  DROP COLUMN IF EXISTS is_verified;
+
+COMMIT;

--- a/src/bot/flows/common/citySelect.ts
+++ b/src/bot/flows/common/citySelect.ts
@@ -35,7 +35,8 @@ const resolveHomeAction = (ctx: BotContext): string => {
   }
 
   const role = ctx.auth?.user.role;
-  if (role === 'client' || role === 'guest' || role === 'moderator') {
+  const isModerator = ctx.auth?.isModerator === true;
+  if (isModerator || role === 'client' || role === 'guest') {
     return CLIENT_MENU_HOME_ACTION;
   }
 

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -9,7 +9,7 @@ export type ExecutorRole = 'courier' | 'driver';
 
 export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
 
-export type UserRole = 'guest' | 'client' | 'executor' | 'moderator';
+export type UserRole = 'guest' | 'client' | 'executor';
 
 export type UserVerifyStatus = 'none' | 'pending' | 'active' | 'rejected' | 'expired';
 
@@ -74,6 +74,7 @@ export interface AuthStateSnapshot {
   verifyStatus: UserVerifyStatus;
   userIsVerified: boolean;
   executor: AuthExecutorState;
+  isModerator: boolean;
   trialStartedAt?: Date;
   trialExpiresAt?: Date;
   city?: AppCity;

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,4 +1,5 @@
 import { pool } from './client';
+import type { ExecutorRole } from '../bot/types';
 
 export interface EnsureClientRoleParams {
   telegramId: number;
@@ -11,7 +12,7 @@ export interface EnsureClientRoleParams {
 export interface UpdateUserRoleParams {
   telegramId: number;
   role: 'guest' | 'client' | 'executor';
-  executorKind?: 'courier' | 'driver' | null;
+  executorKind?: ExecutorRole | null;
   status?: 'active_client' | 'active_executor';
   menuRole?: 'client' | 'courier';
 }

--- a/src/db/verifications.ts
+++ b/src/db/verifications.ts
@@ -1,7 +1,8 @@
 import { pool, withTx } from './client';
 import type { PoolClient } from './client';
+import type { ExecutorRole } from '../bot/types';
 
-export type VerificationRole = 'courier' | 'driver';
+export type VerificationRole = ExecutorRole;
 
 export interface VerificationApplicant {
   telegramId: number;

--- a/src/jobs/nudger.ts
+++ b/src/jobs/nudger.ts
@@ -93,9 +93,9 @@ const buildNudgeKeyboard = (
   }
 
   let fallbackAction: string | null = null;
-  if (role === 'executor') {
+  if (role === 'executor' || role === 'moderator') {
     fallbackAction = EXECUTOR_MENU_ACTION;
-  } else if (role === 'client' || role === 'guest' || role === 'moderator') {
+  } else if (role === 'client' || role === 'guest') {
     fallbackAction = CLIENT_MENU_ACTION;
   }
 


### PR DESCRIPTION
## Summary
- replace courier/driver user role values with an executor role in a new migration while preserving executor_kind and verification data
- update auth/session typing to only expose guest/client/executor roles and surface moderator status separately from executor specialisation
- align onboarding helpers, city selection, and nudger fallbacks with the executor_kind based flow and share executor role typings in the db layer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d94b463c54832db88e8c4e0aaf2cdf