### PR TITLE
Update executor verification prompts and reminder handling

### DIFF
--- a/src/bot/flows/executor/menu.ts
+++ b/src/bot/flows/executor/menu.ts
@@ -31,7 +31,7 @@ export const EXECUTOR_SUBSCRIPTION_ACTION = 'executor:subscription:link';
 export const EXECUTOR_ORDERS_ACTION = 'executor:orders:link';
 export const EXECUTOR_SUPPORT_ACTION = 'support:contact';
 export const EXECUTOR_MENU_ACTION = 'executor:menu:refresh';
-const EXECUTOR_MENU_STEP_ID = 'executor:menu:main';
+const EXECUTOR_MENU_STEP_ID = 'executor:menu:card:v2';
 export const EXECUTOR_MENU_CITY_ACTION = 'executorMenu';
 
 export const EXECUTOR_MENU_TEXT_LABELS = {
@@ -444,9 +444,9 @@ const buildVerificationSection = (
   const instructions = (() => {
     switch (verification.status) {
       case 'idle':
-        return `${guidance.idlePrompt} ${VERIFICATION_ALBUM_HINT}`;
+        return `${guidance.idlePrompt} ${VERIFICATION_ALBUM_HINT} Если нужны примеры, нажмите «Что подходит?» в карточке проверки.`;
       case 'collecting':
-        return `${guidance.collectingPrompt} ${VERIFICATION_ALBUM_HINT}`;
+        return `${guidance.collectingPrompt} ${VERIFICATION_ALBUM_HINT} Не уверены? Откройте «Что подходит?» или воспользуйтесь кнопками «Назад/Где я?» и «Помощь».`;
       case 'submitted':
         return 'Мы передали документы модераторам. После одобрения выдадим доступ автоматически.';
       default:
@@ -524,7 +524,7 @@ const buildNextStepsSection = (
 
   if (!access.isVerified) {
     return [
-      `${guidance.nextStepsPrompt} ${VERIFICATION_ALBUM_HINT}`,
+      `${guidance.nextStepsPrompt} ${VERIFICATION_ALBUM_HINT} Сомневаетесь? Нажмите «Что подходит?» в карточке проверки.`,
       'Дождитесь решения модератора — уведомление придёт в этот чат.',
       'После одобрения автоматически активируется 2-дневный бесплатный доступ, затем оформите подписку через «📨 Получить ссылку на канал».',
     ];

--- a/src/bot/flows/executor/verification.ts
+++ b/src/bot/flows/executor/verification.ts
@@ -84,15 +84,13 @@ const buildVerificationPrompt = (role: ExecutorRole): string => {
   const requiredPhotos = requirements.length || EXECUTOR_VERIFICATION_PHOTO_COUNT;
   const requirementLines = requirements.map((item, index) => `${index + 1}. ${item}`);
 
-  return [
-    '🛡️ Проверка документов',
-    '',
+  const paragraphs = [
     `Чтобы получить доступ к заказам ${copy.genitive}, пришлите ${requiredPhotos} фото в этот чат.`,
-    '',
     ['Нужно:', ...requirementLines].join('\n'),
-    '',
     `ℹ️ ${VERIFICATION_ALBUM_HINT} Не уверены, что отправлять? Нажмите «Что подходит?» — покажем примеры. Запутались? Воспользуйтесь «Назад/Где я?» или «Помощь».`,
-  ].join('\n');
+  ];
+
+  return ['🛡️ Проверка документов', '', paragraphs.join('\n\n')].join('\n');
 };
 
 const VERIFICATION_CHANNEL_MISSING_STEP_ID = 'executor:verification:channel-missing';
@@ -126,15 +124,13 @@ const buildVerificationPromptKeyboard = () =>
 const buildVerificationGuidanceText = (role: ExecutorRole): string => {
   const guidance = getVerificationRoleGuidance(role);
 
-  return [
-    'ℹ️ Что подходит?',
-    '',
+  const paragraphs = [
     guidance.nextStepsPrompt,
-    '',
     '⚠️ Фото должны быть чёткими, без бликов и закрытых данных.',
-    '',
     `ℹ️ ${VERIFICATION_ALBUM_HINT} Если запутались, нажмите «Назад/Где я?» — вернёмся к выбору. Нужна поддержка? Нажмите «Помощь».`,
-  ].join('\n');
+  ];
+
+  return ['ℹ️ Что подходит?', '', paragraphs.join('\n\n')].join('\n');
 };
 
 const VERIFICATION_GUIDANCE_STEP_ID = 'executor:verification:guidance';


### PR DESCRIPTION
## Summary
- refresh the verification prompt copy and keyboard to include guidance buttons
- adjust the verification gate to resend the prompt on unsupported input and update the reminder timestamp
- align executor menu reminders with the new wording and bump the menu step id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9828c57a0832d859eeb14b4b81fcb