### PR TITLE
refactor: centralise safe mode card UI

### DIFF
--- a/src/bot/flows/common/safeMode.ts
+++ b/src/bot/flows/common/safeMode.ts
@@ -1,44 +1,13 @@
 import type { Telegraf } from 'telegraf';
 
 import type { BotContext } from '../../types';
-import { ui } from '../../ui';
-import { buildInlineKeyboard } from '../../keyboards/common';
+import { SAFE_MODE_CARD_ACTIONS, buildSafeModeCardText } from '../../ui/safeModeCard';
 import { askCity } from './citySelect';
 import { promptClientSupport } from '../client/support';
 
-export const SAFE_MODE_CARD_STEP_ID = 'common:safe-mode:card';
-
-const SAFE_MODE_PROFILE_ACTION = 'safe-mode:profile';
-const SAFE_MODE_CITY_ACTION = 'safe-mode:city';
-const SAFE_MODE_SUPPORT_ACTION = 'safe-mode:support';
-
-const SAFE_MODE_ACTIONS = {
-  profile: SAFE_MODE_PROFILE_ACTION,
-  city: SAFE_MODE_CITY_ACTION,
-  support: SAFE_MODE_SUPPORT_ACTION,
-} as const;
-
-const buildSafeModeKeyboard = () =>
-  buildInlineKeyboard([
-    [
-      { label: '👤 Профиль', action: SAFE_MODE_PROFILE_ACTION },
-      { label: '🏙️ Сменить город', action: SAFE_MODE_CITY_ACTION },
-    ],
-    [{ label: '🆘 Помощь', action: SAFE_MODE_SUPPORT_ACTION }],
-  ]);
-
-const buildSafeModeCardText = (prompt?: string): string => {
-  const lines = [
-    '⚠️ Freedom Bot работает в безопасном режиме — часть функций недоступна.',
-    prompt ?? 'Пока доступны только базовые действия: [Профиль], [Сменить город], [Помощь].',
-    '',
-    '• 👤 Профиль — посмотрите актуальные данные аккаунта.',
-    '• 🏙️ Сменить город — уточните рабочий город.',
-    '• 🆘 Помощь — свяжитесь с поддержкой.',
-  ];
-
-  return lines.join('\n');
-};
+const SAFE_MODE_PROFILE_ACTION = SAFE_MODE_CARD_ACTIONS.profile;
+const SAFE_MODE_CITY_ACTION = SAFE_MODE_CARD_ACTIONS.city;
+const SAFE_MODE_SUPPORT_ACTION = SAFE_MODE_CARD_ACTIONS.support;
 
 const buildProfileSummary = (ctx: BotContext): string => {
   const authUser = ctx.auth?.user;
@@ -68,23 +37,6 @@ export const isSafeModeSession = (ctx: BotContext): boolean =>
   ctx.session.safeMode === true
   || ctx.session.isDegraded === true
   || ctx.auth?.user.status === 'safe_mode';
-
-export const showSafeModeCard = async (
-  ctx: BotContext,
-  options: { prompt?: string } = {},
-): Promise<void> => {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
-    return;
-  }
-
-  await ui.step(ctx, {
-    id: SAFE_MODE_CARD_STEP_ID,
-    text: buildSafeModeCardText(options.prompt),
-    keyboard: buildSafeModeKeyboard(),
-    cleanup: false,
-  });
-};
 
 export const registerSafeModeActions = (bot: Telegraf<BotContext>): void => {
   bot.action(SAFE_MODE_PROFILE_ACTION, async (ctx) => {
@@ -150,5 +102,5 @@ export const registerSafeModeActions = (bot: Telegraf<BotContext>): void => {
 export const __testing__ = {
   buildSafeModeCardText,
   buildProfileSummary,
-  SAFE_MODE_ACTIONS,
+  SAFE_MODE_ACTIONS: SAFE_MODE_CARD_ACTIONS,
 };

--- a/src/bot/middlewares/keyboardGuard.ts
+++ b/src/bot/middlewares/keyboardGuard.ts
@@ -9,7 +9,8 @@ import {
   removeKeyboard,
 } from '../ui/menus';
 import type { BotContext } from '../types';
-import { isSafeModeSession, showSafeModeCard } from '../flows/common/safeMode';
+import { isSafeModeSession } from '../flows/common/safeMode';
+import { showSafeModeCard } from '../ui/safeModeCard';
 
 const hasKnownButtonText = (text: string): boolean =>
   CLIENT_WHITELIST.has(text) || EXECUTOR_WHITELIST.has(text);

--- a/src/bot/middlewares/stateGate.ts
+++ b/src/bot/middlewares/stateGate.ts
@@ -3,7 +3,8 @@ import type { MiddlewareFn } from 'telegraf';
 import { executorKeyboard, onboardingKeyboard, removeKeyboard } from '../ui/menus';
 import type { BotContext } from '../types';
 import { logger } from '../../config';
-import { isSafeModeSession, showSafeModeCard } from '../flows/common/safeMode';
+import { isSafeModeSession } from '../flows/common/safeMode';
+import { showSafeModeCard } from '../ui/safeModeCard';
 
 const GUEST_ALLOWLIST = new Set<string>([
   '/start',

--- a/src/bot/services/cleanup.ts
+++ b/src/bot/services/cleanup.ts
@@ -2,7 +2,7 @@ import { logger } from '../../config';
 import type { BotContext } from '../types';
 
 import { safeEditReplyMarkup } from '../../utils/tg';
-import { showSafeModeCard } from '../flows/common/safeMode';
+import { showSafeModeCard } from '../ui/safeModeCard';
 
 const DEFAULT_SAFE_MODE_PROMPT =
   'Мы восстанавливаем данные. Пока доступны действия: [Профиль], [Сменить город], [Помощь].';

--- a/src/bot/ui/menus.ts
+++ b/src/bot/ui/menus.ts
@@ -3,7 +3,8 @@ import { Markup } from 'telegraf';
 import { CLIENT_MENU } from '../../ui/clientMenu';
 import type { BotContext } from '../types';
 import { EXECUTOR_MENU_TEXT_LABELS } from '../flows/executor/menu';
-import { isSafeModeSession, showSafeModeCard } from '../flows/common/safeMode';
+import { isSafeModeSession } from '../flows/common/safeMode';
+import { showSafeModeCard } from './safeModeCard';
 
 export const CLIENT_WHITELIST: Set<string> = new Set(Object.values(CLIENT_MENU));
 export const EXECUTOR_WHITELIST: Set<string> = new Set(

--- a/src/bot/ui/safeModeCard.ts
+++ b/src/bot/ui/safeModeCard.ts
@@ -1,0 +1,63 @@
+import type { BotContext } from '../types';
+import { ui } from '../ui';
+import { buildInlineKeyboard } from '../keyboards/common';
+
+export const SAFE_MODE_CARD_STEP_ID = 'common:safe-mode:card';
+
+const SAFE_MODE_PROFILE_ACTION = 'safe-mode:profile';
+const SAFE_MODE_CITY_ACTION = 'safe-mode:city';
+const SAFE_MODE_SUPPORT_ACTION = 'safe-mode:support';
+
+export const SAFE_MODE_CARD_ACTIONS = {
+  profile: SAFE_MODE_PROFILE_ACTION,
+  city: SAFE_MODE_CITY_ACTION,
+  support: SAFE_MODE_SUPPORT_ACTION,
+} as const;
+
+const buildSafeModeKeyboard = () =>
+  buildInlineKeyboard([
+    [
+      { label: '👤 Профиль', action: SAFE_MODE_PROFILE_ACTION },
+      { label: '🏙️ Сменить город', action: SAFE_MODE_CITY_ACTION },
+    ],
+    [{ label: '🆘 Помощь', action: SAFE_MODE_SUPPORT_ACTION }],
+  ]);
+
+export const buildSafeModeCardText = (prompt?: string): string => {
+  const lines = [
+    '⚠️ Freedom Bot работает в безопасном режиме — часть функций недоступна.',
+    prompt ?? 'Пока доступны только базовые действия: [Профиль], [Сменить город], [Помощь].',
+    '',
+    '• 👤 Профиль — посмотрите актуальные данные аккаунта.',
+    '• 🏙️ Сменить город — уточните рабочий город.',
+    '• 🆘 Помощь — свяжитесь с поддержкой.',
+  ];
+
+  return lines.join('\n');
+};
+
+export interface ShowSafeModeCardOptions {
+  prompt?: string;
+}
+
+export const showSafeModeCard = async (
+  ctx: BotContext,
+  options: ShowSafeModeCardOptions = {},
+): Promise<void> => {
+  const chatId = ctx.chat?.id;
+  if (!chatId) {
+    return;
+  }
+
+  await ui.step(ctx, {
+    id: SAFE_MODE_CARD_STEP_ID,
+    text: buildSafeModeCardText(options.prompt),
+    keyboard: buildSafeModeKeyboard(),
+    cleanup: false,
+  });
+};
+
+export const __testing__ = {
+  buildSafeModeCardText,
+  SAFE_MODE_CARD_ACTIONS,
+};


### PR DESCRIPTION
## Summary
- extract the SAFE_MODE recovery card into a shared UI helper with reusable text and inline keyboard
- update menus and middleware to reuse the helper when sessions enter safe mode for consistent recovery messaging

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d976e411fc832d88e0e6e12cb2bf95