### PR TITLE
Ensure executor active order flag stays in sync with database

### DIFF
--- a/src/bot/flows/executor/jobs.ts
+++ b/src/bot/flows/executor/jobs.ts
@@ -322,17 +322,17 @@ const ensureExecutorReady = async (
 const loadActiveOrder = async (ctx: BotContext): Promise<OrderRecord | null> => {
   const executorId = ctx.auth.user.telegramId;
   if (typeof executorId !== 'number') {
+    ctx.auth.user.hasActiveOrder = false;
     return null;
   }
 
   try {
     const order = await findActiveOrderForExecutor(executorId);
-    if (order) {
-      ctx.auth.user.hasActiveOrder = true;
-    }
+    ctx.auth.user.hasActiveOrder = Boolean(order);
     return order;
   } catch (error) {
     logger.error({ err: error, executorId }, 'Failed to load active order for executor');
+    ctx.auth.user.hasActiveOrder = false;
     return null;
   }
 };

--- a/tests/orders-active-flag.test.js
+++ b/tests/orders-active-flag.test.js
@@ -126,6 +126,18 @@ const createTestDatabase = () => {
       return { rows: [{ count }] };
     }
 
+    if (
+      normalized.startsWith('select exists ( select 1 from orders where claimed_by = $1') &&
+      normalized.includes("status = 'claimed'")
+    ) {
+      const [executorId] = params;
+      const hasActiveOrder = Array.from(orders.values()).some(
+        (order) => order.claimed_by === executorId && order.status === 'claimed',
+      );
+
+      return { rows: [{ has_active_order: hasActiveOrder }] };
+    }
+
     if (normalized.startsWith('update users set has_active_order = $2')) {
       const [telegramId, hasActiveOrder, updatedAt] = params;
       const user = users.get(telegramId);


### PR DESCRIPTION
## Summary
- compute executors' has_active_order flag from the orders table after claim/release events
- update executor job flow to refresh the in-memory flag from the database when loading active orders
- extend the active-order integration test to cover the new queries and lifecycle expectations

## Testing
- node --test tests/orders-active-flag.test.js
- node --test tests/executor-jobs.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9ab2c66c4832db15605102b1d55c5