### PR TITLE
Update user subscription state lifecycle

### DIFF
--- a/src/bot/channels/membership.ts
+++ b/src/bot/channels/membership.ts
@@ -9,6 +9,7 @@ import {
   type ActiveSubscriptionDetails,
 } from '../../db/subscriptions';
 import type { BotContext } from '../types';
+import { updateUserSubscriptionStatus } from '../../db/users';
 
 const INACTIVE_STATUSES = new Set<ChatMemberUpdated['new_chat_member']['status']>([
   'left',
@@ -75,6 +76,16 @@ export const registerMembershipSync = (
         },
         'Marked subscription inactive after membership downgrade',
       );
+      const subscriptionExpiresAt = subscription.expiresAt ?? endedAt;
+      await updateUserSubscriptionStatus({
+        telegramId: userId,
+        subscriptionStatus: 'expired',
+        subscriptionExpiresAt,
+        trialExpiresAt: null,
+        hasActiveOrder: false,
+        status: 'trial_expired',
+        updatedAt: endedAt,
+      });
     } catch (error) {
       logger.error(
         { err: error, chatId, userId, subscriptionId: subscription.id },

--- a/src/bot/flows/executor/subscription.ts
+++ b/src/bot/flows/executor/subscription.ts
@@ -216,6 +216,10 @@ const activateTrialSubscription = async (ctx: BotContext): Promise<void> => {
       lastName: ctx.auth.user.lastName ?? undefined,
       phone: ctx.auth.user.phone ?? ctx.session.phoneNumber ?? undefined,
       shortId: trial.subscriptionId ? String(trial.subscriptionId) : undefined,
+      subscriptionStatus: 'trial',
+      subscriptionExpiresAt: trial.expiresAt,
+      trialExpiresAt: trial.expiresAt,
+      hasActiveOrder: ctx.auth.user.hasActiveOrder,
     };
 
     await reportSubscriptionTrialActivated(ctx.telegram, subscriber, trial.expiresAt);

--- a/src/bot/moderation/paymentQueue.ts
+++ b/src/bot/moderation/paymentQueue.ts
@@ -422,6 +422,8 @@ const handleSubscriptionApproval = async (
     lastName: subscription.lastName ?? undefined,
     phone: subscription.phone,
     shortId: activation.subscriptionId ? String(activation.subscriptionId) : undefined,
+    subscriptionStatus: 'active',
+    subscriptionExpiresAt: activation.nextBillingAt,
   };
 
   await reportSubscriptionApproved(
@@ -521,6 +523,7 @@ const handleSubscriptionRejection = async (
     firstName: subscription.firstName ?? undefined,
     lastName: subscription.lastName ?? undefined,
     phone: subscription.phone,
+    subscriptionStatus: 'none',
   };
 
   await reportSubscriptionRejected(


### PR DESCRIPTION
## Summary
- add a reusable helper to update subscription-related fields on users
- refresh trial and paid activation flows as well as expiry handlers to keep user flags in sync
- surface subscription state in reporting payloads and ensure expired trials are cleaned up

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98bec8dd0832d99d2296f5e6394f0