### PR TITLE
Fix build issues in phone collection flow

### DIFF
--- a/src/bot/flows/client/menu.ts
+++ b/src/bot/flows/client/menu.ts
@@ -16,7 +16,6 @@ import type { BotContext } from '../../types';
 import { presentRolePick } from '../../commands/start';
 import { ensureExecutorState, EXECUTOR_SUBSCRIPTION_ACTION } from '../executor/menu';
 import { reportRoleSet, toUserIdentity } from '../../services/reports';
-import { ensureExecutorState } from '../executor/menu';
 import { promptClientSupport } from './support';
 import { askCity, getCityFromContext, CITY_ACTION_PATTERN } from '../common/citySelect';
 import { CLIENT_ORDERS_ACTION } from './orderActions';

--- a/src/bot/flows/common/phoneCollect.ts
+++ b/src/bot/flows/common/phoneCollect.ts
@@ -1,4 +1,5 @@
 import { Markup, type MiddlewareFn } from 'telegraf';
+import type { ReplyKeyboardMarkup } from 'telegraf/typings/core/types/typegram';
 
 import { logger } from '../../../config';
 import { pool } from '../../../db';
@@ -39,14 +40,17 @@ const rememberEphemeralMessage = (ctx: BotContext, messageId?: number): void => 
   ctx.session.ephemeralMessages.push(messageId);
 };
 
-export const buildPhoneCollectKeyboard = () =>
-  Markup.keyboard([
+export const buildPhoneCollectKeyboard = (): ReplyKeyboardMarkup => {
+  const keyboard = Markup.keyboard([
     [Markup.button.contactRequest('📲 Поделиться контактом')],
     [Markup.button.text(PHONE_HELP_BUTTON_LABEL)],
     [Markup.button.text(PHONE_STATUS_BUTTON_LABEL)],
   ])
     .oneTime(true)
     .resize();
+
+  return keyboard.reply_markup;
+};
 
 interface PhoneStepOverrides {
   title?: string;
@@ -280,7 +284,9 @@ export const respondToPhoneHelp: MiddlewareFn<BotContext> = async (ctx, next) =>
     return;
   }
 
-  const message = await ctx.reply(buildPhoneHelpText(), buildPhoneCollectKeyboard());
+  const message = await ctx.reply(buildPhoneHelpText(), {
+    reply_markup: buildPhoneCollectKeyboard(),
+  });
   ctx.session.awaitingPhone = true;
   rememberEphemeralMessage(ctx, message?.message_id);
 };


### PR DESCRIPTION
## Summary
- return a plain reply keyboard from the phone collection helper to satisfy the UI type expectations
- adjust the phone help reply to pass the keyboard in the reply markup options
- deduplicate the client menu executor state import

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9b89c25b8832d8e185ca4f5ebad42