### PR TITLE
Fix executor flag when restoring completed orders

### DIFF
--- a/src/db/orders.ts
+++ b/src/db/orders.ts
@@ -491,6 +491,7 @@ export const tryRestoreCompletedOrder = async (
     return null;
   }
 
+  await updateExecutorHasActiveOrder(client, executorId);
   await updateActiveOrdersGauge(client);
   return mapOrderRow(row);
 };


### PR DESCRIPTION
## Summary
- ensure restoring completed orders refreshes the executor has_active_order flag via the shared helper
- extend the order lifecycle regression test to cover undoing completion and reactivating the flag

## Testing
- node --test tests/orders-active-flag.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b010407c832dadf7bb1e3c4f6c1f