### PR TITLE
Add safe mode and database fallback reporting

### DIFF
--- a/src/bot/services/cleanup.ts
+++ b/src/bot/services/cleanup.ts
@@ -3,6 +3,7 @@ import type { BotContext } from '../types';
 
 import { safeEditReplyMarkup } from '../../utils/tg';
 import { showSafeModeCard } from '../ui/safeModeCard';
+import { reportSafeModeEnter } from './reports';
 
 const DEFAULT_SAFE_MODE_PROMPT =
   'Мы восстанавливаем данные. Пока доступны действия: [Профиль], [Сменить город], [Помощь].';
@@ -48,6 +49,11 @@ export const enterSafeMode = async (
   }
 
   if (!alreadySafe) {
+    await reportSafeModeEnter(ctx.telegram, {
+      chat: ctx.chat ?? undefined,
+      user: ctx.from ?? undefined,
+      reason: options.reason,
+    });
     logger.warn(
       {
         chatId: ctx.chat?.id,


### PR DESCRIPTION
## Summary
- add SAFE_MODE_ENTER and DB_FALLBACK report builders and senders including chat, user, and reason details
- report the first transition into safe mode from the cleanup service
- trigger the database fallback report once per fallback path in the session middleware

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a1f4d55c832d927079d14dd8621e