### PR TITLE
Ensure trial_ends_at column exists during migration

### DIFF
--- a/db/migrations/0011_user_role_enum_refactor.up.sql
+++ b/db/migrations/0011_user_role_enum_refactor.up.sql
@@ -18,7 +18,8 @@ ALTER TABLE users
   ADD COLUMN IF NOT EXISTS executor_kind executor_kind,
   ADD COLUMN IF NOT EXISTS verify_status user_verify_status NOT NULL DEFAULT 'none',
   ADD COLUMN IF NOT EXISTS trial_started_at TIMESTAMPTZ,
-  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ;
+  ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMPTZ;
 
 UPDATE users
 SET executor_kind = CASE role::text


### PR DESCRIPTION
## Summary
- extend the 0011 user role refactor migration to add the trial_ends_at column when missing so subsequent updates can reference it safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c672973c832db2b4b983eadc7907