### PR TITLE
Refine onboarding role selection flows

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,7 +39,12 @@ import { keyboardGuard } from './bot/middlewares/keyboardGuard';
 import { stateGate } from './bot/middlewares/stateGate';
 import { unknownHandler } from './bot/middlewares/unknown';
 import { callbackDecoder } from './bot/middlewares/callbackDecoder';
-import { ensurePhone, savePhone } from './bot/flows/common/phoneCollect';
+import {
+  ensurePhone,
+  savePhone,
+  PHONE_HELP_BUTTON_LABEL,
+  respondToPhoneHelp,
+} from './bot/flows/common/phoneCollect';
 import { metricsCollector } from './bot/middlewares/metrics';
 import { ensureVerifiedExecutor } from './bot/middlewares/verificationGate';
 import type { BotContext } from './bot/types';
@@ -88,6 +93,8 @@ registerSupportModerationBridge(app);
 registerOrdersChannel(app);
 registerJoinRequests(app);
 registerMembershipSync(app);
+
+app.hears(PHONE_HELP_BUTTON_LABEL, respondToPhoneHelp);
 
 app.on('message', unknownHandler);
 

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -12,46 +12,45 @@ import { buildInlineKeyboard } from '../keyboards/common';
 import { ui } from '../ui';
 import {
   ROLE_SELECTION_BACK_ACTION,
+  ROLE_PICK_HELP_ACTION,
+  ROLE_PICK_EXECUTOR_ACTION,
+  EXECUTOR_KIND_BACK_ACTION,
+  EXECUTOR_KIND_COURIER_ACTION,
+  EXECUTOR_KIND_DRIVER_ACTION,
   EXECUTOR_ROLE_PENDING_CITY_ACTION,
 } from '../flows/executor/roleSelectionConstants';
 
-const ROLE_SELECTION_STEP_ID = 'start:role:selection';
+const ROLE_PICK_STEP_ID = 'start:role:pick';
+const EXECUTOR_KIND_STEP_ID = 'start:role:executor-kind';
 const ROLE_CLIENT_ACTION = 'role:client';
-const ROLE_EXECUTOR_ACTION = 'role:executor';
-const ROLE_COURIER_ACTION = 'role:courier';
-const ROLE_DRIVER_ACTION = 'role:driver';
-const SUPPORT_CONTACT_ACTION = 'support:contact';
 
-const ROLE_SELECTION_TITLE = 'Выбор роли';
-const ROLE_SELECTION_DESCRIPTION =
+const ROLE_PICK_TITLE = 'Выбор роли';
+const ROLE_PICK_DESCRIPTION =
   'Freedom Bot помогает клиентам оформлять заказы и исполнителям брать их в работу. Выберите подходящую роль.';
+const ROLE_PICK_HINT =
+  'ℹ️ Подсказка: выберите «Клиент», если хотите оформлять заказы. Нажмите «Исполнитель», чтобы брать заказы в работу.';
 
-const SPECIALISATION_TITLE = 'Выбор специализации';
-const SPECIALISATION_DESCRIPTION =
+const EXECUTOR_KIND_TITLE = 'Выбор специализации';
+const EXECUTOR_KIND_DESCRIPTION =
   'Уточните, какие заказы хотите получать: доставка подходит курьерам, поездки — водителям.';
+const EXECUTOR_KIND_HINT = 'ℹ️ Курьеры занимаются доставкой, водители помогают с поездками.';
 
-const buildRoleSelectionKeyboard = () =>
+const buildRolePickKeyboard = () =>
   buildInlineKeyboard([
     [
-      { label: '🧑‍💼 Я клиент', action: ROLE_CLIENT_ACTION },
-      { label: '🛠️ Я исполнитель', action: ROLE_EXECUTOR_ACTION },
+      { label: '🧑‍💼 Клиент', action: ROLE_CLIENT_ACTION },
+      { label: '🛠️ Исполнитель', action: ROLE_PICK_EXECUTOR_ACTION },
     ],
-    [
-      { label: '🆘 Помощь', action: SUPPORT_CONTACT_ACTION },
-      { label: '❓ Где я?', action: ROLE_SELECTION_BACK_ACTION },
-    ],
+    [{ label: '🆘 Помощь', action: ROLE_PICK_HELP_ACTION }],
   ]);
 
-const buildExecutorSpecialisationKeyboard = () =>
+const buildExecutorKindKeyboard = () =>
   buildInlineKeyboard([
     [
-      { label: '🚚 Я курьер', action: ROLE_COURIER_ACTION },
-      { label: '🚗 Я водитель', action: ROLE_DRIVER_ACTION },
+      { label: '🚚 Курьер', action: EXECUTOR_KIND_COURIER_ACTION },
+      { label: '🚗 Водитель', action: EXECUTOR_KIND_DRIVER_ACTION },
     ],
-    [
-      { label: '🆘 Помощь', action: SUPPORT_CONTACT_ACTION },
-      { label: '⬅️ Назад', action: ROLE_SELECTION_BACK_ACTION },
-    ],
+    [{ label: '⬅️ Назад', action: EXECUTOR_KIND_BACK_ACTION }],
   ]);
 
 const resetCitySelectionTracking = (ctx: BotContext): void => {
@@ -60,7 +59,26 @@ const resetCitySelectionTracking = (ctx: BotContext): void => {
   }
 };
 
-export const presentRoleSelection = async (ctx: BotContext): Promise<void> => {
+const buildRolePickText = (options?: { withHint?: boolean }): string => {
+  const lines = [ROLE_PICK_TITLE, '', ROLE_PICK_DESCRIPTION];
+  if (options?.withHint) {
+    lines.push('', ROLE_PICK_HINT);
+  }
+  return lines.join('\n');
+};
+
+const buildExecutorKindText = (options?: { withHint?: boolean }): string => {
+  const lines = [EXECUTOR_KIND_TITLE, '', EXECUTOR_KIND_DESCRIPTION];
+  if (options?.withHint) {
+    lines.push('', EXECUTOR_KIND_HINT);
+  }
+  return lines.join('\n');
+};
+
+export const presentRolePick = async (
+  ctx: BotContext,
+  options?: { withHint?: boolean },
+): Promise<void> => {
   const executorState = ensureExecutorState(ctx);
   executorState.awaitingRoleSelection = true;
   executorState.role = undefined;
@@ -69,26 +87,27 @@ export const presentRoleSelection = async (ctx: BotContext): Promise<void> => {
   resetCitySelectionTracking(ctx);
 
   await ui.step(ctx, {
-    id: ROLE_SELECTION_STEP_ID,
-    text: `${ROLE_SELECTION_TITLE}\n\n${ROLE_SELECTION_DESCRIPTION}`,
-    keyboard: buildRoleSelectionKeyboard(),
+    id: ROLE_PICK_STEP_ID,
+    text: buildRolePickText(options),
+    keyboard: buildRolePickKeyboard(),
   });
 };
 
-export const presentExecutorSpecialisationSelection = async (
+export const presentExecutorKindSelection = async (
   ctx: BotContext,
+  options?: { withHint?: boolean },
 ): Promise<void> => {
   const executorState = ensureExecutorState(ctx);
   executorState.awaitingRoleSelection = true;
   executorState.role = undefined;
-  executorState.roleSelectionStage = 'specialization';
+  executorState.roleSelectionStage = 'executorKind';
   ctx.auth.user.executorKind = undefined;
   resetCitySelectionTracking(ctx);
 
   await ui.step(ctx, {
-    id: ROLE_SELECTION_STEP_ID,
-    text: `${SPECIALISATION_TITLE}\n\n${SPECIALISATION_DESCRIPTION}`,
-    keyboard: buildExecutorSpecialisationKeyboard(),
+    id: EXECUTOR_KIND_STEP_ID,
+    text: buildExecutorKindText(options ?? { withHint: true }),
+    keyboard: buildExecutorKindKeyboard(),
   });
 };
 
@@ -131,17 +150,17 @@ export const handleStart = async (ctx: BotContext): Promise<void> => {
   const role = executorState.role;
   const stage = executorState.roleSelectionStage;
   const awaitingRoleSelection = executorState.awaitingRoleSelection === true;
-  if (!role || awaitingRoleSelection || stage === 'role' || stage === 'specialization') {
+  if (!role || awaitingRoleSelection || stage === 'role' || stage === 'executorKind') {
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
-    const prompt = stage === 'specialization'
+    const prompt = stage === 'executorKind'
       ? 'Выберите специализацию исполнителя ниже.'
       : 'Меняем роль — выберите подходящий вариант ниже.';
     await hideClientMenu(ctx, prompt);
-    if (stage === 'specialization') {
-      await presentExecutorSpecialisationSelection(ctx);
+    if (stage === 'executorKind') {
+      await presentExecutorKindSelection(ctx);
     } else {
-      await presentRoleSelection(ctx);
+      await presentRolePick(ctx);
     }
     return;
   }
@@ -165,7 +184,7 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
   bot.start(handleStart);
   bot.hears(/^start$/i, handleStart);
 
-  bot.action(ROLE_EXECUTOR_ACTION, async (ctx) => {
+  bot.action(ROLE_PICK_EXECUTOR_ACTION, async (ctx) => {
     if (ctx.chat?.type !== 'private') {
       try {
         await ctx.answerCbQuery('Пожалуйста, продолжите в личном чате с ботом.');
@@ -178,7 +197,7 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
     const executorState = ensureExecutorState(ctx);
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
-    executorState.roleSelectionStage = 'specialization';
+    executorState.roleSelectionStage = 'executorKind';
     ctx.auth.user.executorKind = undefined;
     resetCitySelectionTracking(ctx);
 
@@ -188,7 +207,59 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
       // Ignore callback errors
     }
 
-    await presentExecutorSpecialisationSelection(ctx);
+    await presentExecutorKindSelection(ctx);
+  });
+
+  bot.action(ROLE_PICK_HELP_ACTION, async (ctx) => {
+    if (ctx.chat?.type !== 'private') {
+      try {
+        await ctx.answerCbQuery('Подсказки доступны только в личном чате с ботом.');
+      } catch {
+        // Ignore
+      }
+      return;
+    }
+
+    const executorState = ensureExecutorState(ctx);
+    executorState.awaitingRoleSelection = true;
+    executorState.role = undefined;
+    executorState.roleSelectionStage = 'role';
+    ctx.auth.user.executorKind = undefined;
+    resetCitySelectionTracking(ctx);
+
+    try {
+      await ctx.answerCbQuery('Подсказка отправлена.');
+    } catch {
+      // Ignore callback errors
+    }
+
+    await presentRolePick(ctx, { withHint: true });
+  });
+
+  bot.action(EXECUTOR_KIND_BACK_ACTION, async (ctx) => {
+    if (ctx.chat?.type !== 'private') {
+      try {
+        await ctx.answerCbQuery('Доступно только в личном чате с ботом.');
+      } catch {
+        // Ignore
+      }
+      return;
+    }
+
+    const executorState = ensureExecutorState(ctx);
+    executorState.awaitingRoleSelection = true;
+    executorState.role = undefined;
+    executorState.roleSelectionStage = 'role';
+    ctx.auth.user.executorKind = undefined;
+    resetCitySelectionTracking(ctx);
+
+    try {
+      await ctx.answerCbQuery('Вернёмся к выбору роли.');
+    } catch {
+      // Ignore callback errors
+    }
+
+    await presentRolePick(ctx, { withHint: true });
   });
 
   bot.action(ROLE_SELECTION_BACK_ACTION, async (ctx) => {
@@ -204,7 +275,7 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
     const executorState = ensureExecutorState(ctx);
     const stage = executorState.roleSelectionStage;
 
-    const goToRoleSelection = async (message: string) => {
+    const goToRoleSelection = async (message: string, options?: { withHint?: boolean }) => {
       executorState.awaitingRoleSelection = true;
       executorState.role = undefined;
       executorState.roleSelectionStage = 'role';
@@ -217,13 +288,13 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
         // Ignore callback errors
       }
 
-      await presentRoleSelection(ctx);
+      await presentRolePick(ctx, options);
     };
 
     if (stage === 'city') {
       executorState.awaitingRoleSelection = true;
       executorState.role = undefined;
-      executorState.roleSelectionStage = 'specialization';
+      executorState.roleSelectionStage = 'executorKind';
       ctx.auth.user.executorKind = undefined;
       resetCitySelectionTracking(ctx);
 
@@ -233,12 +304,12 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
         // Ignore callback errors
       }
 
-      await presentExecutorSpecialisationSelection(ctx);
+      await presentExecutorKindSelection(ctx, { withHint: true });
       return;
     }
 
-    if (stage === 'specialization') {
-      await goToRoleSelection('Вернёмся к выбору роли.');
+    if (stage === 'executorKind') {
+      await goToRoleSelection('Вернёмся к выбору роли.', { withHint: true });
       return;
     }
 
@@ -263,7 +334,7 @@ export const registerStartCommand = (bot: Telegraf<BotContext>): void => {
     const executorState = ensureExecutorState(ctx);
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
-    await presentRoleSelection(ctx);
+    await presentRolePick(ctx);
   });
 };
 

--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -13,7 +13,7 @@ import { CITY_LABEL } from '../../../domain/cities';
 import { CLIENT_COMMANDS } from '../../commands/sets';
 import { setChatCommands } from '../../services/commands';
 import type { BotContext } from '../../types';
-import { presentRoleSelection } from '../../commands/start';
+import { presentRolePick } from '../../commands/start';
 import { ensureExecutorState } from '../executor/menu';
 import { promptClientSupport } from './support';
 import { askCity, getCityFromContext, CITY_ACTION_PATTERN } from '../common/citySelect';
@@ -317,7 +317,7 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     const executorState = ensureExecutorState(ctx);
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
-    await presentRoleSelection(ctx);
+    await presentRolePick(ctx);
   });
 
   bot.action(CITY_ACTION_PATTERN, async (ctx, next) => {
@@ -362,7 +362,7 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     const executorState = ensureExecutorState(ctx);
     executorState.awaitingRoleSelection = true;
     executorState.role = undefined;
-    await presentRoleSelection(ctx);
+    await presentRolePick(ctx);
   });
 
   bot.hears(CLIENT_MENU.refresh, async (ctx) => {
@@ -406,6 +406,6 @@ export const registerClientMenu = (bot: Telegraf<BotContext>): void => {
     }
 
     await hideClientMenu(ctx, 'Меняем роль — выберите подходящий вариант ниже.');
-    await presentRoleSelection(ctx);
+    await presentRolePick(ctx);
   });
 };

--- a/src/bot/flows/executor/roleSelect.ts
+++ b/src/bot/flows/executor/roleSelect.ts
@@ -13,10 +13,9 @@ import { getExecutorRoleCopy } from '../../copy';
 import {
   ROLE_SELECTION_BACK_ACTION,
   EXECUTOR_ROLE_PENDING_CITY_ACTION,
+  EXECUTOR_KIND_COURIER_ACTION,
+  EXECUTOR_KIND_DRIVER_ACTION,
 } from './roleSelectionConstants';
-
-const ROLE_COURIER_ACTION = 'role:courier';
-const ROLE_DRIVER_ACTION = 'role:driver';
 
 const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise<void> => {
   if (ctx.chat?.type !== 'private') {
@@ -87,11 +86,11 @@ const handleRoleSelection = async (ctx: BotContext, role: ExecutorRole): Promise
 };
 
 export const registerExecutorRoleSelect = (bot: Telegraf<BotContext>): void => {
-  bot.action(ROLE_COURIER_ACTION, async (ctx) => {
+  bot.action(EXECUTOR_KIND_COURIER_ACTION, async (ctx) => {
     await handleRoleSelection(ctx, 'courier');
   });
 
-  bot.action(ROLE_DRIVER_ACTION, async (ctx) => {
+  bot.action(EXECUTOR_KIND_DRIVER_ACTION, async (ctx) => {
     await handleRoleSelection(ctx, 'driver');
   });
 };

--- a/src/bot/flows/executor/roleSelectionConstants.ts
+++ b/src/bot/flows/executor/roleSelectionConstants.ts
@@ -1,2 +1,7 @@
 export const ROLE_SELECTION_BACK_ACTION = 'start:onboarding:back' as const;
+export const ROLE_PICK_HELP_ACTION = 'start:role-pick:help' as const;
+export const ROLE_PICK_EXECUTOR_ACTION = 'start:role-pick:executor' as const;
+export const EXECUTOR_KIND_BACK_ACTION = 'start:executor-kind:back' as const;
+export const EXECUTOR_KIND_COURIER_ACTION = 'start:executor-kind:courier' as const;
+export const EXECUTOR_KIND_DRIVER_ACTION = 'start:executor-kind:driver' as const;
 export const EXECUTOR_ROLE_PENDING_CITY_ACTION = 'executorRoleSelection' as const;

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -24,7 +24,7 @@ import {
   resetVerificationState,
   showExecutorMenu,
 } from './menu';
-import { presentRoleSelection } from '../../commands/start';
+import { presentRolePick } from '../../commands/start';
 import { publishVerificationApplication, type VerificationApplication } from '../../moderation/verifyQueue';
 import { getExecutorRoleCopy } from '../../copy';
 import { ui } from '../../ui';
@@ -695,7 +695,7 @@ export const registerExecutorVerification = (bot: Telegraf<BotContext>): void =>
 
     state.awaitingRoleSelection = true;
     state.role = undefined;
-    await presentRoleSelection(ctx);
+    await presentRolePick(ctx);
   });
 
   bot.hears(EXECUTOR_MENU_TEXT_LABELS.documents, async (ctx) => {

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -129,7 +129,7 @@ export interface ExecutorFlowState {
   verification: ExecutorVerificationState;
   subscription: ExecutorSubscriptionState;
   awaitingRoleSelection?: boolean;
-  roleSelectionStage?: 'role' | 'specialization' | 'city';
+  roleSelectionStage?: 'role' | 'executorKind' | 'city';
 }
 
 export type ClientOrderStage =


### PR DESCRIPTION
## Summary
- refresh the phone number prompt with guidance text and a dedicated help reply button, plus a handler that resends instructions when users tap it
- split the start command role chooser into ROLE_PICK and EXECUTOR_KIND steps with explicit help/back callbacks and updated keyboards
- wire the new callback identifiers through executor role selection flows and ensure help/back transitions restore the correct stage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d952ccfe20832db311c544e88f3d01