### PR TITLE
Refine executor role schema and onboarding

### DIFF
--- a/db/migrations/0013_user_role_executor_sync.down.sql
+++ b/db/migrations/0013_user_role_executor_sync.down.sql
@@ -1,0 +1,2 @@
+BEGIN;
+COMMIT;

--- a/db/migrations/0013_user_role_executor_sync.up.sql
+++ b/db/migrations/0013_user_role_executor_sync.up.sql
@@ -1,0 +1,139 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'executor_kind') THEN
+    CREATE TYPE executor_kind AS ENUM ('courier', 'driver');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_verify_status') THEN
+    CREATE TYPE user_verify_status AS ENUM ('none', 'pending', 'active', 'rejected', 'expired');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_subscription_status') THEN
+    CREATE TYPE user_subscription_status AS ENUM ('none', 'trial', 'active', 'grace', 'expired');
+  END IF;
+END $$;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS executor_kind executor_kind,
+  ADD COLUMN IF NOT EXISTS verify_status user_verify_status NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS sub_status user_subscription_status NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS sub_expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS has_active_order BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE users
+  ALTER COLUMN verify_status SET DEFAULT 'none',
+  ALTER COLUMN sub_status SET DEFAULT 'none',
+  ALTER COLUMN has_active_order SET DEFAULT FALSE;
+
+UPDATE users
+SET executor_kind = CASE role::text
+  WHEN 'courier' THEN 'courier'::executor_kind
+  WHEN 'driver' THEN 'driver'::executor_kind
+  ELSE executor_kind
+END
+WHERE executor_kind IS NULL
+  AND role::text IN ('courier', 'driver');
+
+DO $$
+DECLARE
+  has_legacy_roles BOOLEAN;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_type t
+    JOIN pg_enum e ON e.enumtypid = t.oid
+    WHERE t.typname = 'user_role'
+      AND e.enumlabel IN ('courier', 'driver')
+  ) INTO has_legacy_roles;
+
+  IF has_legacy_roles THEN
+    ALTER TYPE user_role RENAME TO user_role_old;
+
+    CREATE TYPE user_role AS ENUM ('guest', 'client', 'executor', 'moderator');
+
+    ALTER TABLE users
+      ALTER COLUMN role DROP DEFAULT,
+      ALTER COLUMN role TYPE user_role USING (
+        CASE role::text
+          WHEN 'courier' THEN 'executor'
+          WHEN 'driver' THEN 'executor'
+          WHEN 'guest' THEN 'guest'
+          WHEN 'client' THEN 'client'
+          WHEN 'moderator' THEN 'moderator'
+          WHEN 'executor' THEN 'executor'
+          ELSE 'guest'
+        END
+      )::user_role,
+      ALTER COLUMN role SET DEFAULT 'client';
+
+    DROP TYPE user_role_old;
+  ELSE
+    ALTER TABLE users
+      ALTER COLUMN role SET DEFAULT 'client';
+
+    UPDATE users
+    SET role = 'executor'::user_role
+    WHERE role::text IN ('courier', 'driver');
+  END IF;
+END $$;
+
+WITH latest AS (
+  SELECT DISTINCT ON (user_id) user_id, status
+  FROM verifications
+  ORDER BY user_id, updated_at DESC, id DESC
+)
+UPDATE users AS u
+SET verify_status = CASE
+      WHEN u.verify_status = 'active' THEN 'active'
+      WHEN latest.status IS NULL THEN u.verify_status
+      WHEN latest.status = 'active' THEN 'active'
+      WHEN latest.status = 'pending' THEN 'pending'
+      WHEN latest.status = 'rejected' THEN 'rejected'
+      WHEN latest.status = 'expired' THEN 'expired'
+      ELSE u.verify_status
+    END
+FROM latest
+WHERE u.tg_id = latest.user_id;
+
+UPDATE users
+SET verify_status = 'active'
+WHERE verify_status = 'none' AND role = 'executor' AND executor_kind IS NOT NULL;
+
+UPDATE users
+SET trial_started_at = COALESCE(trial_started_at, verified_at, trial_expires_at)
+WHERE trial_started_at IS NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'trial_ends_at'
+  ) THEN
+    UPDATE users
+    SET trial_expires_at = COALESCE(trial_expires_at, trial_ends_at)
+    WHERE trial_expires_at IS NULL;
+  END IF;
+END $$;
+
+UPDATE users
+SET trial_expires_at = COALESCE(trial_expires_at, trial_started_at)
+WHERE trial_expires_at IS NULL;
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS trial_ends_at,
+  DROP COLUMN IF EXISTS is_verified;
+
+COMMIT;

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -121,7 +121,7 @@ const applyCommandsForRole = async (ctx: BotContext): Promise<void> => {
     return;
   }
 
-  if (role === 'executor') {
+  if (role === 'executor' || role === 'moderator') {
     await setChatCommands(ctx.telegram, ctx.chat.id, EXECUTOR_COMMANDS, { showMenuButton: true });
   }
 };

--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -198,7 +198,10 @@ const getCachedExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
 
 export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
   const authRole = ctx.auth.user.role;
-  if (authRole === 'executor' && isExecutorKind(ctx.auth.user.executorKind)) {
+  if (
+    (authRole === 'executor' || authRole === 'moderator')
+    && isExecutorKind(ctx.auth.user.executorKind)
+  ) {
     return true;
   }
 
@@ -212,7 +215,10 @@ export const userLooksLikeExecutor = (ctx: BotContext): boolean => {
 
 const deriveAuthExecutorRole = (ctx: BotContext): ExecutorRole | undefined => {
   const authRole = ctx.auth.user.role;
-  if (authRole === 'executor' && isExecutorKind(ctx.auth.user.executorKind)) {
+  if (
+    (authRole === 'executor' || authRole === 'moderator')
+    && isExecutorKind(ctx.auth.user.executorKind)
+  ) {
     return ctx.auth.user.executorKind;
   }
 

--- a/src/bot/middlewares/keyboardGuard.ts
+++ b/src/bot/middlewares/keyboardGuard.ts
@@ -21,8 +21,9 @@ const isExecutorUser = (ctx: BotContext): boolean => {
     return false;
   }
   return (
-    role === 'executor' ||
-    status === 'active_executor'
+    role === 'executor'
+    || role === 'moderator'
+    || status === 'active_executor'
   );
 };
 

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -81,7 +81,7 @@ const createSupportState = (): SupportSessionState => ({
   status: 'idle',
 });
 
-const USER_ROLES: readonly UserRole[] = ['guest', 'client', 'executor'];
+const USER_ROLES: readonly UserRole[] = ['guest', 'client', 'executor', 'moderator'];
 const USER_STATUSES: readonly UserStatus[] = [
   'guest',
   'onboarding',
@@ -161,12 +161,10 @@ const rebuildAuthSnapshot = (value: unknown, sessionUser?: SessionUser): AuthSta
   };
 
   const candidateRole = (candidate as { role?: unknown }).role;
-  if (typeof candidateRole === 'string') {
+  if (typeof candidateRole === 'string' && USER_ROLES.includes(candidateRole as UserRole)) {
+    snapshot.role = candidateRole as UserRole;
     if (candidateRole === 'moderator') {
-      snapshot.role = 'executor';
       snapshot.isModerator = true;
-    } else if (USER_ROLES.includes(candidateRole as UserRole)) {
-      snapshot.role = candidateRole as UserRole;
     }
   }
 
@@ -200,6 +198,8 @@ const rebuildAuthSnapshot = (value: unknown, sessionUser?: SessionUser): AuthSta
   }
 
   if (snapshot.isModerator) {
+    snapshot.role = 'moderator';
+  } else if (snapshot.role === 'moderator') {
     snapshot.role = 'executor';
   }
 

--- a/src/bot/middlewares/verificationGate.ts
+++ b/src/bot/middlewares/verificationGate.ts
@@ -49,7 +49,7 @@ const resolveExecutorRole = (ctx: BotContext, fallback: ExecutorRole): ExecutorR
 
 export const ensureVerifiedExecutor: MiddlewareFn<BotContext> = async (ctx, next) => {
   const role = ctx.auth?.user.role;
-  if (role !== 'executor') {
+  if (role !== 'executor' && role !== 'moderator') {
     await next();
     return;
   }

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -5,11 +5,15 @@ import type { AppCity } from '../domain/cities';
 
 export const EXECUTOR_VERIFICATION_PHOTO_COUNT = 2;
 
-export type ExecutorRole = 'courier' | 'driver';
+export type ExecutorKind = 'courier' | 'driver';
 
-export const EXECUTOR_ROLES: readonly ExecutorRole[] = ['courier', 'driver'];
+export const EXECUTOR_KINDS: readonly ExecutorKind[] = ['courier', 'driver'];
 
-export type UserRole = 'guest' | 'client' | 'executor';
+export type ExecutorRole = ExecutorKind;
+
+export const EXECUTOR_ROLES = EXECUTOR_KINDS;
+
+export type UserRole = 'guest' | 'client' | 'executor' | 'moderator';
 
 export type UserVerifyStatus = 'none' | 'pending' | 'active' | 'rejected' | 'expired';
 

--- a/src/bot/ui/menus.ts
+++ b/src/bot/ui/menus.ts
@@ -66,7 +66,7 @@ export const renderMenuFor = async (
   }
 
   const role = user.role;
-  if (role === 'executor') {
+  if (role === 'executor' || role === 'moderator') {
     await ctx.reply(prompt ?? 'Меню исполнителя доступно ниже.', executorKeyboard());
     return;
   }

--- a/src/db/subscriptions.ts
+++ b/src/db/subscriptions.ts
@@ -1,7 +1,6 @@
+import type { ExecutorKind } from '../bot/types';
 import type { PoolClient } from './client';
 import { pool, withTx } from './client';
-
-type ExecutorRole = 'courier' | 'driver';
 
 export type SubscriptionStatus =
   | 'pending'
@@ -15,7 +14,7 @@ interface TelegramUserDetails {
   firstName?: string;
   lastName?: string;
   phone?: string;
-  executorKind: ExecutorRole;
+  executorKind: ExecutorKind;
 }
 
 interface SubscriptionRow {

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,5 +1,5 @@
 import { pool } from './client';
-import type { ExecutorRole } from '../bot/types';
+import type { ExecutorKind, UserRole } from '../bot/types';
 
 export interface EnsureClientRoleParams {
   telegramId: number;
@@ -11,8 +11,8 @@ export interface EnsureClientRoleParams {
 
 export interface UpdateUserRoleParams {
   telegramId: number;
-  role: 'guest' | 'client' | 'executor';
-  executorKind?: ExecutorRole | null;
+  role: Exclude<UserRole, 'moderator'>;
+  executorKind?: ExecutorKind | null;
   status?: 'active_client' | 'active_executor' | 'safe_mode';
   menuRole?: 'client' | 'courier';
 }
@@ -116,8 +116,14 @@ export const updateUserRole = async ({
   status,
   menuRole,
 }: UpdateUserRoleParams): Promise<void> => {
-  const effectiveStatus = status ?? (role === 'client' ? 'active_client' : 'active_executor');
-  const effectiveMenuRole = menuRole ?? (role === 'client' ? 'client' : 'courier');
+  const effectiveStatus = status
+    ?? (role === 'client'
+      ? 'active_client'
+      : role === 'executor'
+        ? 'active_executor'
+        : 'guest');
+  const effectiveMenuRole = menuRole
+    ?? (role === 'client' ? 'client' : role === 'executor' ? 'courier' : 'client');
   const resolvedExecutorKind = role === 'executor' ? executorKind ?? null : null;
 
   await pool.query(

--- a/src/db/verifications.ts
+++ b/src/db/verifications.ts
@@ -1,8 +1,8 @@
 import { pool, withTx } from './client';
 import type { PoolClient } from './client';
-import type { ExecutorRole } from '../bot/types';
+import type { ExecutorKind } from '../bot/types';
 
-export type VerificationRole = ExecutorRole;
+export type VerificationRole = ExecutorKind;
 
 export interface VerificationApplicant {
   telegramId: number;


### PR DESCRIPTION
## Summary
- add a migration that normalises the user role enum, executor profile columns, and legacy data
- update database helpers, auth middleware, and session snapshots to surface the moderator role and executor_kind
- adjust executor onboarding and guards so moderator accounts share executor behaviour and rely on the new profile fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d967a35edc832d81fa0e26dd0244a9