### PR TITLE
Enable inactivity nudger job

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -67,6 +67,13 @@ are missing or blank.
   subscription period from the bot. Enabled by default; set to `false` to disable
   the trial offer entirely.
 
+## Background jobs
+
+- `JOBS_NUDGER_ENABLED` – Enables the inactivity nudger that reminds users about
+  unfinished flows. Disabled by default.
+- `JOBS_NUDGER_INACTIVITY_SECONDS` – Amount of idle time (in seconds) after which
+  the nudger sends a reminder message. Defaults to 90 seconds.
+
 ## Location and geocoding
 
 - `CITY_DEFAULT` – Optional default city appended to short address queries.

--- a/src/bot/copy.ts
+++ b/src/bot/copy.ts
@@ -1,7 +1,7 @@
 import type { ExecutorRole } from './types';
 
 export const copy = {
-  // nudge убран — мешал пользователям.
+  inactivityNudge: '⏳ Похоже, вы отвлеклись. Продолжить можно кнопками ниже.',
   expiredButton: 'Кнопка устарела — отправляю актуальное меню…',
   tooFrequent: 'Слишком часто. Попробуйте через секунду.',
   waiting: 'Принял. Обрабатываю…',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -307,6 +307,8 @@ export interface AppConfig {
   timezone: string;
   jobs: {
     nudger: string;
+    nudgerEnabled: boolean;
+    nudgerInactivitySeconds: number;
     subscription: string;
     metrics: string;
     paymentReminder: string;
@@ -383,6 +385,8 @@ export const loadConfig = (): AppConfig => {
     timezone: getOptionalString('TIMEZONE') ?? 'Asia/Almaty',
     jobs: {
       nudger: getCronExpression('JOBS_NUDGER_CRON', '*/1 * * * *'),
+      nudgerEnabled: parseBoolean(process.env.JOBS_NUDGER_ENABLED),
+      nudgerInactivitySeconds: parsePositiveInt('JOBS_NUDGER_INACTIVITY_SECONDS', 90),
       subscription: getCronExpression('JOBS_SUBSCRIPTION_CRON', '*/10 * * * *'),
       metrics: getCronExpression('JOBS_METRICS_CRON', '*/60 * * * * *'),
       paymentReminder: getCronExpression('JOBS_PAYMENT_REMINDER_CRON', '*/10 * * * *'),


### PR DESCRIPTION
## Summary
- add configuration switches for the inactivity nudger and document the environment variables
- re-enable the cron-driven nudger to notify inactive sessions with signed callback buttons and mark them as nudged
- introduce copy for the reminder card so the buttons can reuse existing flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d958a0b3f0832d8e526fd308d0c281