### PR TITLE
Normalize safe mode degradation flag and backfill sessions

### DIFF
--- a/db/migrations/0013_sessions_safe_mode_flags.down.sql
+++ b/db/migrations/0013_sessions_safe_mode_flags.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE sessions
+  DROP COLUMN IF EXISTS safe_mode,
+  DROP COLUMN IF EXISTS is_degraded;
+
+COMMIT;

--- a/db/migrations/0013_sessions_safe_mode_flags.up.sql
+++ b/db/migrations/0013_sessions_safe_mode_flags.up.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS safe_mode BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS is_degraded BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE sessions
+SET safe_mode = CASE
+    WHEN state ? 'safeMode' THEN COALESCE((state ->> 'safeMode')::BOOLEAN, false)
+    ELSE false
+  END
+WHERE safe_mode IS DISTINCT FROM CASE
+    WHEN state ? 'safeMode' THEN COALESCE((state ->> 'safeMode')::BOOLEAN, false)
+    ELSE false
+  END;
+
+UPDATE sessions
+SET is_degraded = CASE
+    WHEN state ? 'isDegraded' THEN COALESCE((state ->> 'isDegraded')::BOOLEAN, false)
+    WHEN state ? 'degraded' THEN COALESCE((state ->> 'degraded')::BOOLEAN, false)
+    ELSE false
+  END
+WHERE is_degraded IS DISTINCT FROM CASE
+    WHEN state ? 'isDegraded' THEN COALESCE((state ->> 'isDegraded')::BOOLEAN, false)
+    WHEN state ? 'degraded' THEN COALESCE((state ->> 'degraded')::BOOLEAN, false)
+    ELSE false
+  END;
+
+COMMIT;

--- a/src/bot/flows/common/safeMode.ts
+++ b/src/bot/flows/common/safeMode.ts
@@ -66,7 +66,7 @@ const buildProfileSummary = (ctx: BotContext): string => {
 
 export const isSafeModeSession = (ctx: BotContext): boolean =>
   ctx.session.safeMode === true
-  || ctx.session.degraded === true
+  || ctx.session.isDegraded === true
   || ctx.auth?.user.status === 'safe_mode';
 
 export const showSafeModeCard = async (

--- a/src/bot/middlewares/auth.ts
+++ b/src/bot/middlewares/auth.ts
@@ -541,13 +541,13 @@ const applyAuthState = (
     isAuthenticated?: boolean;
     isStale?: boolean;
     safeMode?: boolean;
-    degraded?: boolean;
+    isDegraded?: boolean;
   },
 ): void => {
   ctx.auth = authState;
   ctx.session.isAuthenticated = options?.isAuthenticated ?? true;
   ctx.session.safeMode = options?.safeMode ?? false;
-  ctx.session.degraded = options?.degraded ?? false;
+  ctx.session.isDegraded = options?.isDegraded ?? false;
   ctx.session.user = {
     id: authState.user.telegramId,
     username: authState.user.username,
@@ -657,7 +657,7 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
 
   try {
     const authState = await loadAuthState(ctx.from);
-    applyAuthState(ctx, authState, { isStale: false, degraded: false });
+    applyAuthState(ctx, authState, { isStale: false, isDegraded: false });
   } catch (error) {
     if (error instanceof AuthStateQueryError) {
       const cachedSnapshot = ctx.session.authSnapshot;
@@ -689,7 +689,7 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
           isAuthenticated: false,
           isStale: true,
           safeMode: true,
-          degraded: true,
+          isDegraded: true,
         });
       } else {
         const guestState = createGuestAuthState(ctx.from!);
@@ -698,7 +698,7 @@ export const auth = (): MiddlewareFn<BotContext> => async (ctx, next) => {
           isAuthenticated: false,
           isStale: true,
           safeMode: true,
-          degraded: true,
+          isDegraded: true,
         });
       }
 

--- a/src/bot/middlewares/session.ts
+++ b/src/bot/middlewares/session.ts
@@ -379,8 +379,16 @@ const normaliseSessionState = (state: SessionState): SessionState => {
     working.safeMode = false;
   }
 
-  if (typeof (working as { degraded?: unknown }).degraded !== 'boolean') {
-    working.degraded = false;
+  const safeModeFlags = working as { isDegraded?: unknown; degraded?: unknown };
+  if (typeof safeModeFlags.isDegraded === 'boolean') {
+    if ('degraded' in safeModeFlags) {
+      delete safeModeFlags.degraded;
+    }
+  } else if (typeof safeModeFlags.degraded === 'boolean') {
+    working.isDegraded = safeModeFlags.degraded;
+    delete safeModeFlags.degraded;
+  } else {
+    working.isDegraded = false;
   }
 
   if (!working.ui) {
@@ -405,7 +413,7 @@ const createDefaultState = (): SessionState => ({
   ephemeralMessages: [],
   isAuthenticated: false,
   safeMode: false,
-  degraded: false,
+  isDegraded: false,
   awaitingPhone: false,
   city: undefined,
   authSnapshot: createAuthSnapshot(),
@@ -421,7 +429,7 @@ const prepareFallbackSession = (
   const session = normaliseSessionState(state ?? createDefaultState());
   session.isAuthenticated = false;
   session.safeMode = true;
-  session.degraded = true;
+  session.isDegraded = true;
   session.authSnapshot.status = 'safe_mode';
   session.authSnapshot.stale = true;
   return session;
@@ -597,7 +605,10 @@ export const session = (): MiddlewareFn<BotContext> => async (ctx, next) => {
       }
 
       ctx.session = normaliseSessionState(state);
-      ctx.session.degraded = false;
+      ctx.session.isDegraded = false;
+      if (ctx.session.safeMode) {
+        ctx.session.safeMode = false;
+      }
 
       await invokeNext();
       finalState = ctx.session;

--- a/src/bot/services/cleanup.ts
+++ b/src/bot/services/cleanup.ts
@@ -21,10 +21,10 @@ export const enterSafeMode = async (
     return;
   }
 
-  const alreadySafe = ctx.session.safeMode === true && ctx.session.degraded === true;
+  const alreadySafe = ctx.session.safeMode === true && ctx.session.isDegraded === true;
 
   ctx.session.safeMode = true;
-  ctx.session.degraded = true;
+  ctx.session.isDegraded = true;
   ctx.session.isAuthenticated = false;
   ctx.session.authSnapshot.status = 'safe_mode';
   ctx.session.authSnapshot.stale = true;

--- a/src/bot/types.ts
+++ b/src/bot/types.ts
@@ -198,7 +198,7 @@ export interface SessionState {
   ephemeralMessages: number[];
   isAuthenticated: boolean;
   safeMode: boolean;
-  degraded: boolean;
+  isDegraded: boolean;
   awaitingPhone: boolean;
   phoneNumber?: string;
   user?: SessionUser;

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -58,10 +58,20 @@ const parseSessionState = (row: SessionRow): SessionState => {
     state.safeMode = false;
   }
 
+  const legacyState = state as { isDegraded?: unknown; degraded?: unknown };
+
   if (typeof row.is_degraded === 'boolean') {
-    state.degraded = row.is_degraded;
-  } else if (typeof (state as { degraded?: unknown }).degraded !== 'boolean') {
-    state.degraded = false;
+    state.isDegraded = row.is_degraded;
+  } else if (typeof legacyState.isDegraded === 'boolean') {
+    state.isDegraded = legacyState.isDegraded;
+  } else if (typeof legacyState.degraded === 'boolean') {
+    state.isDegraded = legacyState.degraded;
+  } else {
+    state.isDegraded = false;
+  }
+
+  if ('degraded' in legacyState) {
+    delete legacyState.degraded;
   }
 
   return state;
@@ -122,7 +132,7 @@ export const saveSessionState = async (
           is_degraded = EXCLUDED.is_degraded,
           updated_at = now()
     `,
-    [key.scope, key.scopeId, payload, state.safeMode === true, state.degraded === true],
+    [key.scope, key.scopeId, payload, state.safeMode === true, state.isDegraded === true],
   );
 };
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,5 +1,5 @@
 import { pool } from './client';
-import type { ExecutorRole } from '../bot/types';
+import type { ExecutorRole, UserStatus } from '../bot/types';
 
 export interface EnsureClientRoleParams {
   telegramId: number;
@@ -9,11 +9,13 @@ export interface EnsureClientRoleParams {
   phone?: string;
 }
 
+type ActiveUserStatuses = Extract<UserStatus, 'active_client' | 'active_executor' | 'safe_mode'>;
+
 export interface UpdateUserRoleParams {
   telegramId: number;
   role: 'guest' | 'client' | 'executor';
   executorKind?: ExecutorRole | null;
-  status?: 'active_client' | 'active_executor' | 'safe_mode';
+  status?: ActiveUserStatuses;
   menuRole?: 'client' | 'courier';
 }
 


### PR DESCRIPTION
## Summary
- add a migration that ensures the sessions table has safe mode columns populated from stored state
- rename the session degradation flag to `isDegraded` and keep backwards compatibility with legacy payloads
- update session/auth middleware and safe mode flows to toggle the new flag and exit safe mode after recovery

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d967aa1f90832d8f6702e6e807dd62